### PR TITLE
At most one console appender for groovy log

### DIFF
--- a/soapui-maven-plugin-tester/pom.xml
+++ b/soapui-maven-plugin-tester/pom.xml
@@ -65,6 +65,30 @@
                             <!-- <goal>security-test</goal> -->
                         </goals>
                     </execution>
+                    <execution>
+                        <id>groovy log 1</id>
+                        <phase>test</phase>
+                        <configuration>
+                            <projectFile>${project.basedir}/src/test/soapui/GroovyLog-soapui-project.xml</projectFile>
+                            <testSuite>Number of ConsoleAppender on groovy.log</testSuite>
+                            <testCase>Groovy log should have at most one ConsoleAppender</testCase>
+                        </configuration>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>groovy log 2</id>
+                        <phase>test</phase>
+                        <configuration>
+                            <projectFile>${project.basedir}/src/test/soapui/GroovyLog-soapui-project.xml</projectFile>
+                            <testSuite>Number of ConsoleAppender on groovy.log</testSuite>
+                            <testCase>Groovy log should have at most one ConsoleAppender</testCase>
+                        </configuration>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/soapui-maven-plugin-tester/src/test/soapui/GroovyLog-soapui-project.xml
+++ b/soapui-maven-plugin-tester/src/test/soapui/GroovyLog-soapui-project.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<con:soapui-project id="119ead01-b0ea-41ff-b2ac-da261ba83ea0" activeEnvironment="Default" name="GroovyLog" resourceRoot="" soapui-version="5.2.1-SNAPSHOT" abortOnError="false" runType="SEQUENTIAL" xmlns:con="http://eviware.com/soapui/config">
+  <con:description>Project to test that ouput in groovy log is not duplicated when the maven plugin 
+is invoked more than one time.</con:description>
+  <con:settings/>
+  <con:testSuite id="2d8e78e2-5c22-423f-a02c-d7241c6cb9b5" name="Number of ConsoleAppender on groovy.log">
+    <con:settings/>
+    <con:runType>SEQUENTIAL</con:runType>
+    <con:testCase id="1b15fda6-8f9e-4f13-8aac-c339935bbbfd" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="Groovy log should have at most one ConsoleAppender" searchProperties="true">
+      <con:settings/>
+      <con:testStep type="groovy" name="Count ConsoleAppender should be zero or one" id="56e8fd8f-1730-4ddb-aa9c-e1af4c64da75">
+        <con:settings/>
+        <con:config>
+          <script>import org.apache.log4j.Logger
+import org.apache.log4j.ConsoleAppender
+
+Logger groovyLog = Logger.getLogger('groovy.log')
+assert groovyLog.getAllAppenders().findAll { it instanceof ConsoleAppender }.size() &lt;= 1</script>
+        </con:config>
+      </con:testStep>
+      <con:properties/>
+    </con:testCase>
+    <con:properties/>
+  </con:testSuite>
+  <con:properties/>
+  <con:wssContainer/>
+  <con:oAuth2ProfileContainer/>
+  <con:sensitiveInformation/>
+</con:soapui-project>

--- a/soapui/src/main/java/com/eviware/soapui/tools/AbstractSoapUIRunner.java
+++ b/soapui/src/main/java/com/eviware/soapui/tools/AbstractSoapUIRunner.java
@@ -19,6 +19,7 @@ package com.eviware.soapui.tools;
 import java.io.File;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +30,7 @@ import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.PosixParser;
+import org.apache.log4j.Appender;
 import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PatternLayout;
@@ -76,11 +78,19 @@ public abstract class AbstractSoapUIRunner implements CmdLineRunner {
         if (!groovyLogInitialized) {
             Logger logger = Logger.getLogger("groovy.log");
 
-            ConsoleAppender appender = new ConsoleAppender();
-            appender.setWriter(new OutputStreamWriter(System.out));
-            appender.setLayout(new PatternLayout("%d{ABSOLUTE} %-5p [%c{1}] %m%n"));
-            logger.addAppender(appender);
-
+            // ensure there is a ConsoleAppender defined, adding one if necessary
+            boolean addAConsoleAppender = true;
+            for (Object appender : Collections.list(logger.getAllAppenders())) {
+                if (appender instanceof ConsoleAppender) {
+                    addAConsoleAppender = false;
+                }
+            }
+            if (addAConsoleAppender) {
+                ConsoleAppender appender = new ConsoleAppender();
+                appender.setWriter(new OutputStreamWriter(System.out));
+                appender.setLayout(new PatternLayout("%d{ABSOLUTE} %-5p [%c{1}] %m%n"));
+                logger.addAppender(appender);
+            }
             groovyLogInitialized = true;
         }
     }

