### PR TITLE
Only change the foreground color for non-selected lines

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/support/log/JLogList.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/log/JLogList.java
@@ -164,7 +164,7 @@ public class JLogList extends JPanel {
             if (value instanceof LoggingEventWrapper) {
                 LoggingEventWrapper eventWrapper = (LoggingEventWrapper) value;
 
-                if (levelColors.containsKey(eventWrapper.getLevel())) {
+                if (!isSelected && levelColors.containsKey(eventWrapper.getLevel())) {
                     component.setForeground(levelColors.get(eventWrapper.getLevel()));
                 }
             }


### PR DESCRIPTION
This is a small fix for an annoying situation on macs : when one selects a line in a log list, the L&F background color is almost as dark as the line foreground color (especially at INFO level) making the selected line (very) difficult to read.  With this fix, the selected line(s) foreground color is not modified and is thus readable and has the standard L&F foreground/background colours.

Fix is applied regardless of platform, one could argue that it should be only applied on plateforms where the current situation is problematic : the test would need to be adjusted accordingly.
