### PR TITLE
Adding ability to propagate test case properties into JUnit report

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/soapui/TestRunnerAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/soapui/TestRunnerAction.java
@@ -41,7 +41,7 @@ import com.eviware.x.form.XFormFieldListener;
 import com.eviware.x.impl.swing.JTextAreaFormField;
 import org.apache.log4j.Logger;
 
-import javax.swing.*;
+import javax.swing.Action;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/soapui/TestRunnerAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/soapui/TestRunnerAction.java
@@ -16,17 +16,6 @@
 
 package com.eviware.soapui.impl.wsdl.actions.iface.tools.soapui;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.StringTokenizer;
-
-import javax.swing.Action;
-
-import org.apache.log4j.Logger;
-
 import com.eviware.soapui.SoapUI;
 import com.eviware.soapui.impl.wsdl.WsdlProject;
 import com.eviware.soapui.impl.wsdl.WsdlTestSuite;
@@ -50,6 +39,15 @@ import com.eviware.x.form.XFormFactory;
 import com.eviware.x.form.XFormField;
 import com.eviware.x.form.XFormFieldListener;
 import com.eviware.x.impl.swing.JTextAreaFormField;
+import org.apache.log4j.Logger;
+
+import javax.swing.*;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringTokenizer;
 
 /**
  * Invokes SoapUI TestRunner tool
@@ -71,6 +69,7 @@ public class TestRunnerAction extends AbstractToolsAction<WsdlProject> {
     protected static final String PRINTREPORT = "Print Report";
     protected static final String ROOTFOLDER = "Root Folder";
     protected static final String EXPORTJUNITRESULTS = "Export JUnit Results";
+    protected static final String EXPORTJUNITRESULTSWITHPROPERTIES = "Export JUnit Results with test properties";
     protected static final String EXPORTALL = "Export All";
     protected static final String ENABLEUI = "Enable UI";
     protected static final String TESTRUNNERPATH = "TestRunner Path";
@@ -177,6 +176,7 @@ public class TestRunnerAction extends AbstractToolsAction<WsdlProject> {
         reportForm = builder.createForm("Reports");
         reportForm.addCheckBox(PRINTREPORT, "Prints a summary report to the console");
         reportForm.addCheckBox(EXPORTJUNITRESULTS, "Exports results to a JUnit-Style report");
+        reportForm.addCheckBox(EXPORTJUNITRESULTSWITHPROPERTIES, "Exports results to a JUnit-Style report with test properties");
         reportForm.addCheckBox(EXPORTALL, "Exports all results (not only errors)");
         reportForm.addTextField(ROOTFOLDER, "Folder to export to", XForm.FieldType.FOLDER);
         reportForm.addSeparator();
@@ -350,6 +350,7 @@ public class TestRunnerAction extends AbstractToolsAction<WsdlProject> {
         builder.addBoolean(PRINTREPORT, "-r");
         builder.addBoolean(EXPORTALL, "-a");
         builder.addBoolean(EXPORTJUNITRESULTS, "-j");
+        builder.addBoolean(EXPORTJUNITRESULTSWITHPROPERTIES, "-J");
         builder.addString(ROOTFOLDER, "-f", "");
 
         if (proVersion) {

--- a/soapui/src/main/java/com/eviware/soapui/report/JUnitReportCollector.java
+++ b/soapui/src/main/java/com/eviware/soapui/report/JUnitReportCollector.java
@@ -16,21 +16,14 @@
 
 package com.eviware.soapui.report;
 
-import java.io.File;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-
+import com.eviware.soapui.model.TestModelItem;
 import com.eviware.soapui.model.testsuite.ProjectRunContext;
 import com.eviware.soapui.model.testsuite.ProjectRunListener;
 import com.eviware.soapui.model.testsuite.ProjectRunner;
 import com.eviware.soapui.model.testsuite.TestCase;
 import com.eviware.soapui.model.testsuite.TestCaseRunContext;
 import com.eviware.soapui.model.testsuite.TestCaseRunner;
+import com.eviware.soapui.model.testsuite.TestProperty;
 import com.eviware.soapui.model.testsuite.TestRunListener;
 import com.eviware.soapui.model.testsuite.TestRunner.Status;
 import com.eviware.soapui.model.testsuite.TestStep;
@@ -43,6 +36,16 @@ import com.eviware.soapui.model.testsuite.TestSuiteRunner;
 import com.eviware.soapui.support.StringUtils;
 import com.eviware.soapui.support.xml.XmlUtils;
 
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 /**
  * Collects TestRun results and creates JUnitReports
  *
@@ -53,7 +56,10 @@ public class JUnitReportCollector implements TestRunListener, TestSuiteRunListen
     HashMap<String, JUnitReport> reports;
     HashMap<TestCase, String> failures;
     HashMap<TestCase, Integer> errorCount;
+
+    protected boolean includeTestPropertiesInReport = false;
     private int maxErrors = 0;
+
 
     public JUnitReportCollector() {
         this(0);
@@ -108,22 +114,32 @@ public class JUnitReportCollector implements TestRunListener, TestSuiteRunListen
         TestCase testCase = testRunner.getTestCase();
         JUnitReport report = reports.get(testCase.getTestSuite().getName());
 
+        HashMap<String, String> testProperties = getTestPropertiesAsHashMap(testCase);
+
         if (Status.INITIALIZED != testRunner.getStatus() && Status.RUNNING != testRunner.getStatus()) {
             if (Status.CANCELED == testRunner.getStatus()) {
-                report.addTestCase(testCase.getName(), testRunner.getTimeTaken());
+                report.addTestCase(testCase.getName(), testRunner.getTimeTaken(), testProperties);
             }
             if (Status.FAILED == testRunner.getStatus()) {
                 String msg = "";
                 if (failures.containsKey(testCase)) {
                     msg = failures.get(testCase).toString();
                 }
-                report.addTestCaseWithFailure(testCase.getName(), testRunner.getTimeTaken(), testRunner.getReason(), msg);
+                report.addTestCaseWithFailure(testCase.getName(), testRunner.getTimeTaken(), testRunner.getReason(), msg, testProperties);
             }
             if (Status.FINISHED == testRunner.getStatus()) {
-                report.addTestCase(testCase.getName(), testRunner.getTimeTaken());
+                report.addTestCase(testCase.getName(), testRunner.getTimeTaken(), testProperties);
             }
 
         }
+    }
+
+    protected HashMap<String, String> getTestPropertiesAsHashMap(TestModelItem testCase) {
+        HashMap<String, String> testProperties = new HashMap<>();
+        for (Map.Entry<String, TestProperty> stringTestPropertyEntry : testCase.getProperties().entrySet()) {
+            testProperties.put(stringTestPropertyEntry.getKey(), stringTestPropertyEntry.getValue().getValue());
+        }
+        return testProperties;
     }
 
     public void afterStep(TestCaseRunner testRunner, TestCaseRunContext runContext, TestStepResult result) {
@@ -183,6 +199,7 @@ public class JUnitReportCollector implements TestRunListener, TestSuiteRunListen
         TestSuite testSuite = testCase.getTestSuite();
         if (!reports.containsKey(testSuite.getName())) {
             JUnitReport report = new JUnitReport();
+            report.setIncludeTestProperties(this.includeTestPropertiesInReport);
             report.setTestSuiteName(testSuite.getProject().getName() + "." + testSuite.getName());
             reports.put(testSuite.getName(), report);
         }
@@ -251,4 +268,9 @@ public class JUnitReportCollector implements TestRunListener, TestSuiteRunListen
 
         return new JUnitReportCollector(maxErrors);
     }
+
+    public void setIncludeTestPropertiesInReport(boolean includeTestPropertiesInReport) {
+        this.includeTestPropertiesInReport = includeTestPropertiesInReport;
+    }
+
 }

--- a/soapui/src/main/java/com/eviware/soapui/report/JUnitSecurityReportCollector.java
+++ b/soapui/src/main/java/com/eviware/soapui/report/JUnitSecurityReportCollector.java
@@ -16,8 +16,6 @@
 
 package com.eviware.soapui.report;
 
-import java.util.List;
-
 import com.eviware.soapui.junit.Testcase;
 import com.eviware.soapui.model.security.SecurityScan;
 import com.eviware.soapui.model.testsuite.TestCase;
@@ -33,6 +31,9 @@ import com.eviware.soapui.security.result.SecurityScanResult;
 import com.eviware.soapui.security.result.SecurityTestStepResult;
 import com.eviware.soapui.security.support.SecurityTestRunListener;
 import com.eviware.soapui.support.xml.XmlUtils;
+
+import java.util.HashMap;
+import java.util.List;
 
 /**
  * Collects Security Test results and creates JUnitReports
@@ -53,6 +54,8 @@ public class JUnitSecurityReportCollector extends JUnitReportCollector implement
         SecurityTest securityTest = ((SecurityTestRunner) testRunner).getSecurityTest();
 
         JUnitReport report = new JUnitReport();
+        report.setIncludeTestProperties(includeTestPropertiesInReport);
+
         String reportName = securityTest.getName();
         report.setTestSuiteName(reportName);
         report.setPackage(testCase.getTestSuite().getProject().getName());
@@ -62,9 +65,12 @@ public class JUnitSecurityReportCollector extends JUnitReportCollector implement
             SecurityTestStepResult secuTestStepResult = securityTest.getSecurityTestStepResultMap().get(ts);
             if (secuTestStepResult != null) {
                 for (SecurityScanResult scanResult : secuTestStepResult.getSecurityScanResultList()) {
+
+                    HashMap<String, String> testProperties = getTestPropertiesAsHashMap(securityTest);
+
                     List<SecurityScanRequestResult> resultList = scanResult.getSecurityRequestResultList();
                     Testcase secTestCase = report.addTestCase(ts.getName() + " - " + scanResult.getSecurityScanName(),
-                            scanResult.getTimeTaken());
+                            scanResult.getTimeTaken(), testProperties);
 
                     secTestCase.setPackage(testCase.getTestSuite().getProject().getName());
 

--- a/soapui/src/main/java/com/eviware/soapui/tools/SoapUITestCaseRunner.java
+++ b/soapui/src/main/java/com/eviware/soapui/tools/SoapUITestCaseRunner.java
@@ -98,6 +98,7 @@ public class SoapUITestCaseRunner extends AbstractSoapUITestRunner {
     private boolean exportAll;
     private boolean ignoreErrors;
     private boolean junitReport;
+    private boolean junitReportWithProperties;
     private int exportCount;
     private int maxErrors = 5;
     private JUnitReportCollector reportCollector;
@@ -201,6 +202,7 @@ public class SoapUITestCaseRunner extends AbstractSoapUITestRunner {
         }
 
         setJUnitReport(cmd.hasOption("j"));
+        setJUnitReportWithProperties(cmd.hasOption("J"));
 
         if (cmd.hasOption("m")) {
             setMaxErrors(Integer.parseInt(cmd.getOptionValue("m")));
@@ -255,6 +257,7 @@ public class SoapUITestCaseRunner extends AbstractSoapUITestRunner {
         options.addOption( "M", false, "Creates a Test Run Log Report in XML format" );
         options.addOption( "f", true, "Sets the output folder to export results to" );
         options.addOption( "j", false, "Sets the output to include JUnit XML reports" );
+        options.addOption( "J", false, "Sets the output to include JUnit XML reports adding test properties to the report" );
         options.addOption( "m", false, "Sets the maximum number of TestStep errors to save for each testcase" );
         options.addOption( "a", false, "Turns on exporting of all results" );
         options.addOption( "A", false, "Turns on exporting of all results using folders instead of long filenames" );
@@ -283,6 +286,13 @@ public class SoapUITestCaseRunner extends AbstractSoapUITestRunner {
         this.junitReport = junitReport;
         if (junitReport) {
             reportCollector = createJUnitSecurityReportCollector();
+        }
+    }
+
+    public void setJUnitReportWithProperties(boolean shouldIncludePropertiesInTheReport) {
+        this.junitReportWithProperties = shouldIncludePropertiesInTheReport;
+        if (this.junitReport && junitReportWithProperties) {
+            reportCollector.setIncludeTestPropertiesInReport(junitReportWithProperties);
         }
     }
 

--- a/soapui/src/main/xsd/junit/report.xsd
+++ b/soapui/src/main/xsd/junit/report.xsd
@@ -43,7 +43,8 @@
   <xs:element name="testcase" type="tns:testcase" />
   <xs:complexType name="testcase">
   	<xs:sequence>
-  		<xs:element ref="tns:failure" minOccurs="0" maxOccurs="1"/>
+		<xs:element ref="tns:properties" minOccurs="0" maxOccurs="1" />
+		<xs:element ref="tns:failure" minOccurs="0" maxOccurs="1"/>
   		<xs:element ref="tns:error" minOccurs="0" maxOccurs="1"/>
   	</xs:sequence>
   	<xs:attribute name="name" type="xs:string"></xs:attribute>


### PR DESCRIPTION
I have a need to be able to link soapUI test results to high level business requirements. I have implemented it by exposing test properties in JUnit report. Current functionality remains unchanged and there is a new checkbox in the report tab of the TestCaseRunner popup. Once selected it sets boolean flags which causes test properties to be included in the JUnit Test output.

Without flag test case xml looks as follows:

```xml
<testcase name="TestCase1" time="0.384">
</testcase>
```

After adding the flag, following tags are added to the output:

```xml
<testcase name="TestCase1" time="0.35">
    <properties>
        <property name="BussinessRequirementId" value="BusinessRequirement1"/>
    </properties>
</testcase>
```