### PR TITLE
Adding the support for attachments for REST and SOAP requests

### DIFF
--- a/soapui-testserver-api/src/main/java/com/smartbear/ready/recipe/HttpRequestTestStepParser.java
+++ b/soapui-testserver-api/src/main/java/com/smartbear/ready/recipe/HttpRequestTestStepParser.java
@@ -2,12 +2,15 @@ package com.smartbear.ready.recipe;
 
 import com.eviware.soapui.config.AbstractRequestConfig;
 import com.eviware.soapui.impl.support.AbstractHttpRequest;
+import com.eviware.soapui.impl.wsdl.support.FileAttachment;
 import com.eviware.soapui.impl.wsdl.teststeps.TestRequest;
 import com.eviware.soapui.impl.wsdl.teststeps.WsdlMessageAssertion;
 import com.eviware.soapui.model.testsuite.TestAssertion;
 import com.eviware.soapui.support.types.StringToStringsMap;
+import com.google.api.client.repackaged.org.apache.commons.codec.binary.Base64;
 import com.smartbear.ready.recipe.assertions.AssertionStruct;
 import com.smartbear.ready.recipe.teststeps.HttpTestRequestStepStruct;
+import com.smartbear.ready.recipe.teststeps.RequestAttachmentStruct;
 
 import java.util.List;
 import java.util.Map;
@@ -37,6 +40,17 @@ public abstract class HttpRequestTestStepParser implements TestStepJsonParser {
                 }
             }
             testRequest.setRequestHeaders(requestHeaders);
+        }
+    }
+
+    void addAttachments(HttpTestRequestStepStruct testStepStruct, AbstractHttpRequest testRequest) {
+        RequestAttachmentStruct[] attachmentArray = testStepStruct.attachments;
+        if (attachmentArray != null) {
+            for (RequestAttachmentStruct attachment : attachmentArray) {
+                FileAttachment fileAtt = (FileAttachment) testRequest.attachBinaryData(Base64.decodeBase64(attachment.content), attachment.contentType);
+                fileAtt.setName(attachment.name);
+                fileAtt.setContentID(attachment.contentId);
+            }
         }
     }
 

