### PR TITLE
Add missing break statement in case SEPARATOR

### DIFF
--- a/soapui/src/main/java/com/eviware/x/form/support/ADialogBuilder.java
+++ b/soapui/src/main/java/com/eviware/x/form/support/ADialogBuilder.java
@@ -363,6 +363,7 @@ public class ADialogBuilder
 			break;
 		case SEPARATOR :
 			form.addSeparator( description );
+            break;
 		case RADIOGROUP_TOP_BUTTON :
 			field = form.addComponent( name, new XFormRadioGroupTopButtonPosition( values ) );
 			break;


### PR DESCRIPTION
Using a SEPARATOR in a form was also inserting a radio group top button...
