### PR TITLE
Check for new refresh token after a successfull refresh operation

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/actions/oauth/OAuth2TokenExtractor.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/actions/oauth/OAuth2TokenExtractor.java
@@ -195,7 +195,7 @@ public class OAuth2TokenExtractor {
 	// Due to RFC6749 6. the client MUST discard the old refresh token if the server issues a new token
 	// and replace it with the new one.
 	String newRefreshToken = oAuthToken.getRefreshToken();
-	if (newRefreshToken!=null && newRefreshToken!=parameters.refreshToken) {
+	if (newRefreshToken!=null && !newRefreshToken.equals(parameters.refreshToken)) {
            parameters.setRefreshTokenInProfile(newRefreshToken);
 	}
     }

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/actions/oauth/OAuth2TokenExtractor.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/actions/oauth/OAuth2TokenExtractor.java
@@ -192,6 +192,12 @@ public class OAuth2TokenExtractor {
         OAuthToken oAuthToken = oAuthClient.accessToken(accessTokenRequest, OAuthJSONAccessTokenResponse.class).getOAuthToken();
         parameters.applyRetrievedAccessToken(oAuthToken.getAccessToken());
         parameters.setAccessTokenIssuedTimeInProfile(TimeUtils.getCurrentTimeInSeconds());
+	// Due to RFC6749 6. the client MUST discard the old refresh token if the server issues a new token
+	// and replace it with the new one.
+	String newRefreshToken = oAuthToken.getRefreshToken();
+	if (newRefreshToken!=null && newRefreshToken!=parameters.refreshToken) {
+           parameters.setRefreshTokenInProfile(newRefreshToken);
+	}
     }
 
     public void addBrowserListener(BrowserListener listener) {


### PR DESCRIPTION
Due to RFC6749 6. the client MUST discard the old refresh token if the server issues a new token and replace it with the new one.
The current code does not respect this situation