### PR TITLE
upgrade Bouncy Castle 1.58

### DIFF
--- a/RELEASENOTES.txt
+++ b/RELEASENOTES.txt
@@ -1,4 +1,16 @@
-﻿# SoapUI Open Source 5.4.0
+﻿# SoapUI Open Source NEXT
+
+### Overall Improvements ###
+
+* SoapUI NEXT uses Bouncy Castle JCE Provider 1.58.
+
+### Bug Fixes ###
+
+### Discontinued Support ###
+
+-------------------------------------------------------------------------------
+
+# SoapUI Open Source 5.4.0
 
 #### Released 2017-11-29 ####
 

--- a/soapui-installer/src/dist/licenses/bcprov-LICENSE.txt
+++ b/soapui-installer/src/dist/licenses/bcprov-LICENSE.txt
@@ -1,18 +1,18 @@
 License
 
-Copyright (c) 2000 - 2006 The Legion Of The Bouncy Castle (http://www.bouncycastle.org)
+Copyright (c) 2000 - 2017 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software
-and associated documentation files (the "Software"), to deal in the Software without restriction, 
-including without limitation the rights to use, copy, modify, merge, publish, distribute, 
-sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is 
+and associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial 
+The above copyright notice and this permission notice shall be included in all copies or substantial
 portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT 
-NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
 IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/soapui-maven-plugin/.classpath
+++ b/soapui-maven-plugin/.classpath
@@ -41,7 +41,7 @@
 	<classpathentry kind="var" path="MAVEN_REPO/xalan/jars/xalan-2.7.1.jar"/>
 	<classpathentry kind="var" path="MAVEN_REPO/xerces/jars/xercesImpl-2.9.1.jar"/>
 	<classpathentry kind="var" path="MAVEN_REPO/wss4j/jars/wss4j-1.5.8.jar"/>
-	<classpathentry kind="var" path="MAVEN_REPO/bouncycastle/jars/bcprov-jdk15-144.jar"/>
+	<classpathentry kind="var" path="MAVEN_REPO/org/bouncycastle/jars/bcprov-jdk15on-1.58.jar"/>
 	<classpathentry kind="var" path="MAVEN_REPO/jtidy/jars/jtidy-r872-jdk15.jar"/>
 	<classpathentry kind="var" path="MAVEN_REPO/javax.jms/jars/jms-1.1.jar"/>
 	<classpathentry kind="var" path="MAVEN_REPO/hermesjms/jars/hermes-1.14.jar"/>

--- a/soapui-maven-plugin/plugin.jelly
+++ b/soapui-maven-plugin/plugin.jelly
@@ -155,7 +155,7 @@
 	       		<ant:pathelement location="${plugin.getDependencyPath('xalan:xalan')}"/>
 	       		<ant:pathelement location="${plugin.getDependencyPath('xerces:xercesImpl')}"/>
 	       		<ant:pathelement location="${plugin.getDependencyPath('wss4j:wss4j')}"/>
-	       		<ant:pathelement location="${plugin.getDependencyPath('bouncycastle:bcprov')}"/>
+	       		<ant:pathelement location="${plugin.getDependencyPath('org.bouncycastle:bcprov-jdk15on')}"/>
 	       		<ant:pathelement location="${plugin.getDependencyPath('jtidy:jtidy')}"/>
    	    		<ant:pathelement location="${plugin.getDependencyPath('javax.jms:jms')}"/>
 				<ant:pathelement location="${plugin.getDependencyPath('hermesjms:hermes')}"/>
@@ -314,7 +314,7 @@
 	       		<ant:pathelement location="${plugin.getDependencyPath('xalan:xalan')}"/>
 	       		<ant:pathelement location="${plugin.getDependencyPath('xerces:xercesImpl')}"/>
 	       		<ant:pathelement location="${plugin.getDependencyPath('wss4j:wss4j')}"/>
-	       		<ant:pathelement location="${plugin.getDependencyPath('bouncycastle:bcprov')}"/>
+	       		<ant:pathelement location="${plugin.getDependencyPath('org.bouncycastle:bcprov-jdk15on')}"/>
 	       		<ant:pathelement location="${plugin.getDependencyPath('jtidy:jtidy')}"/>
    	    		<ant:pathelement location="${plugin.getDependencyPath('javax.jms:jms')}"/>
 				<ant:pathelement location="${plugin.getDependencyPath('hermesjms:hermes')}"/>
@@ -428,7 +428,7 @@
 	       		<ant:pathelement location="${plugin.getDependencyPath('xalan:xalan')}"/>
 	       		<ant:pathelement location="${plugin.getDependencyPath('xerces:xercesImpl')}"/>
 	       		<ant:pathelement location="${plugin.getDependencyPath('wss4j:wss4j')}"/>
-	       		<ant:pathelement location="${plugin.getDependencyPath('bouncycastle:bcprov')}"/>
+	       		<ant:pathelement location="${plugin.getDependencyPath('org.bouncycastle:bcprov-jdk15on')}"/>
 	       		<ant:pathelement location="${plugin.getDependencyPath('jtidy:jtidy')}"/>
    	    		<ant:pathelement location="${plugin.getDependencyPath('javax.jms:jms')}"/>
 				<ant:pathelement location="${plugin.getDependencyPath('hermesjms:hermes')}"/>
@@ -597,7 +597,7 @@
 	       		<ant:pathelement location="${plugin.getDependencyPath('xalan:xalan')}"/>
 	       		<ant:pathelement location="${plugin.getDependencyPath('xerces:xercesImpl')}"/>
 	       		<ant:pathelement location="${plugin.getDependencyPath('wss4j:wss4j')}"/>
-	       		<ant:pathelement location="${plugin.getDependencyPath('bouncycastle:bcprov')}"/>
+	       		<ant:pathelement location="${plugin.getDependencyPath('org.bouncycastle:bcprov-jdk15on')}"/>
 	       		<ant:pathelement location="${plugin.getDependencyPath('jtidy:jtidy')}"/>
    	    		<ant:pathelement location="${plugin.getDependencyPath('javax.jms:jms')}"/>
 				<ant:pathelement location="${plugin.getDependencyPath('hermesjms:hermes')}"/>

--- a/soapui-maven-plugin/project.xml
+++ b/soapui-maven-plugin/project.xml
@@ -264,9 +264,9 @@
 			<type>jar</type>
 		</dependency>
 		<dependency>
-			<groupId>bouncycastle</groupId>
-			<artifactId>bcprov</artifactId>
-			<version>jdk15-144</version>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bcprov-jdk15on</artifactId>
+			<version>1.58</version>
 			<type>jar</type>
 		</dependency>
 		<dependency>

--- a/soapui/pom.xml
+++ b/soapui/pom.xml
@@ -433,9 +433,9 @@
             <version>2.7.1</version>
         </dependency>
         <dependency>
-            <groupId>bouncycastle</groupId>
-            <artifactId>bcprov-jdk15</artifactId>
-            <version>144</version>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.58</version>
         </dependency>
         <dependency>
             <groupId>jtidy</groupId>


### PR DESCRIPTION
Please upgrade the Bouncy Castle dependency in SoapUI. I think the 1.44 version from 2009 is long overdue. We encounter compatibility issues with this old version in our projects.