### PR TITLE
make the port of SOAP Mock Response test step configurable with property expansion

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/mockresponse/AddMockResponseToTestCaseAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/mockresponse/AddMockResponseToTestCaseAction.java
@@ -84,7 +84,7 @@ public class AddMockResponseToTestCaseAction extends AbstractAddToTestCaseAction
 
         config.setName(dialog.getValue(Form.STEP_NAME));
         mockResponseStepConfig.setPath(dialog.getValue(Form.PATH));
-        mockResponseStepConfig.setPort(dialog.getIntValue(Form.PORT, mockService.getPort()));
+        mockResponseStepConfig.setPort(String.valueOf(dialog.getIntValue(Form.PORT, mockService.getPort())));
 
         mockResponse.beforeSave();
         mockResponseStepConfig.getResponse().set(mockResponse.getConfig());

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/operation/AddOperationAsMockResponseStepAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/operation/AddOperationAsMockResponseStepAction.java
@@ -68,7 +68,7 @@ public class AddOperationAsMockResponseStepAction extends AbstractAddToTestCaseA
 
         config.setName(dialog.getValue(Form.STEP_NAME));
         mockResponseStepConfig.setPath(dialog.getValue(Form.PATH));
-        mockResponseStepConfig.setPort(dialog.getIntValue(Form.PORT, 8181));
+        mockResponseStepConfig.setPort(String.valueOf(dialog.getIntValue(Form.PORT, 8181)));
 
         String response = operation.createResponse(operation.getSettings().getBoolean(
                 WsdlSettings.XML_GENERATION_ALWAYS_INCLUDE_OPTIONAL_ELEMENTS));

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/request/AddRequestAsMockResponseStepAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/request/AddRequestAsMockResponseStepAction.java
@@ -80,7 +80,7 @@ public class AddRequestAsMockResponseStepAction extends AbstractAddToTestCaseAct
 
         config.setName(dialog.getValue(Form.STEP_NAME));
         mockResponseStepConfig.setPath(dialog.getValue(Form.PATH));
-        mockResponseStepConfig.setPort(dialog.getIntValue(Form.PORT, 8181));
+        mockResponseStepConfig.setPort(String.valueOf(dialog.getIntValue(Form.PORT, 8181)));
         CompressedStringConfig responseContent = mockResponseStepConfig.getResponse().getResponseContent();
 
         if (request.getResponse() == null && !request.getOperation().isOneWay()) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/WsdlMockResponseStepDesktopPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/WsdlMockResponseStepDesktopPanel.java
@@ -179,7 +179,7 @@ public class WsdlMockResponseStepDesktopPanel extends AbstractWsdlMockResponseDe
             @Override
             public void update(Document document) {
                 try {
-                    getModelItem().setPort(Integer.parseInt(portField.getText()));
+                    getModelItem().setPort(portField.getText());
                 } catch (NumberFormatException e) {
                 }
             }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlMockResponseTestStep.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlMockResponseTestStep.java
