### PR TITLE
Fixes encoding issues when parsing WSDL files

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wsdl/WsdlLoader.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wsdl/WsdlLoader.java
@@ -28,7 +28,6 @@ import org.apache.xmlbeans.XmlObject;
 import org.apache.xmlbeans.XmlOptions;
 import org.xml.sax.InputSource;
 
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URL;
 
@@ -111,7 +110,7 @@ public abstract class WsdlLoader extends AbstractDefinitionLoader implements Wsd
 
 			options.setLoadLineNumbers();
 			String content = readCleanWsdlFrom( url );
-			return XmlUtils.createXmlObject( new ByteArrayInputStream( content.getBytes() ), options );
+			return XmlUtils.createXmlObject( content, options );
 		}
 		catch (XmlException e)
 		{


### PR DESCRIPTION
This change solves the encoding issues described in the following two posts. Issue since SoapUI 4.6.4

https://forum.soapui.org/viewtopic.php?f=13&t=22976
http://forum.soapui.org/viewtopic.php?f=13&t=22911

I tested it with two file encodings by setting 
-Dfile.encoding=UTF-8
-Dfile.encoding=windows-1252

and importing
https://service-es.bygogmiljoe.dk/Sagsbehandling.svc?singleWsdl
http://forum.soapui.org/download/file.php?id=3031&sid=1029232716ee9278136461950819c392 (SecurityTokenService)

The next branch (5.0) is impacted by the same issue.
