### PR TITLE
Fix xmlsec version mismatch (broke WS Security support).

### DIFF
--- a/soapui/pom.xml
+++ b/soapui/pom.xml
@@ -509,11 +509,6 @@
             <version>7.3</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.santuario</groupId>
-            <artifactId>xmlsec</artifactId>
-            <version>1.4.5</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.xerces</groupId>
             <artifactId>xml-apis</artifactId>
             <version>2.9.1</version>


### PR DESCRIPTION
wss4j 1.6.16 depends on xmlsec 1.5.7 and use its new features. However,
    soapui/pom.xml was pulling in xmlsec 1.4.5 explicitly, hence breaking
    WS Security support. This exception in error log is an indication this
    problem:
    
    ```
      ERROR:com.eviware.soapui.impl.wsdl.mock.DispatchException: java.lang.NoSuchMethodError: org.apache.xml.security.encryption.XMLCipher.setSecureValidation(Z)V
        com.eviware.soapui.impl.wsdl.mock.DispatchException: java.lang.NoSuchMethodError: org.apache.xml.security.encryption.XMLCipher.setSecureValidation(Z)V
        at com.eviware.soapui.impl.wsdl.mock.WsdlMockDispatcher.dispatchRequest(WsdlMockDispatcher.java:135)
        at com.eviware.soapui.impl.wsdl.mock.WsdlMockRunner.dispatchRequest(WsdlMockRunner.java:156)
        at com.eviware.soapui.monitor.JettyMockEngine$ServerHandler.handle(JettyMockEngine.java:716)
        at org.mortbay.jetty.handler.HandlerCollection.handle(HandlerCollection.java:114)
        at org.mortbay.jetty.handler.HandlerWrapper.handle(HandlerWrapper.java:152)
        at org.mortbay.jetty.Server.handle(Server.java:326)
        at org.mortbay.jetty.HttpConnection.handleRequest(HttpConnection.java:542)
        at org.mortbay.jetty.HttpConnection$RequestHandler.content(HttpConnection.java:945)
        at org.mortbay.jetty.HttpParser.parseNext(HttpParser.java:843)
        at org.mortbay.jetty.HttpParser.parseAvailable(HttpParser.java:218)
        at org.mortbay.jetty.HttpConnection.handle(HttpConnection.java:404)
        at org.mortbay.io.nio.SelectChannelEndPoint.run(SelectChannelEndPoint.java:410)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
        at java.lang.Thread.run(Unknown Source)
        Caused by: java.lang.NoSuchMethodError: org.apache.xml.security.encryption.XMLCipher.setSecureValidation(Z)V
        at org.apache.ws.security.processor.ReferenceListProcessor.decryptEncryptedData(ReferenceListProcessor.java:315)
        at org.apache.ws.security.processor.EncryptedKeyProcessor.decryptDataRef(EncryptedKeyProcessor.java:451)
        at org.apache.ws.security.processor.EncryptedKeyProcessor.decryptDataRefs(EncryptedKeyProcessor.java:380)
        at org.apache.ws.security.processor.EncryptedKeyProcessor.handleToken(EncryptedKeyProcessor.java:178)
        at org.apache.ws.security.processor.EncryptedKeyProcessor.handleToken(EncryptedKeyProcessor.java:65)
        at org.apache.ws.security.WSSecurityEngine.processSecurityHeader(WSSecurityEngine.java:396)
        at org.apache.ws.security.WSSecurityEngine.processSecurityHeader(WSSecurityEngine.java:303)
        at org.apache.ws.security.WSSecurityEngine.processSecurityHeader(WSSecurityEngine.java:248)
        at com.eviware.soapui.impl.wsdl.support.wss.IncomingWss.processIncoming(IncomingWss.java:125)
        at com.eviware.soapui.impl.wsdl.mock.WsdlMockRequest.initPostRequest(WsdlMockRequest.java:106)
        at com.eviware.soapui.impl.wsdl.mock.WsdlMockRequest.<init>(WsdlMockRequest.java:76)
        at com.eviware.soapui.impl.wsdl.mock.WsdlMockDispatcher.dispatchRequest(WsdlMockDispatcher.java:117)
        ... 14 more
      ```
    
    This change removes explicit xmlsec dependency in soapui/pom.xml
    allowing it to be pulled in transitively via wss4j dependency (what is
    needed by that wss4j version).
