### PR TITLE
Adds soapui.logroot configuration to the log4j definition of the GLOBAL_...

### DIFF
--- a/soapui/src/main/resources/com/eviware/soapui/resources/conf/soapui-log4j.xml
+++ b/soapui/src/main/resources/com/eviware/soapui/resources/conf/soapui-log4j.xml
@@ -53,7 +53,7 @@
    
 	<appender name="GLOBAL_GROOVY_LOG" class="org.apache.log4j.FileAppender">
       <errorHandler class="org.apache.log4j.helpers.OnlyOnceErrorHandler"/>
-     <param name="File" value="global-groovy.log"/>
+     <param name="File" value="${soapui.logroot}global-groovy.log"/>
      <param name="Threshold" value="DEBUG"/>
      <param name="Append" value="true"/>
  <!-- <param name="MaxFileSize" value="5000KB"/>


### PR DESCRIPTION
...GROOVY_LOG

This change is to allow the location of the global-groovy.log to be
changed when the soapui.logroot Java property is present of the soapUI
runtime.

This change alligns the decloratoin of this file appender with the
others in this file which already use this configuration technique.
