### PR TITLE
Fix HTTP 301 redirect, set the Host explicitly

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/HttpClientRequestTransport.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/HttpClientRequestTransport.java
@@ -323,6 +323,10 @@ public class HttpClientRequestTransport implements BaseHttpRequestTransport {
                 uri.getEscapedPath(), uri.getEscapedQuery(), uri.getEscapedFragment());
         getMethod.setURI(newUri);
 
+        // Thijs Brentjens: if the location contains a different Host, due to the redirect, then use that instead of the already existing Host-header. So just set the Host header to the new host of the URI
+        
+        getMethod.setHeader("Host",uri.getHost());
+
         org.apache.http.HttpResponse response = submitRequest(getMethod, httpContext);
 
         if (isRedirectResponse(response.getStatusLine().getStatusCode())) {


### PR DESCRIPTION
Fix 301 redirect to use the Host of the redirect location. See discussion on the forum: http://forum.soapui.org/viewtopic.php?t=23090

Another, earlier Pull request (https://github.com/SmartBear/soapui/pull/42) was closed, because I didn't sign the contributor agreement yet. I did that just now so it should all be in place.