### PR TITLE
Fix an issue with mock service, which attempts to access an ArrayList…

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/mock/dispatch/SequenceMockOperationDispatcher.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/mock/dispatch/SequenceMockOperationDispatcher.java
@@ -31,13 +31,17 @@ public class SequenceMockOperationDispatcher extends AbstractMockOperationDispat
     }
 
     public MockResponse selectMockResponse(MockRequest request, MockResult result) {
-        if (currentDispatchIndex >= getMockOperation().getMockResponseCount()) {
-            currentDispatchIndex = 0;
-        }
+        MockResponse mockResponse = null;
+        MockOperation mockOperation = getMockOperation();
+        synchronized (mockOperation) {
+            if (currentDispatchIndex >= mockOperation.getMockResponseCount()) {
+                currentDispatchIndex = 0;
+            }
 
-        MockResponse mockResponse = getMockOperation().getMockResponseAt(currentDispatchIndex);
+            mockResponse = mockOperation.getMockResponseAt(currentDispatchIndex);
 
-        currentDispatchIndex++;
+            currentDispatchIndex++;
+    	}
         return mockResponse;
     }
 


### PR DESCRIPTION
… con-currently, resulting in IndexOutOfBoundsException

We are using the mock service as a "back-end service simulator" for our middleware product, and we discovered mock service sometimes generates HTTP 500 under heavy load. This patch  is the quick fix to our problem.