### PR TITLE
Fix PasswordDigestExt algorithm

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/entries/UsernameEntry.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/entries/UsernameEntry.java
@@ -77,6 +77,7 @@ public class UsernameEntry extends WssEntryBase {
                 sha.reset();
                 sha.update(password.getBytes("UTF-8"));
                 password = Base64.encode(sha.digest());
+                token.setPasswordsAreEncoded(true);
             } catch (Exception e) {
                 SoapUI.logError(e);
             }


### PR DESCRIPTION
This fixes the PasswordDigestExt algorithm to match the definition described in the ws-security documentation (using the documentation as expectation).

Documentation:
Section about "Username" and it's configurable fields
https://www.soapui.org/soapui-projects/ws-security.html

Tested against Amadeus Web Services. Credential was always being reported invalid prior to this fix.