### PR TITLE
remove parameterization of swing classes to compile with jdk6

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/RestRequestDesktopPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/RestRequestDesktopPanel.java
@@ -106,7 +106,7 @@ public class RestRequestDesktopPanel extends
 	private JPanel addMethodCombo()
 	{
 		JPanel methodPanel = new JPanel( new BorderLayout() );
-		JComboBox<RestRequestInterface.RequestMethod> methodComboBox = new JComboBox<RestRequestInterface.RequestMethod>( new RestRequestMethodModel( getRequest() ) );
+		JComboBox methodComboBox = new JComboBox( new RestRequestMethodModel( getRequest() ) );
 		methodComboBox.setSelectedItem( getRequest().getMethod() );
 
 		JLabel methodLabel = new JLabel( "Method" );

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/RestRequestMethodModel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/RestRequestMethodModel.java
@@ -2,12 +2,9 @@ package com.eviware.soapui.impl.rest.panels.request;
 
 import com.eviware.soapui.impl.rest.RestRequestInterface;
 
-import javax.swing.*;
-import javax.swing.event.ListDataListener;
+import javax.swing.DefaultComboBoxModel;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.util.Arrays;
-import java.util.List;
 
 import static com.eviware.soapui.impl.rest.RestRequestInterface.RequestMethod;
 
@@ -23,7 +20,7 @@ import static com.eviware.soapui.impl.rest.RestRequestInterface.RequestMethod;
  * See the GNU Lesser General Public License for more details at gnu.org.
  *
  */
-public class RestRequestMethodModel extends DefaultComboBoxModel<RequestMethod> implements PropertyChangeListener
+public class RestRequestMethodModel extends DefaultComboBoxModel implements PropertyChangeListener
 {
 	private RestRequestInterface request;
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/resource/RestParamsTable.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/resource/RestParamsTable.java
@@ -157,9 +157,9 @@ public class RestParamsTable extends JPanel
 
 		paramsTable.setSelectionMode( ListSelectionModel.SINGLE_SELECTION );
 		paramsTable.setDefaultEditor( ParameterStyle.class, new DefaultCellEditor(
-				new JComboBox<ParameterStyle>( getStylesForLocation( ParamLocation.RESOURCE ) ) ) );
+				new JComboBox( getStylesForLocation( ParamLocation.RESOURCE ) ) ) );
 		paramsTable.setDefaultEditor( ParamLocation.class, new DefaultCellEditor(
-				new JComboBox<ParamLocation>( ParamLocation.values() ) ) );
+				new JComboBox( ParamLocation.values() ) ) );
 		// Workaround: for some reason the lower part of text gets clipped on some platforms
 		paramsTable.setRowHeight( 25 );
 		paramsTable.getSelectionModel().addListSelectionListener( new ListSelectionListener()
@@ -214,30 +214,30 @@ public class RestParamsTable extends JPanel
 		}
 	}
 
