### PR TITLE
Fix priority of splash screen stomping during assembly build

### DIFF
--- a/soapui-installer/pom.xml
+++ b/soapui-installer/pom.xml
@@ -26,7 +26,7 @@
             <version>1.2.1</version>
             <executions>
               <execution>
-                <phase>package</phase>
+                <phase>prepare-package</phase>
                 <goals>
                   <goal>java</goal>
                 </goals>


### PR DESCRIPTION
There is no guarantee splash screen will be stomped before assembly creation if they both happen in mvn package phase. Therefore do splash screen stomping during prepare-package phase which always comes before package phase (same as maven-gitlog-plugin).