### PR TITLE
Use regexp token as something to find instead of something to match with.

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/basic/SimpleContainsAssertion.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/basic/SimpleContainsAssertion.java
@@ -14,6 +14,8 @@ package com.eviware.soapui.impl.wsdl.teststeps.assertions.basic;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.xmlbeans.XmlObject;
 
@@ -108,8 +110,10 @@ public class SimpleContainsAssertion extends WsdlMessageAssertion implements Req
 
 			if( useRegEx )
 			{
-				if( content.matches( replToken ) )
-					ix = 0;
+			    Pattern p = Pattern. compile (replToken, Pattern.DOTALL);
+			    Matcher m = p. matcher (content);
+			    if (m.find()) 
+			        ix = 0;
 			}
 			else
 			{

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/basic/SimpleNotContainsAssertion.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/basic/SimpleNotContainsAssertion.java
@@ -14,6 +14,8 @@ package com.eviware.soapui.impl.wsdl.teststeps.assertions.basic;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.xmlbeans.XmlObject;
 
@@ -108,8 +110,10 @@ public class SimpleNotContainsAssertion extends WsdlMessageAssertion implements 
 
 			if( useRegEx )
 			{
-				if( content.matches( replToken ) )
-					ix = 0;
+                Pattern p = Pattern. compile (replToken, Pattern.DOTALL);
+                Matcher m = p. matcher (content);
+                if (m.find()) 
+                    ix = 0;
 			}
 			else
 			{


### PR DESCRIPTION
Hi,

For me it's much more natural to use the regexp token as something to *find* instead of something to *match* with, specially in the "contains" assertions context.

In addition, I think it's more convenient to use the Pattern.DOTALL mode because we can consider that line breaks are alway insignificant in SOAP or REST responses. In that mode users do NOT have to enter the '(?s)' trick in their regexp token which is more user friendly I guess (personaly I spent a lot of time because of that trick, maybe I should have read the doc before ;p).

Thanks for having attention to my request,

Vincent.