### PR TITLE
Add support for SNI (Server Name Indication) in TLS

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/http/SoapUIMultiThreadedHttpConnectionManager.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/http/SoapUIMultiThreadedHttpConnectionManager.java
@@ -17,12 +17,14 @@
 package com.eviware.soapui.impl.wsdl.support.http;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.conn.ClientConnectionOperator;
@@ -49,6 +51,7 @@ import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.HttpContext;
 import org.apache.log4j.Logger;
 
+import com.eviware.soapui.SoapUI;
 import com.eviware.soapui.impl.wsdl.submit.transports.http.support.metrics.SoapUIMetrics;
 
 /**
@@ -248,6 +251,12 @@ public class SoapUIMultiThreadedHttpConnectionManager extends ThreadSafeClientCo
                 boolean last = i == addresses.length - 1;
 
                 Socket sock = sf.createSocket(params);
+                try {
+                    // hostname is required by web server with virtual hosts and one IP (TLS-SNI)
+                    PropertyUtils.setProperty(sock, "host", target.getHostName());
+                } catch (IllegalAccessException|InvocationTargetException|NoSuchMethodException e) {
+                    SoapUI.logError(e);
+                }
                 conn.opening(sock, target);
 
                 InetSocketAddress remoteAddress = new InetSocketAddress(address, port);


### PR DESCRIPTION
apache ssl:debug
No SNI: AH02645: Server name not provided via TLS extension (using default/first virtual host)
SNI: AH02043: SSL virtual host for servername www.example.com found