@@ -260,7 +260,7 @@ public class WsdlMockResponseTestStep extends WsdlTestStepWithProperties impleme
     private void initMockObjects(WsdlTestCase testCase) {
         MockServiceConfig mockServiceConfig = MockServiceConfig.Factory.newInstance();
         mockServiceConfig.setPath(mockResponseStepConfig.getPath());
-        mockServiceConfig.setPort(mockResponseStepConfig.getPort());
+        mockServiceConfig.setPort(Integer.parseInt(PropertyExpander.expandProperties(this, mockResponseStepConfig.getPort())));
         mockServiceConfig.setHost(mockResponseStepConfig.getHost());
 
         mockService = new WsdlTestMockService(this, mockServiceConfig);
@@ -327,6 +327,8 @@ public class WsdlMockResponseTestStep extends WsdlTestStepWithProperties impleme
         for (TestAssertion assertion : getAssertionList()) {
             assertion.prepare(testRunner, testRunContext);
         }
+
+        mockService.setPort(Integer.parseInt(PropertyExpander.expandProperties(this, mockResponseStepConfig.getPort())));
 
         if (loadTestRunner == null) {
             mockService.addMockRunListener(mockRunListener);
@@ -629,9 +631,9 @@ public class WsdlMockResponseTestStep extends WsdlTestStepWithProperties impleme
         return mockResponse;
     }
 
-    public void setPort(int port) {
-        int old = getPort();
-        mockService.setPort(port);
+    public void setPort(String port) {
+        String old = getPort();
+        mockService.setPort(Integer.valueOf(PropertyExpander.expandProperties(this, port)));
         mockResponseStepConfig.setPort(port);
         notifyPropertyChanged("port", old, port);
     }
@@ -648,7 +650,7 @@ public class WsdlMockResponseTestStep extends WsdlTestStepWithProperties impleme
         return mockResponse == null ? 0 : mockResponse.getContentLength();
     }
 
-    public int getPort() {
+    public String getPort() {
         return mockResponseStepConfig.getPort();
     }
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/registry/WsdlMockResponseStepFactory.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/registry/WsdlMockResponseStepFactory.java
@@ -120,7 +120,13 @@ public class WsdlMockResponseStepFactory extends WsdlTestStepFactory {
             MockResponseStepConfig config = MockResponseStepConfig.Factory.newInstance();
             config.setInterface(dialog.getValue(CreateForm.INTERFACE));
             config.setOperation(dialog.getValue(CreateForm.OPERATION));
-            config.setPort(dialog.getIntValue(CreateForm.PORT, 8080));
+            String port = dialog.getValue(CreateForm.PORT);
+            if (port != null && !port.isEmpty()) {
+                config.setPort(port);
+            } else {
+                config.setPort("8080");
+            }
+
             config.setPath(dialog.getValue(CreateForm.PATH));
             config.addNewResponse();
             config.getResponse().addNewResponseContent();
@@ -154,7 +160,7 @@ public class WsdlMockResponseStepFactory extends WsdlTestStepFactory {
         @AField(description = "Specifies if a mock response is to be created from the schema", name = "Create Response", type = AFieldType.BOOLEAN)
         public final static String CREATE_RESPONSE = "Create Response";
 
-        @AField(description = "Specifies the port to listen on", name = "Port", type = AFieldType.INT)
+        @AField(description = "Specifies the port to listen on", name = "Port")
         public final static String PORT = "Port";
 
         @AField(description = "Specifies the path to listen on", name = "Path")
@@ -212,7 +218,7 @@ public class WsdlMockResponseStepFactory extends WsdlTestStepFactory {
         dialog.setValue(CreateForm.INTERFACE, operation.getInterface().getName());
         dialog.setValue(CreateForm.OPERATION, operation.getName());
         dialog.setBooleanValue(CreateForm.CREATE_RESPONSE, false);
-        dialog.setIntValue(CreateForm.PORT, mockResponse.getMockOperation().getMockService().getPort());
+        dialog.setValue(CreateForm.PORT, String.valueOf(mockResponse.getMockOperation().getMockService().getPort()));
         dialog.setValue(CreateForm.PATH, mockResponse.getMockOperation().getMockService().getPath());
 
         return createFromDialog(operation.getInterface().getProject(), mockResponse.getMockOperation().getName() + " - "

--- a/soapui/src/main/xsd/soapui/soapui.xsd
+++ b/soapui/src/main/xsd/soapui/soapui.xsd
@@ -1118,7 +1118,7 @@
             <xsd:element name="interface" type="xsd:string"></xsd:element>
             <xsd:element name="operation" type="xsd:string"></xsd:element>
             <xsd:element name="path" type="xsd:string"></xsd:element>
-            <xsd:element name="port" type="xsd:int"></xsd:element>
+            <xsd:element name="port" type="xsd:string"></xsd:element>
             <xsd:element name="timeout" type="xsd:long"></xsd:element>
             <xsd:element name="response" type="tns:MockResponse"></xsd:element>
             <xsd:element name="assertion" type="tns:TestAssertion"


### PR DESCRIPTION
see https://community.smartbear.com/t5/SoapUI-Open-Source/Scripting-Mock-Response-s-port-number/td-p/34386