--- a/soapui/src/main/java/com/eviware/soapui/tools/AbstractSoapUIRunner.java
+++ b/soapui/src/main/java/com/eviware/soapui/tools/AbstractSoapUIRunner.java
@@ -76,22 +76,32 @@ public abstract class AbstractSoapUIRunner implements CmdLineRunner {
 
     protected void initGroovyLog() {
         if (!groovyLogInitialized) {
-            Logger logger = Logger.getLogger("groovy.log");
+            ensureConsoleAppenderIsDefined(Logger.getLogger("groovy.log"));
+            groovyLogInitialized = true;
+        }
+    }
 
+    /**
+     * Ensure there is one (and only one) ConsoleAppender instance configured for <code>logger</code>.
+     *
+     * @param logger
+     */
+    protected void ensureConsoleAppenderIsDefined(Logger logger) {
+        if (logger != null) {
             // ensure there is a ConsoleAppender defined, adding one if necessary
-            boolean addAConsoleAppender = true;
+            ConsoleAppender consoleAppender = null;
             for (Object appender : Collections.list(logger.getAllAppenders())) {
                 if (appender instanceof ConsoleAppender) {
-                    addAConsoleAppender = false;
+                    consoleAppender = (ConsoleAppender) appender;
+                    break;
                 }
             }
-            if (addAConsoleAppender) {
-                ConsoleAppender appender = new ConsoleAppender();
-                appender.setWriter(new OutputStreamWriter(System.out));
-                appender.setLayout(new PatternLayout("%d{ABSOLUTE} %-5p [%c{1}] %m%n"));
-                logger.addAppender(appender);
+            if (consoleAppender == null) {
+                consoleAppender = new ConsoleAppender();
+                consoleAppender.setWriter(new OutputStreamWriter(System.out));
+                consoleAppender.setLayout(new PatternLayout("%d{ABSOLUTE} %-5p [%c{1}] %m%n"));
+                logger.addAppender(consoleAppender);
             }
-            groovyLogInitialized = true;
         }
     }
 

--- a/soapui/src/main/java/com/eviware/soapui/tools/AbstractSoapUIRunner.java
+++ b/soapui/src/main/java/com/eviware/soapui/tools/AbstractSoapUIRunner.java
@@ -89,19 +89,15 @@ public abstract class AbstractSoapUIRunner implements CmdLineRunner {
     protected void ensureConsoleAppenderIsDefined(Logger logger) {
         if (logger != null) {
             // ensure there is a ConsoleAppender defined, adding one if necessary
-            ConsoleAppender consoleAppender = null;
             for (Object appender : Collections.list(logger.getAllAppenders())) {
                 if (appender instanceof ConsoleAppender) {
-                    consoleAppender = (ConsoleAppender) appender;
-                    break;
+                    return;
                 }
             }
-            if (consoleAppender == null) {
-                consoleAppender = new ConsoleAppender();
-                consoleAppender.setWriter(new OutputStreamWriter(System.out));
-                consoleAppender.setLayout(new PatternLayout("%d{ABSOLUTE} %-5p [%c{1}] %m%n"));
-                logger.addAppender(consoleAppender);
-            }
+            ConsoleAppender consoleAppender = new ConsoleAppender();
+            consoleAppender.setWriter(new OutputStreamWriter(System.out));
+            consoleAppender.setLayout(new PatternLayout("%d{ABSOLUTE} %-5p [%c{1}] %m%n"));
+            logger.addAppender(consoleAppender);
         }
     }
 


### PR DESCRIPTION
This is a rework of pull request #151 :
* a test project is added to soapui-maven-plugin-tester (triggered in phase test in pom.xml) that fails when there is more than one ConsoleAppender associated with `groovy.log` logger; without the fix to AbstractSoapUIRunner, this test fails.
* a fix to AbstractSoapUIRunner that adds a ConsoleAppender only if there none yet.