### PR TITLE
fix problem with NullPointerException while adding assertions in MacOS

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/assertions/AddAssertionPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/assertions/AddAssertionPanel.java
@@ -1,17 +1,17 @@
 /*
  * SoapUI, Copyright (C) 2004-2017 SmartBear Software
  *
- * Licensed under the EUPL, Version 1.1 or - as soon as they will be approved by the European Commission - subsequent 
- * versions of the EUPL (the "Licence"); 
- * You may not use this work except in compliance with the Licence. 
- * You may obtain a copy of the Licence at: 
- * 
- * http://ec.europa.eu/idabc/eupl 
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the Licence is 
- * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
- * express or implied. See the Licence for the specific language governing permissions and limitations 
- * under the Licence. 
+ * Licensed under the EUPL, Version 1.1 or - as soon as they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the Licence for the specific language governing permissions and limitations
+ * under the Licence.
  */
 
 package com.eviware.soapui.impl.wsdl.panels.assertions;
@@ -401,6 +401,10 @@ public class AddAssertionPanel extends SimpleDialog {
         public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus,
                                                        int row, int column) {
 
+            if (value == null) {
+                return super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+            }
+
             boldFont = getFont().deriveFont(Font.BOLD);
 
             AssertionListEntry entry = (AssertionListEntry) value;
@@ -468,10 +472,16 @@ public class AddAssertionPanel extends SimpleDialog {
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus,
                                                        int row, int column) {
+
+            if (value == null) {
+                return super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+            }
+
             String categoryName = (String) value;
             boolean disabled = true;
             Font boldFont = getFont().deriveFont(Font.BOLD);
             SortedSet<AssertionListEntry> assertions = categoriesAssertionsMap.get(categoryName);
+
             for (AssertionListEntry assertionListEntry : assertions) {
                 if (isAssertionApplicable(assertionListEntry.getTypeId())) {
                     disabled = false;


### PR DESCRIPTION
I created this pull request to address the problem described in https://community.smartbear.com/t5/SoapUI-Open-Source/Updated-AddAssertionPanel-still-not-working-on-macOS-SoapUI-5-4/m-p/146697#M24668
The idea for this solution comes from https://github.com/JDatePicker/JDatePicker/issues/58
I tested the fix on my MacBook Pro with macOS 10.13 and everything seems to work fine.