### PR TITLE
Initializing factories resulted in recursive call to addExternalListeners instead of addExternalFactories

### DIFF
--- a/src/java/com/eviware/soapui/DefaultSoapUICore.java
+++ b/src/java/com/eviware/soapui/DefaultSoapUICore.java
@@ -690,7 +690,7 @@ public class DefaultSoapUICore implements SoapUICore
 			{
 				if( factoryFile.isDirectory() )
 				{
-					addExternalListeners( factoryFile.getAbsolutePath(), classLoader );
+					addExternalFactories( factoryFile.getAbsolutePath(), classLoader );
 					continue;
 				}
 


### PR DESCRIPTION
Initializing factories resulted in recursive call to addExternalListeners instead of addExternalFactories.
