### PR TITLE
Add a setting to start (or not) Cajo server at startup.

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/SoapUI.java
+++ b/soapui/src/main/java/com/eviware/soapui/SoapUI.java
@@ -55,6 +55,7 @@ import com.eviware.soapui.model.workspace.Workspace;
 import com.eviware.soapui.model.workspace.WorkspaceFactory;
 import com.eviware.soapui.monitor.MockEngine;
 import com.eviware.soapui.monitor.TestMonitor;
+import com.eviware.soapui.settings.LoadUISettings;
 import com.eviware.soapui.settings.ProxySettings;
 import com.eviware.soapui.settings.UISettings;
 import com.eviware.soapui.settings.VersionUpdateSettings;
@@ -648,7 +649,13 @@ public class SoapUI
 					} ).start();
 				}
 
-				CajoServer.getInstance().start();
+                if ( ! getSettings().isSet( LoadUISettings.START_CAJO_SERVER_AT_STARTUP ) || getSettings().getBoolean( LoadUISettings.START_CAJO_SERVER_AT_STARTUP ) ) {
+                    CajoServer.getInstance().start();
+                }
+                else
+                {
+                    log.info("Cajo server not started because setting '" + LoadUISettings.START_CAJO_SERVER_AT_STARTUP + "' is false.");
+                }
 			}
 			catch( Exception e )
 			{

--- a/soapui/src/main/java/com/eviware/soapui/settings/LoadUISettings.java
+++ b/soapui/src/main/java/com/eviware/soapui/settings/LoadUISettings.java
@@ -26,4 +26,6 @@ public interface LoadUISettings
 	public final static String LOADUI_CAJO_ITEM_NAME = LoadUISettings.class.getSimpleName() + "@" + "cajo_item_name";
 	public final static String SOAPUI_CAJO_PORT = LoadUISettings.class.getSimpleName() + "@" + "cajo_soapui_port";
 
+    public final static String START_CAJO_SERVER_AT_STARTUP = LoadUISettings.class.getSimpleName() + "@" + "start_cajo_server_at_startup";
+
 }


### PR DESCRIPTION
When connected to a VPN configured to clear all routes, starting the Cajo server just hangs there.
Added a setting to prevent start of Cajo server.
