### PR TITLE
Update AbstractTestCaseRunner.java

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/AbstractTestCaseRunner.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/AbstractTestCaseRunner.java
@@ -217,9 +217,11 @@ public abstract class AbstractTestCaseRunner<T extends TestRunnable, T2 extends 
         // enforceMaxResults( getTestRunnable().getMaxResults() );
         enforceMaxResults(getTestCase().getMaxResults());
 
-        for (int i = 0; i < testRunListeners.length; i++) {
-            if (Arrays.asList(getTestCase().getTestRunListeners()).contains(testRunListeners[i])) {
-                testRunListeners[i].afterStep(this, getRunContext(), stepResult);
+        if (testRunListeners != null) {
+            for (int i = 0; i < testRunListeners.length; i++) {
+                if (Arrays.asList(getTestCase().getTestRunListeners()).contains(testRunListeners[i])) {
+                    testRunListeners[i].afterStep(this, getRunContext(), stepResult);
+                }
             }
         }
 
@@ -245,6 +247,9 @@ public abstract class AbstractTestCaseRunner<T extends TestRunnable, T2 extends 
     }
 
     protected boolean runBeforeSteps(TestStep testStep) {
+        if (testRunListeners == null || testRunListeners.length == 0) {
+            return true;
+        }
         for (TestRunListener testRunListener : testRunListeners) {
             if (Arrays.asList(getTestCase().getTestRunListeners()).contains(testRunListener)) {
                 testRunListener.beforeStep(this, getRunContext(), testStep);


### PR DESCRIPTION
Fix exception when no listeners added
java.lang.NullPointerException
	at com.eviware.soapui.impl.wsdl.support.AbstractTestCaseRunner.runBeforeSteps(AbstractTestCaseRunner.java:248)
	at com.eviware.soapui.impl.wsdl.support.AbstractTestCaseRunner.runTestStep(AbstractTestCaseRunner.java:208)
	at com.eviware.soapui.impl.wsdl.support.AbstractTestCaseRunner.runTestStep(AbstractTestCaseRunner.java:204)