### PR TITLE
Prevent duplicates in groovy.log appenders

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/tools/AbstractSoapUIRunner.java
+++ b/soapui/src/main/java/com/eviware/soapui/tools/AbstractSoapUIRunner.java
@@ -19,6 +19,7 @@ package com.eviware.soapui.tools;
 import java.io.File;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +30,7 @@ import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.PosixParser;
+import org.apache.log4j.Appender;
 import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PatternLayout;
@@ -76,10 +78,19 @@ public abstract class AbstractSoapUIRunner implements CmdLineRunner {
         if (!groovyLogInitialized) {
             Logger logger = Logger.getLogger("groovy.log");
 
-            ConsoleAppender appender = new ConsoleAppender();
-            appender.setWriter(new OutputStreamWriter(System.out));
-            appender.setLayout(new PatternLayout("%d{ABSOLUTE} %-5p [%c{1}] %m%n"));
-            logger.addAppender(appender);
+            // ensure there is a ConsoleAppender defined, adding one if necessary
+            boolean addAConsoleAppender = true;
+            for (Object appender : Collections.list(logger.getAllAppenders())) {
+                if (appender instanceof ConsoleAppender) {
+                    addAConsoleAppender = false;
+                }
+            }
+            if (addAConsoleAppender) {
+                ConsoleAppender appender = new ConsoleAppender();
+                appender.setWriter(new OutputStreamWriter(System.out));
+                appender.setLayout(new PatternLayout("%d{ABSOLUTE} %-5p [%c{1}] %m%n"));
+                logger.addAppender(appender);
+            }
 
             groovyLogInitialized = true;
         }


### PR DESCRIPTION
Do not add a new ConsoleAppender to groovy.log logger if one is already present.

Without this patch, when a ConsoleAppender have been already defined in the soapui-log4j.xml file, initGroovyLog() will add a second one.  

Also, without this patch, when called from SoapUITestCaseRunner (through soapui-maven-plugin for example), every invocation will add another appender, because a new instance of SoapUITestCaseRunner is created (thus groovyLogInitialized is false) but the logger we get from Logger.getLogger("groovy.log") is the instance already configured in the JVM; we get as many ConsoleAppender instances as SoapUITestCaseRunner.run() invocations.

I think this is related to  SOAP-1938, but I'm not sure because I don't have access to your jira issues.