### PR TITLE
Apache Commons Collections: Security Update

### DIFF
--- a/soapui-maven-plugin/.classpath
+++ b/soapui-maven-plugin/.classpath
@@ -6,7 +6,7 @@
 	<classpathentry kind="var" path="MAVEN_REPO/wsdl4j/jars/wsdl4j-1.6.2-fixed.jar"/>
 	<classpathentry kind="var" path="MAVEN_REPO/log4j/jars/log4j-1.2.14.jar"/>
 	<classpathentry kind="var" path="MAVEN_REPO/commons-logging/jars/commons-logging-1.1.1.jar"/>
-	<classpathentry kind="var" path="MAVEN_REPO/commons-collections/jars/commons-collections-3.2.1.jar"/>
+	<classpathentry kind="var" path="MAVEN_REPO/commons-collections/jars/commons-collections-3.2.2.jar"/>
 	<classpathentry kind="var" path="MAVEN_REPO/commons-lang/jars/commons-lang-2.4.jar"/>
 	<classpathentry kind="var" path="MAVEN_REPO/commons-io/jars/commons-io-1.3.2.jar"/>
 	<classpathentry kind="var" path="MAVEN_REPO/commons-ssl/jars/not-yet-commons-ssl-0.3.11.jar"/>

--- a/soapui-maven-plugin/project.xml
+++ b/soapui-maven-plugin/project.xml
@@ -54,7 +54,7 @@
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<version>3.2.1</version>
+			<version>3.2.2</version>
 			<type>jar</type>
 			<url>http://jakarta.apache.org/commons/logging</url>
 		</dependency>

--- a/soapui/pom.xml
+++ b/soapui/pom.xml
@@ -176,7 +176,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>


### PR DESCRIPTION
SoapUI currently uses Apache Commons Collections 3.2.1 as a dependency, which has well known vulnerabilities: https://issues.apache.org/jira/browse/COLLECTIONS-580

Additionally, SoapUI opens an RMI endpoint on port 1198, which exposes these well known vulnerabilities to the network.

This is a naive stab at remediation.