### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: java
+jdk:
+  - oraclejdk8
+cache:
+  directories:
+    - $HOME/.m2
+services:
+  - xvfb
+install: mvn test-compile dependency:resolve-plugins dependency:go-offline
+script: xvfb-run mvn clean package


### PR DESCRIPTION
Similar to https://github.com/SmartBear/soapui/pull/443 but it is actually tested. See:

* Working - https://travis-ci.com/modax/soapui/jobs/178413048 (on top of `origin/release-5.5.0`)
* Failing https://travis-ci.com/modax/soapui/builds/101241974 (needs https://github.com/SmartBear/soapui/pull/448 on top of current `next` to succeed)