### PR TITLE
Fix WSDL Mock Runner leaks during test case runs

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlMockResponseTestStep.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlMockResponseTestStep.java
@@ -1181,10 +1181,12 @@ public class WsdlMockResponseTestStep extends WsdlTestStepWithProperties impleme
                 if (startTestStep instanceof WsdlMockResponseTestStep) {
                     // do nothing - this is done in the StartStepMockRunListener instead
                 } else {
-                    try {
-                        startListening(runContext);
-                    } catch (Exception e) {
-                        SoapUI.logError(e);
+                    if (!isDisabled()) {
+                        try {
+                            startListening(runContext);
+                        } catch (Exception e) {
+                            SoapUI.logError(e);
+                        }
                     }
                 }
             }
@@ -1208,10 +1210,12 @@ public class WsdlMockResponseTestStep extends WsdlTestStepWithProperties impleme
         }
 
         public void propertyChange(PropertyChangeEvent evt) {
-            try {
-                startListening(runContext);
-            } catch (Exception e) {
-                SoapUI.logError(e);
+            if (!isDisabled()) {
+                try {
+                    startListening(runContext);
+                } catch (Exception e) {
+                    SoapUI.logError(e);
+                }
             }
         }
     }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlMockResponseTestStep.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlMockResponseTestStep.java
@@ -410,17 +410,7 @@ public class WsdlMockResponseTestStep extends WsdlTestStepWithProperties impleme
             result.startTimer();
 
             if (!mockRunListener.hasResult()) {
-                if (testMockResponse == null) {
-                    initTestMockResponse(context);
-                }
-
-                if (mockRunner == null) {
-                    mockRunner = mockService.start(context);
-                }
-
-                if (!mockRunner.isRunning()) {
-                    mockRunner.start();
-                }
+                startListening(context);
 
                 long timeout = getTimeout();
                 synchronized (mockRunListener) {
@@ -1165,7 +1155,7 @@ public class WsdlMockResponseTestStep extends WsdlTestStepWithProperties impleme
         }
     }
 
-    private void startListening(TestCaseRunContext runContext) throws Exception {
+    private synchronized void startListening(TestCaseRunContext runContext) throws Exception {
         if (mockRunner == null) {
             mockRunner = mockService.start((WsdlTestRunContext) runContext);
         }


### PR DESCRIPTION
2 commits:
```
    Protect against mock runner leaks due to concurrent starts
    
    startListening() is typically called from main test runner thread while
    onMockResult() gets called from another thread (i.e. Jetty HTTP thread)
    asynchronously. Hence previous logic was very prone to race conditions
    when "Start Step" was used in conjuction with another
    WsdlMockResponseTestStep. onMockResult() and internalRun() would begin
    creating mockRunner in parallel resulting in one of them eventually
    losing a race to be assigned to the test case's 'mockRunner' field.
    Such leaked mock service would hang in Running state forever
    interferring with further tests until SoapUI is restarted.
```
```
    Do not pre-start (leak) mock service if test step is disabled
    
    This affects mock services on the disabled tests refered by "Start Step"
    from other WsdlMockResponseTestSteps. If mock service in the disabled step
    is started, it might never be stopped as finish() is not called on
    disabled steps. This results into mock service leak in the
    JettyMockEngine which will wreack havoc when running other tests or
    esp. repeating the same test.
```
