### PR TITLE
Decent Borders Native Look And Feel

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/ui/desktop/standalone/StandaloneDesktop.java
+++ b/soapui/src/main/java/com/eviware/soapui/ui/desktop/standalone/StandaloneDesktop.java
@@ -247,7 +247,7 @@ public class StandaloneDesktop extends AbstractSoapUIDesktop {
             frame.setBorder(BorderFactory.createCompoundBorder(BorderFactory.createRaisedBevelBorder(),
                     BorderFactory.createEmptyBorder(4, 4, 4, 4)));
         } else if (!UISupport.isMac()) {
-            frame.setBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY));
+            frame.setBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY, 3));
         }
         return frame;
     }


### PR DESCRIPTION
Hello,

I noticed that the last change affected the new UI only.
Under Windows and set UISettings.NATIVE_LAF there still is that 1 Pixel LineBorder.

This really minor change puts that Native Look And Feel Border to 3 Pixels, which still fits the UI.
4 Pixels would be too thick in this case.

Alternatively you could remove the whole "else if" block, then the Windows Look And Feel would manage the Borders.
But I did test this... the bottom border is too tiny and does not match the side borders.

I only use the new UI, so i am already happy with the first fix.
But if you want to make Native Look And Feel users happy, then this fix would conclude the Decent Borders issue in all cases.

Oh, you should test the UI changes in Mac OS, because I do not own any Mac computers.