-	private DefaultComboBoxModel<ParameterStyle> getStylesForLocation( ParamLocation paramLocation )
+	private DefaultComboBoxModel getStylesForLocation( ParamLocation paramLocation )
 	{
 		if( paramLocation == ParamLocation.METHOD )
 		{
-			return new DefaultComboBoxModel<ParameterStyle>(
+			return new DefaultComboBoxModel(
 					new ParameterStyle[] { ParameterStyle.QUERY, ParameterStyle.HEADER, ParameterStyle.MATRIX, ParameterStyle.PLAIN } );
 		}
 		else
 		{
-			return new DefaultComboBoxModel<ParameterStyle>(
+			return new DefaultComboBoxModel(
 					new ParameterStyle[] { ParameterStyle.QUERY, ParameterStyle.TEMPLATE, ParameterStyle.HEADER, ParameterStyle.MATRIX, ParameterStyle.PLAIN } );
 		}
 	}
 
-	private DefaultComboBoxModel<ParamLocation> getLocationForParameter( ParameterStyle style )
+	private DefaultComboBoxModel getLocationForParameter( ParameterStyle style )
 	{
 		if( style != ParameterStyle.TEMPLATE )
 		{
-			return new DefaultComboBoxModel<ParamLocation>(
+			return new DefaultComboBoxModel(
 					new ParamLocation[] { ParamLocation.RESOURCE, ParamLocation.METHOD } );
 		}
 		else
 		{
-			return new DefaultComboBoxModel<ParamLocation>(
+			return new DefaultComboBoxModel(
 					new ParamLocation[] { ParamLocation.RESOURCE } );
 		}
 	}

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/RestTestRequestDesktopPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/RestTestRequestDesktopPanel.java
@@ -12,12 +12,6 @@
 
 package com.eviware.soapui.impl.wsdl.panels.teststeps;
 
-import java.awt.*;
-import java.beans.PropertyChangeEvent;
-import java.util.Date;
-
-import javax.swing.*;
-
 import com.eviware.soapui.SoapUI;
 import com.eviware.soapui.impl.rest.RestMethod;
 import com.eviware.soapui.impl.rest.RestResource;
@@ -50,6 +44,22 @@ import com.eviware.soapui.support.components.JInspectorPanel;
 import com.eviware.soapui.support.components.JInspectorPanelFactory;
 import com.eviware.soapui.support.components.JXToolBar;
 import com.eviware.soapui.support.log.JLogList;
+
+import javax.swing.AbstractListModel;
+import javax.swing.ComboBoxModel;
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.ListModel;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.beans.PropertyChangeEvent;
+import java.util.Date;
 
 public class RestTestRequestDesktopPanel extends AbstractRestRequestDesktopPanel<RestTestRequestStep, RestTestRequest>
 {
@@ -178,7 +188,7 @@ public class RestTestRequestDesktopPanel extends AbstractRestRequestDesktopPanel
 		if( getRequest().getResource() != null  )
 		{
 			JXToolBar toolbar = UISupport.createToolbar();
-			methodResourceCombo = new JComboBox<ComboBoxModel>( new PathComboBoxModel() );
+			methodResourceCombo = new JComboBox( new PathComboBoxModel() );
 			methodResourceCombo.setRenderer( new RestMethodListCellRenderer() );
 			methodResourceCombo.setPreferredSize( new Dimension( 200, 20 ) );
 			methodResourceCombo.setSelectedItem( getRequest().getRestMethod() );

--- a/soapui/src/test/java/com/eviware/soapui/impl/rest/panels/request/RestRequestDesktopPanelTest.java
+++ b/soapui/src/test/java/com/eviware/soapui/impl/rest/panels/request/RestRequestDesktopPanelTest.java
@@ -55,7 +55,7 @@ public class RestRequestDesktopPanelTest
 	private RestRequest restRequest;
 	private StubbedDialogs dialogs;
 	private XDialogs originalDialogs;
-	private JComboBox<String> endpointsCombo;
+	private JComboBox endpointsCombo;
 
 	@Before
 	public void setUp() throws Exception
@@ -329,7 +329,7 @@ public class RestRequestDesktopPanelTest
 	@Test
 	public void keepsEnteredEndpointValueWhenEditingEndpoint() throws Exception
 	{
-		JComboBox<String> endpointsCombo = findEndpointsComboBox();
+		JComboBox endpointsCombo = findEndpointsComboBox();
 		String otherValue = "http://dn.se";
 		setComboTextFieldValue( endpointsCombo, otherValue );
 		endpointsCombo.setSelectedItem( EndpointsComboBoxModel.EDIT_ENDPOINT );
@@ -392,13 +392,13 @@ public class RestRequestDesktopPanelTest
 		return document.getText( 0, document.getLength() );
 	}
 
-	private JComboBox<String> findEndpointsComboBox()
+	private JComboBox findEndpointsComboBox()
 	{
 		ContainerWalker finder = new ContainerWalker( requestDesktopPanel );
 		return finder.findComboBoxWithValue( ENDPOINT );
 	}
 
-	private void setComboTextFieldValue( JComboBox<String> endpointsCombo, String otherValue )
+	private void setComboTextFieldValue( JComboBox endpointsCombo, String otherValue )
 	{
 		( ( JTextComponent )endpointsCombo.getEditor().getEditorComponent() ).setText( otherValue );
 	}

--- a/soapui/src/test/java/com/eviware/soapui/impl/rest/panels/resource/RestParamsTableTest.java
+++ b/soapui/src/test/java/com/eviware/soapui/impl/rest/panels/resource/RestParamsTableTest.java
@@ -93,7 +93,7 @@ public class RestParamsTableTest
 	{
 		paramTable.editCellAt( 0, RestParamsTableModel.STYLE_COLUMN_INDEX );
 		DefaultCellEditor cellEditor = ( DefaultCellEditor )paramTable.getCellEditor( 0, RestParamsTableModel.STYLE_COLUMN_INDEX );
-		JComboBox<RestParamsPropertyHolder.ParameterStyle> comboBox = ( JComboBox )cellEditor.getComponent();
+		JComboBox comboBox = ( JComboBox )cellEditor.getComponent();
 		return getSelectableValues( comboBox );
 	}
 
@@ -101,13 +101,13 @@ public class RestParamsTableTest
 	{
 		paramTable.editCellAt( 0, RestParamsTableModel.LOCATION_COLUMN_INDEX );
 		DefaultCellEditor cellEditor = ( DefaultCellEditor )paramTable.getCellEditor( 0, RestParamsTableModel.LOCATION_COLUMN_INDEX );
-		JComboBox<NewRestResourceActionBase.ParamLocation> comboBox = ( JComboBox )cellEditor.getComponent();
+		JComboBox comboBox = ( JComboBox )cellEditor.getComponent();
 		return getSelectableValues( comboBox );
 	}
 
-	private <T> List<T> getSelectableValues( JComboBox<T> comboBox )
+	private <T> List<T> getSelectableValues( JComboBox comboBox )
 	{
-		List<T> availableStyles = new ArrayList<T>();
+		List availableStyles = new ArrayList();
 		for( int i = 0; i < comboBox.getItemCount(); i++ )
 		{
 			availableStyles.add( comboBox.getItemAt( i ) );

--- a/soapui/src/test/java/com/eviware/soapui/impl/wsdl/panels/teststeps/RestTestRequestDesktopPanelTest.java
+++ b/soapui/src/test/java/com/eviware/soapui/impl/wsdl/panels/teststeps/RestTestRequestDesktopPanelTest.java
@@ -48,7 +48,7 @@ public class RestTestRequestDesktopPanelTest
 	private RestRequest restRequest;
 	private StubbedDialogs dialogs;
 	private XDialogs originalDialogs;
-	private JComboBox<String> endpointsCombo;
+	private JComboBox endpointsCombo;
 
 	@Before
 	public void setUp() throws Exception
@@ -99,7 +99,7 @@ public class RestTestRequestDesktopPanelTest
 
 	/* Helpers */
 
-	private JComboBox<String> findEndpointsComboBox()
+	private JComboBox findEndpointsComboBox()
 
 	{
 		ContainerWalker finder = new ContainerWalker( restTestDesktopPanel );

--- a/soapui/src/test/java/com/eviware/soapui/utils/ContainerWalker.java
+++ b/soapui/src/test/java/com/eviware/soapui/utils/ContainerWalker.java
@@ -38,14 +38,13 @@ public class ContainerWalker
 		throw new NoSuchElementException( "No button found with icon file " + iconFile );
 	}
 
-	// Currently unused, but probably useful
-	public <T> JComboBox<T> findComboBoxWithValue( T value )
+	public <T> JComboBox findComboBoxWithValue( T value )
 	{
 		for( Component component : containedComponents )
 		{
 			if( component instanceof JComboBox )
 			{
-				JComboBox<T> comboBox = ( JComboBox<T> )component;
+				JComboBox comboBox = ( JComboBox )component;
 				for( int i = 0; i < comboBox.getItemCount(); i++ )
 				{
 					if( comboBox.getItemAt( i ).equals( value ) )


### PR DESCRIPTION
As I described on the forum,

http://forum.soapui.org/viewtopic.php?f=1&t=22619&sid=a082ccb7a6cf2277f19297f20678a1b0,

compiling with jdk6 is no longer possible.

This pull request restores that by removing generics parameters in swing class usage.

If the intention was to completly drop jdk6 for compilation of soapui, please ignore this pull request.
