### PR TITLE
MockAsWar: Honor the soapui.ext.libraries system property

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/tools/MockAsWar.java
+++ b/soapui/src/main/java/com/eviware/soapui/tools/MockAsWar.java
@@ -17,7 +17,6 @@
 package com.eviware.soapui.tools;
 
 import com.eviware.soapui.SoapUI;
-import com.eviware.soapui.analytics.Analytics;
 import com.eviware.soapui.impl.wsdl.WsdlProject;
 import com.eviware.soapui.support.StringUtils;
 import com.eviware.soapui.support.Tools;
@@ -28,9 +27,6 @@ import com.eviware.x.dialogs.XProgressMonitor;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
-import org.apache.log4j.Logger;
-
-import javax.annotation.Nullable;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -43,6 +39,8 @@ import java.io.OutputStreamWriter;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import javax.annotation.Nullable;
+import org.apache.log4j.Logger;
 
 public class MockAsWar {
     protected static final String SOAPUI_SETTINGS = "[SoapUISettings]";
@@ -198,7 +196,8 @@ public class MockAsWar {
 
             if (includeExt) {
                 // copy all from bin/ext to soapui.home/war/WEB-INF/lib/
-                fromDir = new File(System.getProperty(SOAPUI_HOME), "ext");
+                String extDirPath = System.getProperty("soapui.ext.libraries");
+                fromDir = extDirPath != null ? new File(extDirPath) : new File(new File(System.getProperty(SOAPUI_HOME)), "ext");                
                 JarPackager.copyAllFromTo(fromDir, lib, null);
             }
 


### PR DESCRIPTION
This property is already set in the wargenerator scripts from the SoapUI distribution. This pull request allows the MockAsWar to honor it.
