### PR TITLE
Ensure working java6 build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,53 +88,53 @@
                             </rules>
                         </configuration>
                     </execution>
-					<execution>
-						<id>enforce-bytecode-version</id>
-						<goals>
-							<goal>enforce</goal>
-						</goals>
-						<configuration>
-							<rules>
-								<!-- http://mojo.codehaus.org/extra-enforcer-rules/enforceBytecodeVersion.html -->
-								<enforceBytecodeVersion>
-									<maxJdkVersion>1.6</maxJdkVersion>
-								</enforceBytecodeVersion>
-							</rules>
-							<fail>true</fail>
-						</configuration>
-					</execution>
+                    <execution>
+                        <id>enforce-bytecode-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <!-- http://mojo.codehaus.org/extra-enforcer-rules/enforceBytecodeVersion.html -->
+                                <enforceBytecodeVersion>
+                                    <maxJdkVersion>1.6</maxJdkVersion>
+                                </enforceBytecodeVersion>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
                 </executions>
-				<dependencies>
-					<dependency>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>extra-enforcer-rules</artifactId>
-						<version>1.0-beta-2</version>
-					</dependency>
-				</dependencies>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>extra-enforcer-rules</artifactId>
+                        <version>1.0-beta-2</version>
+                    </dependency>
+                </dependencies>
             </plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>animal-sniffer-maven-plugin</artifactId>
-				<version>1.9</version>
-				<configuration>
-					<signature>
-						<groupId>org.codehaus.mojo.signature</groupId>
-						<!-- currently, we cannot use java16 1.1 because some classes depends on the sun specific
-						implementation (com.sun.java.swing.plaf.windows) -->
-						<artifactId>java16-sun</artifactId>
-						<version>1.10</version>
-					</signature>
-				</configuration>
-				<executions>
-					<execution>
-						<id>animal-sniffer-check</id>
-						<phase>process-classes</phase>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.9</version>
+                <configuration>
+                    <signature>
+                        <groupId>org.codehaus.mojo.signature</groupId>
+                        <!-- currently, we cannot use java16 1.1 because some classes depends on the sun specific
+                        implementation (com.sun.java.swing.plaf.windows) -->
+                        <artifactId>java16-sun</artifactId>
+                        <version>1.10</version>
+                    </signature>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>animal-sniffer-check</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Regarding recent discussions, SoapUI is still supposed to support Java 6.

As developpers often use Java 7 to build SoapUI, some dependencies to newly Java 7 api can be added without any notice. Then, the build fails with Java 6 and a fix is lately applied (see 6831b103db78eb8bc969cc5b30a5bc9d2e460133 for instance)

This pull request adds a new check in the build (thanks to the animal-sniffer-maven-plugin) to be sure that the SoapUI code does not depends on Java 7 api.
In addition, another check is performed to be sure that dependencies can be used when running with Java 6.

// cc @erikryverling