--- a/soapui-testserver-api/src/main/java/com/smartbear/ready/recipe/RestRequestTestStepParser.java
+++ b/soapui-testserver-api/src/main/java/com/smartbear/ready/recipe/RestRequestTestStepParser.java
@@ -59,6 +59,7 @@ class RestRequestTestStepParser extends HttpRequestTestStepParser {
         addAuthentication(requestTestStepElement, testRequest);
         addProperties(requestTestStepElement, testRequest);
         addAssertions(requestTestStepElement, testRequest);
+        addAttachments(requestTestStepElement, testRequest);
     }
 
     private String createRequestName(HttpMethod httpMethod, WsdlTestCase testCase) {

--- a/soapui-testserver-api/src/main/java/com/smartbear/ready/recipe/SoapRequestTestStepParser.java
+++ b/soapui-testserver-api/src/main/java/com/smartbear/ready/recipe/SoapRequestTestStepParser.java
@@ -48,6 +48,7 @@ class SoapRequestTestStepParser extends HttpRequestTestStepParser {
         addHeaders(requestTestStepElement, testRequest);
         addAuthentication(requestTestStepElement, testRequest);
         addAssertions(requestTestStepElement, testRequest);
+        addAttachments(requestTestStepElement, testRequest);
     }
 
     private void addProperties(SoapTestRequestStepStruct testStepStruct, WsdlTestRequest testRequest) {

--- a/soapui-testserver-api/src/main/java/com/smartbear/ready/recipe/teststeps/HttpTestRequestStepStruct.java
+++ b/soapui-testserver-api/src/main/java/com/smartbear/ready/recipe/teststeps/HttpTestRequestStepStruct.java
@@ -16,6 +16,7 @@ public class HttpTestRequestStepStruct extends TestStepStruct {
     public boolean entitizeParameters;
     public String clientCertificateFileName;
     public String clientCertificatePassword;
+    public RequestAttachmentStruct[] attachments;
 
     public HttpTestRequestStepStruct(String type, String name, String URI,
                                      AssertionStruct[] assertions,
@@ -27,7 +28,8 @@ public class HttpTestRequestStepStruct extends TestStepStruct {
                                      String requestBody,
                                      AuthenticationStruct authentication,
                                      String clientCertificateFileName,
-                                     String clientCertificatePassword) {
+                                     String clientCertificatePassword,
+                                     RequestAttachmentStruct[] attachments) {
         super(type, name);
         this.URI = URI;
         this.assertions = assertions;
@@ -40,5 +42,6 @@ public class HttpTestRequestStepStruct extends TestStepStruct {
         this.authentication = authentication;
         this.clientCertificateFileName = clientCertificateFileName;
         this.clientCertificatePassword = clientCertificatePassword;
+        this.attachments = attachments;
     }
 }

--- a/soapui-testserver-api/src/main/java/com/smartbear/ready/recipe/teststeps/RequestAttachmentStruct.java
+++ b/soapui-testserver-api/src/main/java/com/smartbear/ready/recipe/teststeps/RequestAttachmentStruct.java
@@ -1,0 +1,24 @@
+package com.smartbear.ready.recipe.teststeps;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RequestAttachmentStruct {
+
+    public String contentType;
+    public String name;
+    public String contentId;
+    public String content;
+
+    @JsonCreator
+    public RequestAttachmentStruct(
+            @JsonProperty("contentType") String contentType,
+            @JsonProperty("name") String name,
+            @JsonProperty("contentId") String contentId,
+            @JsonProperty("content") String content) {
+        this.contentType = contentType;
+        this.name = name;
+        this.contentId = contentId;
+        this.content = content;
+    }
+}

--- a/soapui-testserver-api/src/main/java/com/smartbear/ready/recipe/teststeps/RestTestRequestStepStruct.java
+++ b/soapui-testserver-api/src/main/java/com/smartbear/ready/recipe/teststeps/RestTestRequestStepStruct.java
@@ -38,9 +38,10 @@ public class RestTestRequestStepStruct extends HttpTestRequestStepStruct {
             @JsonProperty("entitizeParameters") boolean entitizeParameters,
             @JsonProperty("postQueryString") boolean postQueryString,
             @JsonProperty("clientCertificateFileName") String clientCertificateFileName,
-            @JsonProperty("clientCertificatePassword") String clientCertificatePassword) {
+            @JsonProperty("clientCertificatePassword") String clientCertificatePassword,
+            @JsonProperty("attachments") RequestAttachmentStruct[] attachments) {
         super(type, name, URI, assertions, encoding, headers, timeout, followRedirects, entitizeParameters,
-                requestBody, authentication, clientCertificateFileName, clientCertificatePassword);
+                requestBody, authentication, clientCertificateFileName, clientCertificatePassword, attachments);
 
         checkNotNull(method, "method");
         checkNotNull(URI, "URI");

--- a/soapui-testserver-api/src/main/java/com/smartbear/ready/recipe/teststeps/SoapTestRequestStepStruct.java
+++ b/soapui-testserver-api/src/main/java/com/smartbear/ready/recipe/teststeps/SoapTestRequestStepStruct.java
@@ -38,9 +38,10 @@ public class SoapTestRequestStepStruct extends HttpTestRequestStepStruct {
             @JsonProperty("followRedirects") boolean followRedirects,
             @JsonProperty("entitizeParameters") boolean entitizeParameters,
             @JsonProperty("clientCertificateFileName") String clientCertificateFileName,
-            @JsonProperty("clientCertificatePassword") String clientCertificatePassword) {
+            @JsonProperty("clientCertificatePassword") String clientCertificatePassword,
+            @JsonProperty("attachments") RequestAttachmentStruct[] attachments) {
         super(type, name, uri, assertions, encoding, headers, timeout, followRedirects, entitizeParameters,
-                requestBody, authentication, clientCertificateFileName, clientCertificatePassword);
+                requestBody, authentication, clientCertificateFileName, clientCertificatePassword, attachments);
 
         checkNotNull(wsdl, "wsdl");
         checkNotNull(operation, "operation");

--- a/soapui-testserver-api/src/main/resources/test-recipe-schema.json
+++ b/soapui-testserver-api/src/main/resources/test-recipe-schema.json
@@ -15,6 +15,29 @@
         }
       ]
     },
+    "RequestAttachment": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "contentId": {
+          "type": "string"
+        },
+        "content": {
+          "type": "string",
+          "format": "byte"
+        }
+      },
+      "required": [
+        "contentType",
+        "content"
+      ],
+      "additionalProperties": false
+    },
     "OAuth2AccessTokenPosition": {
       "type": "string",
       "enum": [
@@ -897,6 +920,12 @@
             ]
           }
         },
+        "attachments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RequestAttachment"
+          }
+        },
         "assertions": {
           "type": "array",
           "items": {
@@ -1055,6 +1084,12 @@
                 }
               }
             ]
