### PR TITLE
Qualify this otherwise we get a ClassCastException when clearing the log...

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/support/log/JLogList.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/log/JLogList.java
@@ -401,7 +401,7 @@ public class JLogList extends JPanel {
             lines.clear();
             SwingUtilities.invokeLater(new Runnable() {
                 public void run() {
-                    fireIntervalRemoved(this, 0, size - 1);
+                    fireIntervalRemoved(LogListModel.this, 0, size - 1);
                 }
             });
         }


### PR DESCRIPTION
Another small fix to the LogList : with java7 and recent versions of soapui, clearing the log panel (on a groovy script for example) gives me : 

Exception in thread "AWT-EventQueue-0" java.lang.ClassCastException: com.eviware.soapui.support.log.JLogList$LogListModel$1 cannot be cast to javax.swing.ListModel
    at com.eviware.soapui.support.ListDataChangeListener.intervalRemoved(ListDataChangeListener.java:33)
    at javax.swing.AbstractListModel.fireIntervalRemoved(AbstractListModel.java:179)
    at com.eviware.soapui.support.log.JLogList$LogListModel.access$900(JLogList.java:383)
    at com.eviware.soapui.support.log.JLogList$LogListModel$1.run(JLogList.java:404)
    at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:251)

This fixes that.
