### PR TITLE
Buffer mockrequest inputstream to avoid incomplete Multiparts

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/support/attachments/MockRequestDataSource.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/support/attachments/MockRequestDataSource.java
@@ -19,9 +19,12 @@ package com.eviware.soapui.impl.wsdl.submit.transports.http.support.attachments;
 import com.eviware.soapui.SoapUI;
 import com.eviware.soapui.impl.wsdl.monitor.CaptureInputStream;
 import com.eviware.soapui.settings.UISettings;
+import com.eviware.soapui.support.Tools;
 
 import javax.activation.DataSource;
 import javax.servlet.http.HttpServletRequest;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -55,7 +58,9 @@ public class MockRequestDataSource implements DataSource {
     }
 
     public InputStream getInputStream() throws IOException {
-        return request.getInputStream();
+        // buffer the entire stream to avoid incomplete BodyParts in MultipartMessageSupport:
+        ByteArrayOutputStream out = Tools.readAll(request.getInputStream(), Tools.READ_ALL);
+        return new ByteArrayInputStream(out.toByteArray());
     }
 
     public String getName() {


### PR DESCRIPTION
A mockservice running as war package in Tomcat behaves differently than when running in SoapUI/Jetty when handling requests with attachments, i.e. multipart requests.

Requests to a mockservice in Tomcat get cut off and attachments received are incomplete.

This can be demonstrated with a simple Rest mockservice that returns the size of the last attachment:

```
<?xml version="1.0" encoding="UTF-8"?>
<con:soapui-project id="ca6af0ce-7d7c-411f-b216-13b548e35ed8" activeEnvironment="Default" name="Dummy" resourceRoot="" soapui-version="5.4.0-EB" abortOnError="false" runType="SEQUENTIAL" xmlns:con="http://eviware.com/soapui/config">
    <con:settings/>
    <con:restMockService id="976de04b-31ac-448d-8050-4b18c8e80663" port="6060" path="/" host="localhost" name="Dummy" docroot="">
        <con:settings/>
        <con:startScript/>
        <con:stopScript/>
        <con:properties/>
        <con:afterRequestScript/>
        <con:restMockAction name="/dummy" method="POST" resourcePath="/dummy" id="24c1de2f-6435-4ba5-a24d-b6bde9ab05b7">
            <con:settings/>
            <con:defaultResponse>dummy</con:defaultResponse>
            <con:dispatchStyle>SEQUENCE</con:dispatchStyle>
            <con:dispatchPath/>
            <con:response name="dummy" id="748900cb-cd03-48de-9894-4c3b72a8e480" httpResponseStatus="200" mediaType="multipart/mixed">
                <con:settings/>
                <con:script>mockResponse.responseContent = mockRequest.requestAttachments?.getAt(-1).inputStream.text.size()</con:script>
                <con:responseContent/>
            </con:response>
        </con:restMockAction>
    </con:restMockService>
    <con:properties/>
    <con:wssContainer/>
    <con:oAuth2ProfileContainer/>
    <con:oAuth1ProfileContainer/>
    <con:sensitiveInformation/>
</con:soapui-project>
```

This can apparently be fixed by buffering the entire InputStream in the MockRequestDataSource, 
which is similar to the Jetty implementation [`com.eviware.soapui.monitor.JettyMockEngine$BufferedServletInputStream`](https://github.com/SmartBear/soapui/blob/release-5.4.0/soapui/src/main/java/com/eviware/soapui/monitor/JettyMockEngine.java#L332).

This pull request does not address the actual root cause but rather provides a patch that is not too invasive from a regression risk perspective. 
Automated unit/integration tests are not included as they would involve starting a Tomcat container.

