### PR TITLE
Remove unused joda-time

### DIFF
--- a/soapui/pom.xml
+++ b/soapui/pom.xml
@@ -521,11 +521,6 @@
             <version>1.142</version>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>1.6.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.ws.commons.util</groupId>
             <artifactId>ws-commons-util</artifactId>
             <version>1.0.2</version>


### PR DESCRIPTION
Seems like the library joda-time isn't used by SoapUI. Maybe we could remove it?

I found this while experimenting with Dropwizard and SoapUI when SoapUI's old joda-time version clashed with Dropwizard's updated one.
