### PR TITLE
Default font size for <pre>

### DIFF
--- a/soapui/src/main/resources/com/eviware/soapui/resources/mockaswar/stylesheet.css
+++ b/soapui/src/main/resources/com/eviware/soapui/resources/mockaswar/stylesheet.css
@@ -1,4 +1,3 @@
-
 body {
     font:normal 68% verdana,arial,helvetica;
     color:#000000;
@@ -84,7 +83,6 @@ h6 {
 pre
 {
     font-family: Courier;
-    font-size: 8px;
 }
 
 hr


### PR DESCRIPTION
Default font size for &lt;pre&gt; makes request and response log in mock service web ui much more readable than 8px and is much closer in size to the rest of the page text

8px: 
![pre8px](https://f.cloud.github.com/assets/349523/1654217/b6f9a5aa-5b46-11e3-976f-5c3e7d35f75e.png)

Default:
![predefaultsize](https://f.cloud.github.com/assets/349523/1654219/bd2ce8d8-5b46-11e3-9587-e68a02a9dfa4.png)
