### PR TITLE
A fix for the XQueryAssertionContains wildcard bug.

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/basic/XQueryContainsAssertion.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/basic/XQueryContainsAssertion.java
@@ -282,6 +282,8 @@ public class XQueryContainsAssertion extends WsdlMessageAssertion implements Req
                     } catch (ComparisonFailure e) {
                         return Diff.RETURN_ACCEPT_DIFFERENCE;
                     }
+                    
+                    return Diff.RETURN_IGNORE_DIFFERENCE_NODES_IDENTICAL;
                 }
 
                 return Diff.RETURN_ACCEPT_DIFFERENCE;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/basic/XQueryContainsAssertion.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/basic/XQueryContainsAssertion.java
@@ -279,11 +279,10 @@ public class XQueryContainsAssertion extends WsdlMessageAssertion implements Req
                         .getId())) {
                     try {
                         Tools.assertSimilar(diff.getControlNodeDetail().getValue(), diff.getTestNodeDetail().getValue(), '*');
+                        return Diff.RETURN_IGNORE_DIFFERENCE_NODES_IDENTICAL;
                     } catch (ComparisonFailure e) {
                         return Diff.RETURN_ACCEPT_DIFFERENCE;
-                    }
-                    
-                    return Diff.RETURN_IGNORE_DIFFERENCE_NODES_IDENTICAL;
+                    }                    
                 }
 
                 return Diff.RETURN_ACCEPT_DIFFERENCE;

--- a/soapui/src/test/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/XQueryContainsTest.java
+++ b/soapui/src/test/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/XQueryContainsTest.java
@@ -91,5 +91,20 @@ public class XQueryContainsTest {
         assertEquals("Not matched expected!", "XQuery Match matches content for [/DirectionsResponse/route[1]/leg[1]/step[1]/start_location[1]/lat[1]]",
                 result);
     }
+    
+    @Test
+    public void positiveWildcardTest() throws AssertionException {
+        assertion.setPath("for $f in //step[1]/html_instructions return $f");
+        assertion.setExpectedContent("<html_instructions>Head *</html_instructions>");
+        assertion.setAllowWildcards(true);
+        assertion.assertContent(response, context, XQueryContainsAssertion.ID);
+    }
 
+    @Test(expected = AssertionException.class)
+    public void negativeWildcardTest() throws AssertionException {
+        assertion.setPath("for $f in //step[1]/html_instructions return $f");
+        assertion.setExpectedContent("<html_instructions>ABC *</html_instructions>");
+        assertion.setAllowWildcards(true);
+        assertion.assertContent(response, context, XQueryContainsAssertion.ID);
+    }
 }


### PR DESCRIPTION
Dear sir/madam,

I have created a fix for the bug described in these discussions:

- http://forum.soapui.org/viewtopic.php?t=15436
- http://forum.loadui.org/viewtopic.php?f=13&t=24498

Basically the wildcard is not interpreted as a wildcard, but as a literal character. The fix corrects this behavior.

I will send the CLA as soon as my employer gives me the green light (on signing the CLA).

Best regards,
Bouke Nijhuis