### PR TITLE
Add support for adding Java event handlers to JavaScript in the WebView based browser component

### DIFF
--- a/soapui-system-test/src/test/java/com/eviware/soapui/support/components/EnabledWebViewBasedBrowserComponentTest.java
+++ b/soapui-system-test/src/test/java/com/eviware/soapui/support/components/EnabledWebViewBasedBrowserComponentTest.java
@@ -1,0 +1,43 @@
+package com.eviware.soapui.support.components;
+
+import org.junit.Test;
+
+import javax.swing.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+public class EnabledWebViewBasedBrowserComponentTest {
+    private static final String SCHEME = "file://";
+    private static final String TEST_STARTER_PAGE_URL
+            = SCHEME + EnabledWebViewBasedBrowserComponentTest.class
+            .getResource("/starter-pages/starter-page-with-an-single-action-button.html").getPath();
+    private static final String MEMBER_NAME = "member";
+    private static final int TIMEOUT = 10;
+
+    private final CountDownLatch latch = new CountDownLatch(1);
+
+    @Test
+    public void sucessfullCallbackWhenClickingOnAnElement() throws InterruptedException {
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                WebViewBasedBrowserComponent browserComponent = new EnabledWebViewBasedBrowserComponent(true
+                        , WebViewBasedBrowserComponent.PopupStrategy.INTERNAL_BROWSER_REUSE_WINDOW);
+                browserComponent.addJavaScriptEventHandler(MEMBER_NAME, new JavaScriptCallback());
+                browserComponent.navigate(TEST_STARTER_PAGE_URL);
+            }
+        });
+        /* Wait for the browser to initialize and click on the HTML element programmatically.
+        If we don't get a callback within a resonable amount of time, fail the test */
+        assertThat(latch.await(TIMEOUT, TimeUnit.SECONDS), is(true));
+    }
+
+    public class JavaScriptCallback {
+        public void call() {
+            latch.countDown();
+        }
+    }
+}

--- a/soapui-system-test/src/test/resources/starter-pages/starter-page-with-an-single-action-button.html
+++ b/soapui-system-test/src/test/resources/starter-pages/starter-page-with-an-single-action-button.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+    <head lang="en">
+        <meta charset="UTF-8">
+        <title>Starter page with an single action button</title>
+        <script src="jquery.min.js"></script>
+        <script type="text/javascript">
+            $(document).ready(
+                window.setTimeout(function() {
+                    $("p").click();
+                }
+                // We need to delay a bit to make sure the 'callback' object is initilizedS
+                , 100)
+            );
+        </script>
+    </head>
+    <body>
+        <p onclick="member.call();">Click me</p>
+    </body>
+</html>

--- a/soapui/src/main/java/com/eviware/soapui/support/components/DisabledWebViewBasedBrowserComponent.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/components/DisabledWebViewBasedBrowserComponent.java
@@ -66,4 +66,8 @@ class DisabledWebViewBasedBrowserComponent implements WebViewBasedBrowserCompone
     @Override
     public void executeJavaScript(String script) {
     }
+
+    @Override
+    public void addJavaScriptEventHandler(String memberName, Object eventHandler) {
+    }
 }

--- a/soapui/src/main/java/com/eviware/soapui/support/components/WebViewBasedBrowserComponent.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/components/WebViewBasedBrowserComponent.java
@@ -42,4 +42,12 @@ public interface WebViewBasedBrowserComponent {
     void removeBrowserStateListener(BrowserListener listener);
 
     void executeJavaScript(String script);
+
+    /**
+     * Provides a JavaScript object <i>memberName</i> when the current page is successfully loaded which can be used to call
+     * the <i>eventHandler</i>.
+     *
+     * @see netscape.javascript.JSObject#setMember()
+     */
+    void addJavaScriptEventHandler(String memberName, Object eventHandler);
 }


### PR DESCRIPTION
I'm using the recommended way of creating a _JavaScript -> Java_ integration as described in the [_Calling back to Java from JavaScript_ section of the WebEngine JavaDoc](http://docs.oracle.com/javafx/2/api/javafx/scene/web/WebEngine.html)

I've also put the test in the _soapui-system-test_ module since it's time dependent and more of a integration test

_SOAP-2329_
