### PR TITLE
Improve JettyMockEngine logging/reporting

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/monitor/JettyMockEngine.java
+++ b/soapui/src/main/java/com/eviware/soapui/monitor/JettyMockEngine.java
@@ -635,7 +635,7 @@ public class JettyMockEngine implements MockEngine {
         }
 
         private void printMockServiceList(HttpServletResponse response) throws IOException {
-            response.setStatus(HttpServletResponse.SC_OK);
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
             response.setContentType("text/html");
 
             MockRunner[] mockRunners = getMockRunners();

--- a/soapui/src/main/java/com/eviware/soapui/monitor/JettyMockEngine.java
+++ b/soapui/src/main/java/com/eviware/soapui/monitor/JettyMockEngine.java
@@ -205,6 +205,8 @@ public class JettyMockEngine implements MockEngine {
             Map<String, List<MockRunner>> map = runners.get(port);
 
             if (map == null || !map.containsKey(mockService.getPath())) {
+                log.warn("Unable to find mockService [" + mockService.getName() + "] on port [" + port +
+                        "] at path [" + mockService.getPath() + "] in order to stop it");
                 return;
             }
 
@@ -215,7 +217,7 @@ public class JettyMockEngine implements MockEngine {
 
             mockRunners.remove(runner);
 
-            log.info("Stopped MockService [" + mockService.getName() + "] on port [" + port + "]");
+            log.info("Stopped mockService [" + mockService.getName() + "] on port [" + port + "] at path [" + mockService.getPath() + "]");
 
             if (map.isEmpty() && !SoapUI.getSettings().getBoolean(HttpSettings.LEAVE_MOCKENGINE)) {
                 SoapUIConnector connector = connectors.get(port);
@@ -644,8 +646,10 @@ public class JettyMockEngine implements MockEngine {
 
             for (MockRunner mockRunner : mockRunners) {
                 out.print("<li><a href=\"");
-                out.print(mockRunner.getMockContext().getMockService().getPath() + "?WSDL");
-                out.print("\">" + mockRunner.getMockContext().getMockService().getName() + "</a></li>");
+                out.print(mockRunner.getMockContext().getMockService().getPath() + "?WSDL\">");
+                out.print(mockRunner.getMockContext().getMockService().getName());
+                out.print(" (on port " + mockRunner.getMockContext().getMockService().getPort() + ")");
+                out.print("</a></li>");
             }
 
             out.print("</ul></p></body></html>");


### PR DESCRIPTION
2 commits:
```
    Improve logging in JettyMockEngine
    
    Unify Started/Stopped log messages and log a warning when attempting to
    stop a mock service which does not exist (which most likely means there
    is a bug somewhere).
```
```
    Return HTTP 404 when requested mock service isn't found
    
    On all occasions mock service list is returned when requested mock
    service cannot be found. So it makes very much sense to return 404 in
    these cases (with running service as before).
    
    What is more, returning HTTP 200 is very misleading and might mislead
    callers into thinking that everything is fine.
```