### PR TITLE
use treeset so the list of endpoints is sorted in the ui

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/testcase/actions/SetEndpointAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/testcase/actions/SetEndpointAction.java
@@ -18,6 +18,7 @@ package com.eviware.soapui.impl.wsdl.panels.testcase.actions;
 
 import java.awt.event.ActionEvent;
 import java.util.HashSet;
+import java.util.TreeSet;
 import java.util.Set;
 
 import javax.swing.AbstractAction;
@@ -47,7 +48,7 @@ public class SetEndpointAction extends AbstractAction {
     }
 
     public void actionPerformed(ActionEvent e) {
-        Set<String> endpointSet = new HashSet<String>();
+        Set<String> endpointSet = new TreeSet<String>();
         Set<String> currentEndpointSet = new HashSet<String>();
 
         endpointSet.add(USE_CURRENT);


### PR DESCRIPTION
I use the endpoint selector in SoapUI frequently and, with 100+ endpoints, it can be time consuming to find the exact one which I want to test. I can type the endpoint in order to have it select it but this is time consuming and prone to typos. This change makes it much faster to locate endpoints in the list.