### PR TITLE
SOAPUIOS-448 Endpoint Explorer: Default text from Endpoint field is not cleared if copy/paste some value

### DIFF
--- a/soapui/src/main/resources/com/eviware/soapui/explorer/soapui-pro-api-endpoint-explorer-starter-page.html
+++ b/soapui/src/main/resources/com/eviware/soapui/explorer/soapui-pro-api-endpoint-explorer-starter-page.html
@@ -192,6 +192,13 @@
                 }
             })
 
+            $('#methodEndpoint').contextmenu(function () {
+                if ($('#methodEndpoint').hasClass('hint')) {
+                    $('#methodEndpoint').removeClass('hint');
+                    $('#methodEndpoint').val("");
+                }
+            });
+
             $('#closeAction').click(function() {
                 closeCallback.close();
             });


### PR DESCRIPTION
https://smartbear.atlassian.net/browse/SOAPUIOS-448