### PR TITLE
Force Content-Transfer-Encoding=binary for XOP attachments

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/mock/WsdlMockResponse.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/mock/WsdlMockResponse.java
@@ -729,7 +729,7 @@ public class WsdlMockResponse extends AbstractWsdlModelItem<MockResponseConfig> 
 			initRootPart( responseContent, mp, isXOP );
 
 			// init mimeparts
-			AttachmentUtils.addMimeParts( this, Arrays.asList( getAttachments() ), mp, contentIds );
+			AttachmentUtils.addMimeParts( this, Arrays.asList( getAttachments() ), mp, contentIds, isXOP );
 
 			// create request message
 			MimeMessage message = new MimeMessage( AttachmentUtils.JAVAMAIL_SESSION );

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/filters/HttpRequestFilter.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/filters/HttpRequestFilter.java
@@ -382,7 +382,7 @@ public class HttpRequestFilter extends AbstractRequestFilter
 								mp = new MimeMultipart();
 
 							// init mimeparts
-							AttachmentUtils.addMimeParts( request, attachments, mp, new StringToStringMap() );
+							AttachmentUtils.addMimeParts( request, attachments, mp, new StringToStringMap(), false );
 
 							// create request message
 							MimeMessage message = new MimeMessage( AttachmentUtils.JAVAMAIL_SESSION );

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/filters/WsdlPackagingRequestFilter.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/filters/WsdlPackagingRequestFilter.java
@@ -108,7 +108,7 @@ public class WsdlPackagingRequestFilter extends AbstractRequestFilter
 			initRootPart( wsdlRequest, requestContent, mp, isXOP );
 
 			// init mimeparts
-			AttachmentUtils.addMimeParts( wsdlRequest, Arrays.asList( wsdlRequest.getAttachments() ), mp, contentIds );
+			AttachmentUtils.addMimeParts( wsdlRequest, Arrays.asList( wsdlRequest.getAttachments() ), mp, contentIds, isXOP );
 
 			// create request message
 			MimeMessage message = new MimeMessage( AttachmentUtils.JAVAMAIL_SESSION );

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/support/attachments/AttachmentUtils.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/support/attachments/AttachmentUtils.java
@@ -582,7 +582,7 @@ public class AttachmentUtils
 	 */
 
 	public static void addMimeParts( AttachmentContainer container, List<Attachment> attachments, MimeMultipart mp,
-			StringToStringMap contentIds ) throws MessagingException
+			StringToStringMap contentIds, boolean isXOP ) throws MessagingException
 	{
 		// no multipart handling?
 		if( !container.isMultipartEnabled() )
@@ -592,7 +592,7 @@ public class AttachmentUtils
 				Attachment att = attachments.get( c );
 				if( att.getAttachmentType() != Attachment.AttachmentType.CONTENT )
 				{
-					addSingleAttachment( mp, contentIds, att );
+					addSingleAttachment( mp, contentIds, att, isXOP );
 				}
 			}
 		}
@@ -623,13 +623,13 @@ public class AttachmentUtils
 				if( attachments.size() == 1 )
 				{
 					Attachment att = attachments.get( 0 );
-					addSingleAttachment( mp, contentIds, att );
+					addSingleAttachment( mp, contentIds, att, isXOP );
 				}
 				// more than one attachment with the same part -> create multipart
 				// attachment
 				else if( attachments.size() > 1 )
 				{
-					addMultipartAttachment( mp, contentIds, attachments );
+					addMultipartAttachment( mp, contentIds, attachments, isXOP );
 				}
 			}
 		}
@@ -640,7 +640,7 @@ public class AttachmentUtils
 	 */
 
 	public static void addMultipartAttachment( MimeMultipart mp, StringToStringMap contentIds,
-			List<Attachment> attachments ) throws MessagingException
+			List<Attachment> attachments, boolean isXOP ) throws MessagingException
 	{
 		MimeMultipart multipart = new MimeMultipart( "mixed" );
 		long totalSize = 0;
@@ -651,7 +651,7 @@ public class AttachmentUtils
 			String contentType = att.getContentType();
 			totalSize += att.getSize();
 
-			MimeBodyPart part = contentType.startsWith( "text/" ) ? new MimeBodyPart() : new PreencodedMimeBodyPart(
+			MimeBodyPart part = contentType.startsWith( "text/" ) && !isXOP ? new MimeBodyPart() : new PreencodedMimeBodyPart(
 					"binary" );
 
 			part.setDataHandler( new DataHandler( new AttachmentDataSource( att ) ) );
@@ -736,11 +736,11 @@ public class AttachmentUtils
 	 * Adds a simple MimeBodyPart from an attachment
 	 */
 
-	public static void addSingleAttachment( MimeMultipart mp, StringToStringMap contentIds, Attachment att )
+	public static void addSingleAttachment( MimeMultipart mp, StringToStringMap contentIds, Attachment att, boolean isXOP )
 			throws MessagingException
 	{
 		String contentType = att.getContentType();
-		MimeBodyPart part = contentType.startsWith( "text/" ) ? new MimeBodyPart()
+		MimeBodyPart part = contentType.startsWith( "text/" ) && !isXOP ? new MimeBodyPart()
 				: new PreencodedMimeBodyPart( "binary" );
 
 		part.setDataHandler( new DataHandler( new AttachmentDataSource( att ) ) );


### PR DESCRIPTION
We had a problem similar as described in http://forum.soapui.org/viewtopic.php?t=2060 with one of our clients and Oracle Service Bus. For all text/\* content types SoapUI sends encoded XOP parts instead of raw binary (in our case Content-Transfer-Encoding: quoted-printable)

Although the MTOM/XOP specification is not explicit on the value of Content-Transfer-Encoding, all interop examples always show binary mode (even for text/xml binaries) (http://www.w3.org/2000/xp/Group/4/08/implementation.html) 

The major goal of MTOM/XOP is to avoid encoding binaries and send them in raw format, so using other encoding formats like quoted-printable is strange.  This was confirmed by our vendor Oracle. They do support other Content-Transfer-Encoding for SOAP /w Attachment, but not for MTOM.

Can you please review the behavior in SoapUI? I did notice that when text/xml files are imported as base64 (insert file as base64) SoapUI already uses Content-Transfer-Encoding: binary  even when mime:contentType="text/xml". This pull request makes the behavior identical to the binaries in the attachment tab and only applies to MTOM. Thanks!
