### PR TITLE
Proposed changes to improve testrunner.bat script.

### DIFF
--- a/soapui-installer/src/dist/bin/testrunner.bat
+++ b/soapui-installer/src/dist/bin/testrunner.bat
@@ -73,19 +73,19 @@ IF "%SOAPUI_ARTIFACT%"=="soapui-pro" (
 ) ELSE (
   SET CLASSNAME=com.eviware.soapui.tools.SoapUITestCaseRunner
   SET "ARGS=%*"
-  IF "!%ARGS%:-F=!" NEQ "!%ARGS%!" (
+  IF NOT "%ARGS:-F=%"=="%ARGS%" (
     ECHO Pro option -F was found and not allowed by community edition of SoapUI.
     GOTO :ERROR
   )
-  IF "!%ARGS%:-R=!" NEQ "!%ARGS%!" (
+  IF NOT "%ARGS:-R=%"=="%ARGS%" (
     ECHO Pro option -R was found and not allowed by community edition of SoapUI.
     GOTO :ERROR
   )
-  IF "!%ARGS%:-g=!" NEQ "!%ARGS%!" (
+  IF NOT "%ARGS:-g=%"=="%ARGS%" (
     ECHO Pro option -g was found and not allowed by community edition of SoapUI.
     GOTO :ERROR
   )
-  IF "!%ARGS%:-E=!" NEQ "!%ARGS%!" (
+  IF NOT "%ARGS:-E=%"=="%ARGS%" (
     ECHO Pro option -E was found and not allowed by community edition of SoapUI.
     GOTO :ERROR
   )

--- a/soapui-installer/src/dist_standalone/bin/testrunner.bat
+++ b/soapui-installer/src/dist_standalone/bin/testrunner.bat
@@ -73,19 +73,19 @@ IF "%SOAPUI_ARTIFACT%"=="soapui-pro" (
 ) ELSE (
   SET CLASSNAME=com.eviware.soapui.tools.SoapUITestCaseRunner
   SET "ARGS=%*"
-  IF "!%ARGS%:-F=!" NEQ "!%ARGS%!" (
+  IF NOT "%ARGS:-F=%"=="%ARGS%" (
     ECHO Pro option -F was found and not allowed by community edition of SoapUI.
     GOTO :ERROR
   )
-  IF "!%ARGS%:-R=!" NEQ "!%ARGS%!" (
+  IF NOT "%ARGS:-R=%"=="%ARGS%" (
     ECHO Pro option -R was found and not allowed by community edition of SoapUI.
     GOTO :ERROR
   )
-  IF "!%ARGS%:-g=!" NEQ "!%ARGS%!" (
+  IF NOT "%ARGS:-g=%"=="%ARGS%" (
     ECHO Pro option -g was found and not allowed by community edition of SoapUI.
     GOTO :ERROR
   )
-  IF "!%ARGS%:-E=!" NEQ "!%ARGS%!" (
+  IF NOT "%ARGS:-E=%"=="%ARGS%" (
     ECHO Pro option -E was found and not allowed by community edition of SoapUI.
     GOTO :ERROR
   )


### PR DESCRIPTION
Proposed changes to improve testrunner.bat script.
- Improved detection of java.exe location, preferring system defined JAVA_HOME, otherwise using embedded Java included with app.
- Improved SOAPUI_HOME variable determination by deducing it from the current "bin" run directory, ignoring system defined SOAPUI_HOME variable.  Also forces script to run in SOAPUI_HOME\bin directory (script can be altered to allow running in a different directory if necessary).  This is because it makes little sense to run the script from outside this directory.
- Added :ERROR function with 10 second pause timer.
- Sets window title and improved script output, showing variable values that the script determines.
- Script defines ${project.src.artifactId} and ${project.version} variables that Maven build tool uses to hard code the jar file name within the script.  If the set values are incorrect, the script handles the error and reports it to the user.

NOTE:  There are 7 .bat scripts in the "bin" directory and this pull request is ONLY for the testrunner.bat . It may be that the entire "dist_standalone" directory is now "probably" unnecessary since this new script handles JAVA_HOME better, and works for both the standalone and dynamic location of the JRE.

Please do not feel like you must accept this PR. This is a "proposed" improvement only, adding under 75 lines of new code, and DEV may have reasons to not accept it. My reasoning for this update was so the script is friendlier and less problematic when used with Jenkins (or similar CI servers).  Also, if you would like to decline this PR and cherry pick any parts of the script, that is ok with me.

If this PR is approved, I could make these further changes at a later date, which could allow build master to retire the dist-standalone directory  :
1. Merge all 7 scripts into one unified .bat script that takes either script args or prompt a menu (if no args are given).   The new script could be called "runner.bat" and has test, tool, war generation, security, mock runner, and load runner variations all in one script.  It would add another 100 lines of code.
2. Replicate the final .bat changes into a bash .sh version of the runner script called "runner.sh" .