+          }
+        },
+        "attachments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RequestAttachment"
           }
         },
         "assertions": {

--- a/soapui-testserver-api/src/test/java/com/smartbear/ready/recipe/RestRequestParsingTest.java
+++ b/soapui-testserver-api/src/test/java/com/smartbear/ready/recipe/RestRequestParsingTest.java
@@ -5,8 +5,10 @@ import com.eviware.soapui.impl.rest.RestService;
 import com.eviware.soapui.impl.rest.actions.support.NewRestResourceActionBase;
 import com.eviware.soapui.impl.rest.support.RestParamsPropertyHolder;
 import com.eviware.soapui.impl.wsdl.WsdlProject;
+import com.eviware.soapui.impl.wsdl.support.FileAttachment;
 import com.eviware.soapui.impl.wsdl.teststeps.RestTestRequest;
 import com.eviware.soapui.impl.wsdl.teststeps.RestTestRequestStep;
+import com.eviware.soapui.model.iface.Attachment;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -128,5 +130,20 @@ public class RestRequestParsingTest extends RecipeParserTestBase {
         assertThat(restRequestStep.getRestMethod().getProperty("mat2").getParamLocation(), is(NewRestResourceActionBase.ParamLocation.METHOD));
         assertThat(restRequestStep.getRestMethod().getProperty("mat1").getStyle(), is(RestParamsPropertyHolder.ParameterStyle.MATRIX));
         assertThat(restRequestStep.getRestMethod().getProperty("mat2").getStyle(), is(RestParamsPropertyHolder.ParameterStyle.MATRIX));
+    }
+
+    @Test
+    public void parsesRequestAttachment() throws Exception {
+        WsdlProject project = buildProjectFromRecipe("request-with-base64-attachment.json");
+
+        RestTestRequestStep restRequestStep = getSingleRestRequestStepIn(project);
+        RestTestRequest testRequest = restRequestStep.getTestRequest();
+        Attachment[] attachments = testRequest.getAttachments();
+        assertThat(attachments.length, is(1));
+        Attachment attachment = attachments[0];
+        assertThat(attachment.getName(), is("A Name"));
+        assertThat(attachment.getContentType(), is("text/plain"));
+        assertThat(attachment.getContentID(), is("An id"));
+        assertThat(((FileAttachment) attachment).getData(), is("Content".getBytes()));
     }
 }

--- a/soapui-testserver-api/src/test/java/com/smartbear/ready/recipe/SoapRequestParsingTest.java
+++ b/soapui-testserver-api/src/test/java/com/smartbear/ready/recipe/SoapRequestParsingTest.java
@@ -2,17 +2,21 @@ package com.smartbear.ready.recipe;
 
 import com.eviware.soapui.impl.wsdl.WsdlProject;
 import com.eviware.soapui.impl.wsdl.submit.filters.RemoveEmptyContentRequestFilter;
+import com.eviware.soapui.impl.wsdl.support.FileAttachment;
 import com.eviware.soapui.impl.wsdl.teststeps.WsdlTestRequest;
 import com.eviware.soapui.impl.wsdl.teststeps.WsdlTestRequestStep;
 import com.eviware.soapui.impl.wsdl.teststeps.assertions.basic.SchemaComplianceAssertion;
 import com.eviware.soapui.impl.wsdl.teststeps.assertions.soap.NotSoapFaultAssertion;
 import com.eviware.soapui.impl.wsdl.teststeps.assertions.soap.SoapFaultAssertion;
+import com.eviware.soapui.model.iface.Attachment;
 import com.eviware.soapui.support.xml.XmlUtils;
 import org.apache.xmlbeans.XmlObject;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -90,6 +94,20 @@ public class SoapRequestParsingTest extends RecipeParserTestBase {
 
         assertFalse(content.contains("CityName"));
         assertFalse(content.contains("CountryName"));
+    }
+
+    @Test
+    public void parsesRequestAttachment() throws Exception {
+        WsdlProject project = buildProjectWithWsdlReference("simple-soap-request-with-base64-attachment.json");
+        WsdlTestRequestStep restRequestStep = getSingleTestStepIn(project, WsdlTestRequestStep.class);
+        WsdlTestRequest request = restRequestStep.getTestRequest();
+        Attachment[] attachments = request.getAttachments();
+        assertThat(attachments.length, is(1));
+        Attachment attachment = attachments[0];
+        assertThat(attachment.getName(), is("A Name"));
+        assertThat(attachment.getContentType(), is("text/plain"));
+        assertThat(attachment.getContentID(), is("An id"));
+        assertThat(((FileAttachment) attachment).getData(), is("Content".getBytes()));
     }
 
     private WsdlProject buildProjectWithWsdlReference(String jsonFile) throws Exception {

--- a/soapui-testserver-api/src/test/resources/test-recipes/request-with-base64-attachment.json
+++ b/soapui-testserver-api/src/test/resources/test-recipes/request-with-base64-attachment.json
@@ -1,0 +1,17 @@
+{
+  "testSteps": [
+    {
+      "type": "REST Request",
+      "method": "GET",
+      "URI": "http://google.com/",
+      "attachments" : [
+        {
+          "contentType" : "text/plain",
+          "name" : "A Name",
+          "contentId" : "An id",
+          "content": "Q29udGVudA=="
+        }
+      ]
+    }
+  ]
+}

--- a/soapui-testserver-api/src/test/resources/test-recipes/simple-soap-request-with-base64-attachment.json
+++ b/soapui-testserver-api/src/test/resources/test-recipes/simple-soap-request-with-base64-attachment.json
@@ -1,0 +1,24 @@
+{
+  "testSteps": [
+    {
+      "type": "SOAP Request",
+      "wsdl": "globalweather.wsdl",
+      "binding": "GlobalWeatherSoap",
+      "operation": "GetCitiesByCountry",
+      "parameters": [
+        {
+          "name": "CountryName",
+          "value": "Sweden"
+        }
+      ],
+      "attachments" : [
+        {
+          "contentType" : "text/plain",
+          "name" : "A Name",
+          "contentId" : "An id",
+          "content": "Q29udGVudA=="
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
It was added in Ready! API but not in SoapUI - so, adding it here as well.