### PR TITLE
MockAsWarGenerator: Allow subclasses to use an alternative MockAsWar

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/tools/SoapUIMockAsWarGenerator.java
+++ b/soapui/src/main/java/com/eviware/soapui/tools/SoapUIMockAsWarGenerator.java
@@ -21,9 +21,8 @@ import com.eviware.soapui.impl.wsdl.WsdlProject;
 import com.eviware.soapui.model.project.ProjectFactoryRegistry;
 import com.eviware.soapui.settings.ProjectSettings;
 import com.eviware.soapui.support.StringUtils;
-import org.apache.commons.cli.CommandLine;
-
 import java.io.File;
+import org.apache.commons.cli.CommandLine;
 
 public class SoapUIMockAsWarGenerator extends AbstractSoapUIRunner {
     public static String TITLE = "SoapUI " + SoapUI.SOAPUI_VERSION + " War Generator";
@@ -127,12 +126,17 @@ public class SoapUIMockAsWarGenerator extends AbstractSoapUIRunner {
 
         log.info("Creating WAR file with endpoint [" + endpoint + "]");
 
-        MockAsWar mockAsWar = new MockAsWar(pFile, getSettingsFile(), getOutputFolder(), warFile, includeLibraries,
-                includeActions, includeListeners, endpoint, enableWebUI, project);
+        MockAsWar mockAsWar = newMockAsWar(project, pFile, endpoint);
 
         mockAsWar.createMockAsWarArchive();
         log.info("WAR Generation complete");
         return true;
+    }
+
+    // allow subclasses to use an alternative implementation of MockAsWar
+    protected MockAsWar newMockAsWar(WsdlProject project, String projectPath, String endpoint) {
+        return new MockAsWar(projectPath, getSettingsFile(), getOutputFolder(), warFile, includeLibraries,
+                includeActions, includeListeners, endpoint, enableWebUI, project);
     }
 
     public boolean isIncludeActions() {


### PR DESCRIPTION
This PR introduces a new protected method that creates the MockAsWar instance. It allows user to create subclasses of the generator to use their own implementation of MockAsWar.
As a 1st use case, it will help me cleaning the code of the `mock-as-war` goal in [maven-soapui-extension-plugin](https://github.com/redfish4ktc/maven-soapui-extension-plugin)
