### PR TITLE
RIA-11092 Move to java 12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,6 @@
         <maven-assembly-plugin-version>3.1.1</maven-assembly-plugin-version>
         <!-- org.codehaus.mojo -->
         <versions-maven-plugin-version>2.7</versions-maven-plugin-version>
-        <animal-sniffer-maven-plugin-version>1.18</animal-sniffer-maven-plugin-version>
         <exec-maven-plugin-version>1.6.0</exec-maven-plugin-version>
 
         <!-- other -->
@@ -148,7 +147,7 @@
                     <dependency>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>extra-enforcer-rules</artifactId>
-                        <version>1.0-beta-2</version>
+                        <version>1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -166,33 +165,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>${maven-site-plugin-version}</version>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>${animal-sniffer-maven-plugin-version}</version>
-                <configuration>
-                    <signature>
-                        <groupId>org.codehaus.mojo.signature</groupId>
-                        <!-- currently, we cannot use java16 1.1 because some classes depends on the sun specific
-                        implementation (com.sun.java.swing.plaf.windows) -->
-                        <artifactId>java18</artifactId>
-                        <version>1.0</version>
-                    </signature>
-                    <ignores>
-                        <ignore>javafx.*</ignore>
-                        <ignore>netscape.*</ignore>
-                    </ignores>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>animal-sniffer-check</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,29 @@
         <javafx.version>2.2</javafx.version>
         <!-- Set this property to the location of your JavaFX runtime jar if you want to compile with Java 6 -->
         <javafx.runtime.lib.jar>${java.home}/lib/jfxrt.jar</javafx.runtime.lib.jar>
+
+        <!-- org.apache.maven.plugins -->
+        <maven-enforcer-plugin-version>3.0.0-M2</maven-enforcer-plugin-version>
+        <maven-clean-plugin-version>3.1.0</maven-clean-plugin-version>
+        <maven-compiler-plugin-version>3.8.1</maven-compiler-plugin-version>
+        <maven-javadoc-plugin-version>3.1.0</maven-javadoc-plugin-version>
+        <maven-deploy-plugin-version>3.0.0-M1</maven-deploy-plugin-version>
+        <maven-install-plugin-version>3.0.0-M1</maven-install-plugin-version>
+        <maven-site-plugin-version>3.7.1</maven-site-plugin-version>
+        <maven-jar-plugin-version>3.1.2</maven-jar-plugin-version>
+        <maven-surefire-plugin-version>3.0.0-M3</maven-surefire-plugin-version>
+        <maven-plugin-plugin-version>3.6.0</maven-plugin-plugin-version>
+        <maven-failsafe-plugin-version>3.0.0-M3</maven-failsafe-plugin-version>
+        <maven-assembly-plugin-version>3.1.1</maven-assembly-plugin-version>
+        <!-- org.codehaus.mojo -->
+        <versions-maven-plugin-version>2.7</versions-maven-plugin-version>
+        <animal-sniffer-maven-plugin-version>1.18</animal-sniffer-maven-plugin-version>
+        <exec-maven-plugin-version>1.6.0</exec-maven-plugin-version>
+
+        <!-- other -->
+        <maven-gitlog-plugin-version>1.9.1</maven-gitlog-plugin-version>
+
+        <requireMavenVersion-value>3.0.5</requireMavenVersion-value>
     </properties>
 
     <modules>
@@ -46,9 +69,17 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>${versions-maven-plugin-version}</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>2.5</version>
+                <version>${maven-clean-plugin-version}</version>
                 <configuration>
                     <filesets>
                         <fileset>
@@ -64,7 +95,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>${maven-compiler-plugin-version}</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -73,7 +104,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8.1</version>
+                <version>${maven-javadoc-plugin-version}</version>
                 <configuration>
                     <maxmemory>1024m</maxmemory>
                     <additionalparam>-Xdoclint:none</additionalparam>
@@ -82,7 +113,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>${maven-enforcer-plugin-version}</version>
                 <executions>
                     <execution>
                         <id>enforce-versions</id>
