### PR TITLE
[build] Update maven plugin artifactId to soapui-maven-plugin

### DIFF
--- a/soapui-maven-plugin-tester/pom.xml
+++ b/soapui-maven-plugin-tester/pom.xml
@@ -31,7 +31,7 @@
         <plugins>
             <plugin>
                 <groupId>com.smartbear.soapui</groupId>
-                <artifactId>maven-soapui-plugin</artifactId>
+                <artifactId>soapui-maven-plugin</artifactId>
                 <version>${project.parent.version}</version>
                 <executions>
                     <execution>

--- a/soapui-maven-plugin/pom.xml
+++ b/soapui-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 
     <modelVersion>4.0.0</modelVersion>
 	<groupId>com.smartbear.soapui</groupId>
-	<artifactId>maven-soapui-plugin</artifactId>
+	<artifactId>soapui-maven-plugin</artifactId>
     <name>soapUI Maven plugin</name>
     <description>Maven 2 project for building a soapUI plugin that is compatible with both Maven 1.x and Maven 2.x.</description>
 	<packaging>maven-plugin</packaging>


### PR DESCRIPTION
The plugin artifactId currently does not follow conventions for plugins whose  groupId is not org.apache.maven.plugins. 
We also get the following warning when building the  plugin

```
[ERROR]`Artifact Ids of the format maven-___-plugin are reserved for
plugins in the Group Id org.apache.maven.plugins
Please change your artifactId to the format ___-maven-plugin
In the future this error will break the build.
```

The module of the plugin has been renamed during maven3 build migration; it is now soapui-maven-plugin. As the groupId has also changed, I think it is the right time to update the artifactId ot soapui-maven-plugin. User of the plugin will be required to modify the plugin coordinates only one.

You will find the change in this PR
