### PR TITLE
MockAsWar: remove the WsdlProject parameter from the constructor

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/actions/MockAsWarAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/actions/MockAsWarAction.java
@@ -34,9 +34,8 @@ import com.eviware.x.form.support.AField;
 import com.eviware.x.form.support.AField.AFieldType;
 import com.eviware.x.form.support.AForm;
 import com.eviware.x.form.validators.RequiredValidator;
-import org.apache.log4j.Logger;
-
 import java.io.IOException;
+import org.apache.log4j.Logger;
 
 public class MockAsWarAction extends AbstractSoapUIAction<WsdlProject> {
     private XFormDialog dialog;
@@ -81,8 +80,7 @@ public class MockAsWarAction extends AbstractSoapUIAction<WsdlProject> {
                     dialog.getBooleanValue(MockAsWarDialog.EXT_LIBS),
                     dialog.getBooleanValue(MockAsWarDialog.ACTIONS), dialog.getBooleanValue(MockAsWarDialog.LISTENERS),
                     dialog.getValue(MockAsWarDialog.MOCKSERVICE_ENDPOINT),
-                    dialog.getBooleanValue(MockAsWarDialog.ENABLE_WEBUI),
-                    project);
+                    dialog.getBooleanValue(MockAsWarDialog.ENABLE_WEBUI));
             mockAsWar.createMockAsWarArchive();
 
             if (project.getRestMockServiceCount() > 0) {

--- a/soapui/src/main/java/com/eviware/soapui/tools/MockAsWar.java
+++ b/soapui/src/main/java/com/eviware/soapui/tools/MockAsWar.java
@@ -17,8 +17,6 @@
 package com.eviware.soapui.tools;
 
 import com.eviware.soapui.SoapUI;
-import com.eviware.soapui.analytics.Analytics;
-import com.eviware.soapui.impl.wsdl.WsdlProject;
 import com.eviware.soapui.support.StringUtils;
 import com.eviware.soapui.support.Tools;
 import com.eviware.soapui.support.UISupport;
@@ -28,9 +26,6 @@ import com.eviware.x.dialogs.XProgressMonitor;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
-import org.apache.log4j.Logger;
-
-import javax.annotation.Nullable;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -43,6 +38,8 @@ import java.io.OutputStreamWriter;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import javax.annotation.Nullable;
+import org.apache.log4j.Logger;
 
 public class MockAsWar {
     protected static final String SOAPUI_SETTINGS = "[SoapUISettings]";
@@ -69,11 +66,8 @@ public class MockAsWar {
     protected final String localEndpoint;
     protected boolean enableWebUI;
 
-    private WsdlProject project;
-
     public MockAsWar(String projectPath, String settingsPath, String warDir, String warFile, boolean includeExt,
-                     boolean actions, boolean listeners, String localEndpoint, boolean enableWebUI, WsdlProject project) {
-        this.project = project;
+                     boolean actions, boolean listeners, String localEndpoint, boolean enableWebUI) {
         this.localEndpoint = localEndpoint;
         this.projectFile = new File(projectPath);
         this.settingsFile = StringUtils.hasContent(settingsPath) ? new File(settingsPath) : null;

--- a/soapui/src/main/java/com/eviware/soapui/tools/SoapUIMockAsWarGenerator.java
+++ b/soapui/src/main/java/com/eviware/soapui/tools/SoapUIMockAsWarGenerator.java
@@ -21,9 +21,8 @@ import com.eviware.soapui.impl.wsdl.WsdlProject;
 import com.eviware.soapui.model.project.ProjectFactoryRegistry;
 import com.eviware.soapui.settings.ProjectSettings;
 import com.eviware.soapui.support.StringUtils;
-import org.apache.commons.cli.CommandLine;
-
 import java.io.File;
+import org.apache.commons.cli.CommandLine;
 
 public class SoapUIMockAsWarGenerator extends AbstractSoapUIRunner {
     public static String TITLE = "SoapUI " + SoapUI.SOAPUI_VERSION + " War Generator";
@@ -128,7 +127,7 @@ public class SoapUIMockAsWarGenerator extends AbstractSoapUIRunner {
         log.info("Creating WAR file with endpoint [" + endpoint + "]");
 
         MockAsWar mockAsWar = new MockAsWar(pFile, getSettingsFile(), getOutputFolder(), warFile, includeLibraries,
-                includeActions, includeListeners, endpoint, enableWebUI, project);
+                includeActions, includeListeners, endpoint, enableWebUI);
 
         mockAsWar.createMockAsWarArchive();
         log.info("WAR Generation complete");


### PR DESCRIPTION
This parameter had been introduced for the initial usage statistics implementation, but is not needed anymore.
Adding this parameter breaks the api compatibility with the previous version, so I propose to remove it.

I have already notified SmartBear developers about this, see
- https://github.com/SmartBear/soapui/commit/f36ce5b35df9cdc981150da3557c7d6c9689a3d2#commitcomment-6422713
- https://github.com/SmartBear/soapui/commit/41b8d65d9b74e3a8e7268c7615f1a1445f38c1ec#commitcomment-6427225

//cc @olensmar, @sergeylukashenko, @shadidchowdhury 
