### PR TITLE
Fix detailed display of WSDL mock response time outs

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/AbstractMessageExchange.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/AbstractMessageExchange.java
@@ -30,7 +30,9 @@ public abstract class AbstractMessageExchange<T extends ModelItem> implements Me
     public AbstractMessageExchange(T modelItem) {
         super();
         this.modelItem = modelItem;
-        discardResponse = modelItem.getSettings().getBoolean("discardResponse");
+        if (modelItem != null) {
+            discardResponse = modelItem.getSettings().getBoolean("discardResponse");
+        }
     }
 
     public T getModelItem() {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlMockResponseTestStep.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlMockResponseTestStep.java
@@ -34,6 +34,7 @@ import com.eviware.soapui.impl.wsdl.mock.WsdlMockResponse.ResponseHeaderHolder;
 import com.eviware.soapui.impl.wsdl.mock.WsdlMockResult;
 import com.eviware.soapui.impl.wsdl.mock.WsdlMockRunner;
 import com.eviware.soapui.impl.wsdl.mock.dispatch.QueryMatchMockOperationDispatcher;
+import com.eviware.soapui.impl.wsdl.panels.mockoperation.WsdlMockRequestMessageExchange;
 import com.eviware.soapui.impl.wsdl.panels.mockoperation.WsdlMockResultMessageExchange;
 import com.eviware.soapui.impl.wsdl.support.IconAnimator;
 import com.eviware.soapui.impl.wsdl.support.assertions.AssertableConfig;
@@ -433,11 +434,11 @@ public class WsdlMockResponseTestStep extends WsdlTestStepWithProperties impleme
                 mockRunner.stop();
             }
 
-            AssertedWsdlMockResultMessageExchange messageExchange = new AssertedWsdlMockResultMessageExchange(
-                    mockRunListener.getLastResult());
-            result.setMessageExchange(messageExchange);
-
             if (mockRunListener.getLastResult() != null) {
+                AssertedWsdlMockResultMessageExchange messageExchange = new AssertedWsdlMockResultMessageExchange(
+                        mockRunListener.getLastResult());
+                result.setMessageExchange(messageExchange);
+
                 lastResult = mockRunListener.getLastResult();
                 mockResponse.setMockResult(lastResult);
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/actions/ShowMessageExchangeAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/actions/ShowMessageExchangeAction.java
@@ -92,10 +92,7 @@ public class ShowMessageExchangeAction extends AbstractAction {
         messageTabs.addTab("Response Message", buildResponseTab());
         messageTabs.addTab("Properties", buildPropertiesTab());
 
-        String[] messages = messageExchange.getMessages();
-        if (messages != null && messages.length > 0) {
-            messageTabs.addTab("Messages", buildMessagesTab());
-        }
+        messageTabs.addTab("Messages", buildMessagesTab());
 
         if (getAssertedXPaths().size() > 0) {
             messageTabs.addTab("XPath Assertions", buildAssertionsTab());
@@ -168,9 +165,7 @@ public class ShowMessageExchangeAction extends AbstractAction {
     }
 
     private Component buildMessagesTab() {
-        String[] messages = messageExchange.getMessages();
-        return messages == null || messages.length == 0 ? new JLabel("No messages to display") : new JScrollPane(
-                new JList(messages));
+        return hasMessages() ? new JScrollPane(new JList<>(messageExchange.getMessages())) : new JLabel("No messages to display");
     }
 
     private Component buildResponseTab() {
@@ -181,6 +176,10 @@ public class ShowMessageExchangeAction extends AbstractAction {
     private Component buildRequestTab() {
         requestMessageEditor = new MessageExchangeRequestMessageEditor(messageExchange);
         return requestMessageEditor;
+    }
+
+    private boolean hasMessages() {
+        return messageExchange != null && messageExchange.getMessages() != null && messageExchange.getMessages().length > 0;
     }
 
     private final class MessageExchangeDesktopPanel extends DefaultDesktopPanel {


### PR DESCRIPTION
Prior logic means that null mock result used to be supplied to the
AssertedWsdlMockResultMessageExchange when mock response step timed out.
Neither AbstractMessageExchange, not ShowMessageExchangeAction were
ready for that.

The patch:

- adds support for null modelItem to AbstractMessageExchange (which used
  to be supported some time ago). However, this change ends up not being
  used due to change below;

- adds support for null message exchange to ShowMessageExchangeAction as
  it is way to easier handle such condition there than support null mock
  result in WsdlMockResponseMessageExchange. Make appropriate changes in
  WsdlMockResponseTestStep.