### PR TITLE
Multithreading support

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/inspectors/schema/InferredSchemaManager.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/inspectors/schema/InferredSchemaManager.java
@@ -18,8 +18,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.eviware.soapui.impl.rest.RestService;
 import com.eviware.soapui.impl.wadl.inference.InferredSchema;
@@ -37,10 +37,10 @@ public class InferredSchemaManager
 
 	static
 	{
-		schemas = new HashMap<RestService, InferredSchema>();
-		propertyChangeSupports = new HashMap<RestService, PropertyChangeSupport>();
-		filenames = new HashMap<String, String>();
-		rFilenames = new HashMap<String, String>();
+		schemas = new ConcurrentHashMap<RestService, InferredSchema>();
+		propertyChangeSupports = new ConcurrentHashMap<RestService, PropertyChangeSupport>();
+		filenames = new ConcurrentHashMap<String, String>();
+		rFilenames = new ConcurrentHashMap<String, String>();
 	}
 
 	public static String filenameForNamespace( String namespace )


### PR DESCRIPTION
This branch resolves certain exceptions that come up when trying to run test cases concurrently.

For example, the wsdlReader object is shared between threads in WsdlInterfaceDefinition, and the WSDLReaderImpl is not set up with synchronization.  So we get the following exception occasionally:

```
java.lang.NullPointerException
    at com.ibm.wsdl.xml.WSDLReaderImpl.readWSDL(Unknown Source)
    at com.eviware.soapui.impl.wsdl.support.wsdl.WsdlInterfaceDefinition.load(WsdlInterfaceDefinition.java:52)
    at com.eviware.soapui.impl.wsdl.support.wsdl.WsdlContext.loadDefinition(WsdlContext.java:66)
    at com.eviware.soapui.impl.wsdl.support.wsdl.WsdlContext.loadDefinition(WsdlContext.java:30)
    at com.eviware.soapui.impl.support.definition.support.AbstractDefinitionContext.cacheDefinition(AbstractDefinitionContext.java:278)
    at com.eviware.soapui.impl.support.definition.support.AbstractDefinitionContext.access$400(AbstractDefinitionContext.java:44)
    at com.eviware.soapui.impl.support.definition.support.AbstractDefinitionContext$Loader.construct(AbstractDefinitionContext.java:245)
    at com.eviware.soapui.support.swing.SwingWorkerDelegator.construct(SwingWorkerDelegator.java:46)
    at com.eviware.soapui.support.swing.SwingWorker$2.run(SwingWorker.java:149)
    at java.lang.Thread.run(Thread.java:744)
```

When loading projects concurrently, we also get this exception from time to time:

```
java.lang.NullPointerException
    at java.beans.PropertyChangeSupport.<init>(PropertyChangeSupport.java:91)
    at com.eviware.soapui.impl.rest.panels.request.inspectors.schema.InferredSchemaManager.getInferredSchema(InferredSchemaManager.java:94)
    at com.eviware.soapui.impl.rest.panels.request.inspectors.schema.InferredSchemaManager.addPropertyChangeListener(InferredSchemaManager.java:136)
    at com.eviware.soapui.impl.rest.RestRepresentation.<init>(RestRepresentation.java:79)
    at com.eviware.soapui.impl.rest.RestMethod.<init>(RestMethod.java:71)
    at com.eviware.soapui.impl.rest.RestResource.<init>(RestResource.java:89)
    at com.eviware.soapui.impl.rest.RestResource.<init>(RestResource.java:61)
    at com.eviware.soapui.impl.rest.RestService.<init>(RestService.java:48)
    at com.eviware.soapui.impl.rest.RestServiceFactory.build(RestServiceFactory.java:26)
    at com.eviware.soapui.impl.rest.RestServiceFactory.build(RestServiceFactory.java:20)
    at com.eviware.soapui.impl.wsdl.InterfaceFactoryRegistry.build(InterfaceFactoryRegistry.java:49)
    at com.eviware.soapui.impl.wsdl.WsdlProject.loadProject(WsdlProject.java:344)
    at com.eviware.soapui.impl.wsdl.WsdlProject.<init>(WsdlProject.java:215)
    at com.eviware.soapui.impl.wsdl.WsdlProject.<init>(WsdlProject.java:183)
    at com.eviware.soapui.impl.wsdl.WsdlProject.<init>(WsdlProject.java:178)
    at com.eviware.soapui.impl.wsdl.WsdlProject.<init>(WsdlProject.java:163)
...
```

In AbstractDefinitionContext, synchronizing on a static lock object was added in the Loader's construct method.  This is because multiple threads will share a static object (_schemaType) in the DefinitionCacheConfigImpl.  This ends up causing "[Schema Compliance] null" failures to show up in test cases running concurrently.

The current changes in this branch resolve these issues.
