### PR TITLE
Added put to possible redirect message type.

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/HttpClientRequestTransport.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/HttpClientRequestTransport.java
@@ -331,12 +331,22 @@ public class HttpClientRequestTransport implements BaseHttpRequestTransport {
 				.equals(RestRequestInterface.HttpMethod.POST.toString()));
 	}
 
+    private boolean isPutMethod(ExtendedHttpMethod httpMethod, org.apache.http.HttpResponse httpResponse) {
+		int statusCode = httpResponse.getStatusLine().getStatusCode();
+		return (statusCode != HttpServletResponse.SC_SEE_OTHER && 
+				httpMethod != null &&
+				httpMethod.getMethod()
+				.equals(RestRequestInterface.HttpMethod.PUT.toString()));
+	}
+
     private ExtendedHttpMethod followRedirects(HttpClient httpClient, int redirectCount, ExtendedHttpMethod httpMethod,
     										   org.apache.http.HttpResponse httpResponse, HttpContext httpContext, SubmitContext submitContext) throws Exception {
 		ExtendedHttpMethod getMethod;
-		if(isPostMethod(httpMethod, httpResponse))
+		if(isPostMethod(httpMethod, httpResponse)) {
 			getMethod = new ExtendedPostMethod();
-		else {
+		} else if(isPutMethod(httpMethod, httpResponse)) {
+			getMethod = new ExtendedPutMethod();
+		} else {
 			getMethod = new ExtendedGetMethod();
 		}
 


### PR DESCRIPTION
If a put is redirected currently it drops into the else block that sets getMethod to ExtendedGetMethod. Added put as an option.

I think potentially this should involve all request types and reuse the switch from createHttpMethod around line 430. Currently if you have a site that redirects and try to run a put the put flops to a get in the old else block. It looks like someone fixed it for post but never added other verbs or thought they would not be applicable. I believe all of them could redirect and drop into the followRedirects method.