### PR TITLE
Fixing null pointer on http monitor.

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/AbstractMessageExchange.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/AbstractMessageExchange.java
@@ -30,7 +30,7 @@ public abstract class AbstractMessageExchange<T extends ModelItem> implements Me
     public AbstractMessageExchange(T modelItem) {
         super();
         this.modelItem = modelItem;
-        discardResponse = modelItem.getSettings().getBoolean("discardResponse");
+        discardResponse = modelItem != null ? modelItem.getSettings().getBoolean("discardResponse") : false;
     }
 
     public T getModelItem() {

--- a/soapui/src/test/java/com/eviware/soapui/impl/wsdl/monitor/JProxyServletWsdlMonitorMessageExchangeTest.java
+++ b/soapui/src/test/java/com/eviware/soapui/impl/wsdl/monitor/JProxyServletWsdlMonitorMessageExchangeTest.java
@@ -1,0 +1,20 @@
+package com.eviware.soapui.impl.wsdl.monitor;
+
+import com.eviware.soapui.impl.wsdl.WsdlProject;
+import com.eviware.soapui.support.SoapUIException;
+import com.eviware.soapui.utils.ModelItemFactory;
+import org.apache.xmlbeans.XmlException;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+public class JProxyServletWsdlMonitorMessageExchangeTest {
+
+    @Test
+    public void testConstructor() throws XmlException, IOException, SoapUIException {
+        WsdlProject project = ModelItemFactory.makeWsdlProject();
+        JProxyServletWsdlMonitorMessageExchange sut = new JProxyServletWsdlMonitorMessageExchange(project);
+    }
+}


### PR DESCRIPTION
Null pointer exception encountered while using proxy exposed by http monitor of SOAP-UI.

`java.lang.NullPointerException
	at com.eviware.soapui.impl.wsdl.submit.AbstractMessageExchange.<init>(AbstractMessageExchange.java:33)
	at com.eviware.soapui.impl.wsdl.submit.AbstractWsdlMessageExchange.<init>(AbstractWsdlMessageExchange.java:36)
	at com.eviware.soapui.impl.wsdl.monitor.WsdlMonitorMessageExchange.<init>(WsdlMonitorMessageExchange.java:28)
	at com.eviware.soapui.impl.wsdl.monitor.JProxyServletWsdlMonitorMessageExchange.<init>(JProxyServletWsdlMonitorMessageExchange.java:86)
	at com.eviware.soapui.impl.wsdl.monitor.jettyproxy.ProxyServlet.service(ProxyServlet.java:173)
	at org.mortbay.jetty.servlet.ServletHolder.handle(ServletHolder.java:511)
	at org.mortbay.jetty.servlet.ServletHandler.handle(ServletHandler.java:401)
	at org.mortbay.jetty.handler.ContextHandler.handle(ContextHandler.java:766)
	at org.mortbay.jetty.handler.HandlerWrapper.handle(HandlerWrapper.java:152)
	at org.mortbay.jetty.Server.handle(Server.java:326)
	at com.eviware.soapui.impl.wsdl.monitor.jettyproxy.JettyServer.handle(JettyServer.java:76)
	at org.mortbay.jetty.HttpConnection.handleRequest(HttpConnection.java:542)
	at org.mortbay.jetty.HttpConnection$RequestHandler.headerComplete(HttpConnection.java:928)
	at org.mortbay.jetty.HttpParser.parseNext(HttpParser.java:549)
	at org.mortbay.jetty.HttpParser.parseAvailable(HttpParser.java:212)
	at org.mortbay.jetty.HttpConnection.handle(HttpConnection.java:404)
	at org.mortbay.jetty.bio.SocketConnector$Connection.run(SocketConnector.java:228)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.lang.Thread.run(Unknown Source)`

![image](https://user-images.githubusercontent.com/854248/71029960-c7975b00-2110-11ea-8dc8-d4d30220842f.png)

Error reproduced on version 5.5.0, not reproduced on 4.6.4 ; regression maybe introduced by commit fa96f21.

The pull request only adds a null check on modelItem and set default value of discardResponse to false in case of null ; http monitor working again with just this.