@@ -92,7 +123,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>3.0.0</version>
+                                    <version>${requireMavenVersion-value}</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>
@@ -122,9 +153,24 @@
                 </dependencies>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>${maven-deploy-plugin-version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>${maven-install-plugin-version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>${maven-site-plugin-version}</version>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.15</version>
+                <version>${animal-sniffer-maven-plugin-version}</version>
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>

--- a/soapui-installer/pom.xml
+++ b/soapui-installer/pom.xml
@@ -23,7 +23,7 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>1.2.1</version>
+            <version>${exec-maven-plugin-version}</version>
             <executions>
               <execution>
                 <phase>prepare-package</phase>
@@ -47,7 +47,7 @@
           <plugin>
             <groupId>com.github.danielflower.mavenplugins</groupId>
             <artifactId>maven-gitlog-plugin</artifactId>
-            <version>1.4.11</version>
+            <version>${maven-gitlog-plugin-version}</version>
             <configuration>
               <reportTitle>
                 SoapUI ${project.version} | https://github.com/SmartBear/soapui/tree/maintenance
@@ -61,7 +61,7 @@
 
           <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
-            <version>2.3</version>
+            <version>${maven-assembly-plugin-version}</version>
             <configuration>
               <outputDirectory>${assembly.build.directory}</outputDirectory>
               <descriptors>

--- a/soapui-maven-plugin/pom.xml
+++ b/soapui-maven-plugin/pom.xml
@@ -55,7 +55,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>${maven-plugin-plugin-version}</version>
             </plugin>
 
             <!-- FIXME Why do we need this plugin ? -->
@@ -76,12 +76,6 @@
 					</execution>
 				</executions>
 			</plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-            </plugin>
-
 
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>

--- a/soapui-system-test/pom.xml
+++ b/soapui-system-test/pom.xml
@@ -19,7 +19,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12.4</version>
+                <version>${maven-surefire-plugin-version}</version>
                 <configuration>
                     <excludes>
                         <exclude>**/*.class</exclude>
@@ -29,7 +29,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.16</version>
+                <version>${maven-failsafe-plugin-version}</version>
                 <configuration>
                     <systemProperties>
                         <soapui.log4j.config>${project.build.testOutputDirectory}/config/soapui-test-log4j.xml
@@ -44,7 +44,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
+                <version>${maven-jar-plugin-version}</version>
                 <inherited>true</inherited>
                 <executions>
                     <execution>

--- a/soapui/pom.xml
+++ b/soapui/pom.xml
@@ -32,7 +32,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
+                <version>${maven-jar-plugin-version}</version>
                 <inherited>true</inherited>
                 <executions>
                     <execution>
@@ -72,13 +72,8 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12.1</version>
+                <version>${maven-surefire-plugin-version}</version>
                 <configuration>
                     <systemProperties>
                         <!-- Only log errors and only log to the console to decrease the log verbosity -->
@@ -93,7 +88,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.2.1</version>
+                <version>${exec-maven-plugin-version}</version>
                 <configuration>
                     <mainClass>com.eviware.soapui.SoapUI</mainClass>
                 </configuration>

--- a/soapui/src/main/java/com/eviware/soapui/model/tree/AbstractModelItemTreeNode.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/tree/AbstractModelItemTreeNode.java
@@ -209,7 +209,7 @@ public abstract class AbstractModelItemTreeNode<T extends ModelItem> implements 
         });
     }
 
-    public Enumeration<?> children() {
+    public Enumeration<? extends TreeNode> children() {
         Vector<TreeNode> children = new Vector<TreeNode>();
         for (int c = 0; c < getChildCount(); c++) {
             children.add(getChildAt(c));

--- a/soapui/src/main/java/com/eviware/soapui/support/components/VerticalWindowsTabbedPaneUI.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/components/VerticalWindowsTabbedPaneUI.java
@@ -1,32 +1,27 @@
 /*
  * SoapUI, Copyright (C) 2004-2019 SmartBear Software
  *
- * Licensed under the EUPL, Version 1.1 or - as soon as they will be approved by the European Commission - subsequent 
- * versions of the EUPL (the "Licence"); 
- * You may not use this work except in compliance with the Licence. 
- * You may obtain a copy of the Licence at: 
- * 
- * http://ec.europa.eu/idabc/eupl 
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the Licence is 
- * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
- * express or implied. See the Licence for the specific language governing permissions and limitations 
- * under the Licence. 
+ * Licensed under the EUPL, Version 1.1 or - as soon as they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the Licence for the specific language governing permissions and limitations
+ * under the Licence.
  */
 
 package com.eviware.soapui.support.components;
 
-import com.sun.java.swing.plaf.windows.WindowsTabbedPaneUI;
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
-
 import javax.swing.Icon;
+import javax.swing.plaf.basic.BasicTabbedPaneUI;
 import java.awt.FontMetrics;
 import java.awt.Insets;
 
-// The annotation is necessary to stop animal-sniffer-plugin from complaining, because this class extends a class
-// that is not officially part of the Java API.
-@IgnoreJRERequirement
-public class VerticalWindowsTabbedPaneUI extends WindowsTabbedPaneUI {
+public class VerticalWindowsTabbedPaneUI extends BasicTabbedPaneUI {
     protected void installDefaults() {
         super.installDefaults();
 


### PR DESCRIPTION
These changes may be implemented right now for build with java 8 on it will work correctly.
1. update maven plugins.
2. exclude "animal-sniffer-maven-plugin". it is useless. From the box we use java 8 and it will work. For custom build it cannot be build on java 9 and higher. if customer build it for example on java 7 then he will launch it on the same java.
3. Exclude sun WindowsTabbedPaneUI  class. Replace it on "BasicTabbedPaneUI". We don't use WindowsTabbedPaneUI benefits which allow to use custom colors and xp theme.
4. fix logical compilation issue which is important for java 11 and may be fixed for java 8.
Build is compilable and work.