### PR TITLE
Add a setting to clear the values of proxy system properties

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/actions/ProxyPrefs.java
+++ b/soapui/src/main/java/com/eviware/soapui/actions/ProxyPrefs.java
@@ -31,8 +31,9 @@ public class ProxyPrefs implements Prefs
 	public static final String USERNAME = "Username";
 	public static final String PASSWORD = "Password";
 	public static final String EXCLUDES = "Excludes";
+    public static final String IGNORE_PROXY_SYSTEM_PROPERTIES = "Ignore Proxy System Properties";
 
-	private JTextField hostTextField;
+    private JTextField hostTextField;
 	private JTextField portTextField;
 	private JTextField userTextField;
 	private JPasswordField passwordTextField;
@@ -71,7 +72,10 @@ public class ProxyPrefs implements Prefs
 			userTextField = proxyPrefForm.appendTextField( USERNAME, "proxy username to use" );
 			passwordTextField = proxyPrefForm.appendPasswordField( PASSWORD, "proxy password to use" );
 
-		}
+            proxyPrefForm.addSpace(5);
+            proxyPrefForm.appendCheckBox( IGNORE_PROXY_SYSTEM_PROPERTIES, "Ignore proxy system properties", false );
+
+        }
 		return proxyPrefForm;
 	}
 
@@ -146,6 +150,7 @@ public class ProxyPrefs implements Prefs
 		values.put( USERNAME, settings.getString( ProxySettings.USERNAME, "" ) );
 		values.put( PASSWORD, settings.getString( ProxySettings.PASSWORD, "" ) );
 		values.put( EXCLUDES, settings.getString( ProxySettings.EXCLUDES, "" ) );
+        values.put( IGNORE_PROXY_SYSTEM_PROPERTIES, settings.getBoolean( ProxySettings.IGNORE_PROXY_SYSTEM_PROPERTIES ) );
 		return values;
 	}
 
@@ -181,7 +186,9 @@ public class ProxyPrefs implements Prefs
 		settings.setString( ProxySettings.USERNAME, values.get( USERNAME ) );
 		settings.setString( ProxySettings.PASSWORD, values.get( PASSWORD ) );
 		settings.setString( ProxySettings.EXCLUDES, values.get( EXCLUDES ) );
-		boolean enableProxy = !none.isSelected();
+        settings.setBoolean( ProxySettings.IGNORE_PROXY_SYSTEM_PROPERTIES, values.getBoolean( IGNORE_PROXY_SYSTEM_PROPERTIES ) );
+
+        boolean enableProxy = !none.isSelected();
 		if( !autoProxy && ( StringUtils.isNullOrEmpty( proxyHost ) || StringUtils.isNullOrEmpty( proxyPort ) ) )
 		{
 			enableProxy = false;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/http/ProxyUtils.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/http/ProxyUtils.java
@@ -49,15 +49,50 @@ public class ProxyUtils
 
 	private static boolean autoProxy;
 
+    private static final String systemPropertySocksProxyHost;
+    private static final String systemPropertySocksProxyPort;
+    private static final String systemPropertyHttpProxyHost;
+    private static final String systemPropertyHttpProxyPort;
+
 	static
 	{
 		setProxyEnabled( SoapUI.getSettings().getBoolean( ProxySettings.ENABLE_PROXY ) );
 		setAutoProxy( SoapUI.getSettings().getBoolean( ProxySettings.AUTO_PROXY ) );
+        systemPropertySocksProxyHost = System.getProperty( "socksProxyHost" );
+        systemPropertySocksProxyPort = System.getProperty( "socksProxyPort" );
+        systemPropertyHttpProxyHost = System.getProperty( "http.proxyHost" );
+        systemPropertyHttpProxyPort = System.getProperty( "http.proxyPort" );
 	}
 
 	public static void initProxySettings( final Settings settings, HttpUriRequest httpMethod, HttpContext httpContext,
 													  String urlString, final PropertyExpansionContext context )
 	{
+        if (settings.getBoolean( ProxySettings.IGNORE_PROXY_SYSTEM_PROPERTIES ))
+        {
+            System.clearProperty("socksProxyHost");
+            System.clearProperty("socksProxyPort");
+            System.clearProperty("http.proxyHost");
+            System.clearProperty("http.proxyPort");
+        }
+        else
+        {
+            // restore socks properties
+            if (! StringUtils.isNullOrEmpty( systemPropertySocksProxyHost ) ) {
+                System.setProperty( "socksProxyHost", systemPropertySocksProxyHost );
+            }
+            if (! StringUtils.isNullOrEmpty( systemPropertySocksProxyPort ) ) {
+                System.setProperty( "socksProxyPort", systemPropertySocksProxyPort );
+            }
+            // restore http properties
+            if (! StringUtils.isNullOrEmpty( systemPropertyHttpProxyHost ) ) {
+                System.setProperty( "http.proxyHost", systemPropertyHttpProxyHost );
+            }
+            if (! StringUtils.isNullOrEmpty( systemPropertyHttpProxyPort ) ) {
+                System.setProperty( "http.proxyPort", systemPropertyHttpProxyPort );
+            }
+        }
+
+
 		if( proxyEnabled )
 		{
 			if( autoProxy )

--- a/soapui/src/main/java/com/eviware/soapui/settings/ProxySettings.java
+++ b/soapui/src/main/java/com/eviware/soapui/settings/ProxySettings.java
@@ -42,4 +42,8 @@ public interface ProxySettings
 
 	@Setting( name = "Auto Proxy", description = "use automatic proxy detection", type = SettingType.BOOLEAN, defaultValue = "true" )
 	public final static String AUTO_PROXY = ProxySettings.class.getSimpleName() + "@" + "autoProxy";
+
+    @Setting( name = "Ignore proxy system properties", description="Ignore the values of system properties socksProxyHost, socksProxyPort, http.proxyHost and http.proxyPort.", type = SettingType.BOOLEAN, defaultValue = "false" )
+    public final static String IGNORE_PROXY_SYSTEM_PROPERTIES = ProxySettings.class.getSimpleName() + "@" + "ignoreProxySystemProperties";
+
 }


### PR DESCRIPTION
With a VPN configuration clearing the routes and setting system properties for proxy servers, socket connections end up trying to go through a socks server and, depending on how that one is configured, may hung there until it times out.

Ignoring the values put in system properties re-enable direct socket connection and this pull-request introduces a setting in "Proxy Settings" to select that if desired.

Note that this is still required even if the new proxy setting is set to None in preferences :  the jvm uses a SocksSocketImpl by default which looks for socksProxyHost and socksProxyPort and try to connect to a socks server if they are defined.  
