### PR TITLE
Use Java ProxySelector if NONE SOAPUI proxy is on

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/http/ProxyUtils.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/http/ProxyUtils.java
@@ -180,7 +180,7 @@ public class ProxyUtils {
     }
 
     public static void setGlobalProxy(Settings settings) {
-        ProxySelector proxySelector = null;
+        ProxySelector proxySelector = ProxySelector.getDefault();
         ProxySettingsAuthenticator authenticator = null;
         if (proxyEnabled) {
             if (autoProxy) {

--- a/soapui/src/test/java/com/eviware/soapui/impl/wsdl/support/http/ProxyUtilsTestCase.java
+++ b/soapui/src/test/java/com/eviware/soapui/impl/wsdl/support/http/ProxyUtilsTestCase.java
@@ -76,6 +76,8 @@ public class ProxyUtilsTestCase {
     @Before
     public void setup() {
         clearProxySystemProperties();
+        //clear system-wide proxy selector, as long as it is manipulated by tests
+        ProxySelector.setDefault(null);
 
         httpMethod = new ExtendedGetMethod();
     }


### PR DESCRIPTION
Works around issue https://community.smartbear.com/t5/SoapUI-Open-Source/Possible-Bug-SoapUI-5-is-setting-default-proxyselector-to-null/td-p/97482

Due to nullified ProxySelector NPE may happen intermittently
during normal Maven build with SOAP UI plugin used at the
moment of artifact resolution via HTTP:
```
[ERROR] Failed to execute goal on project myproject: Could not resolve dependencies for project com.mycompany:myproject:jar:20.08.00.000-BUILD-SNAPSHOT: Failed to collect dependencies at com.mycompany.datatransfer:myartifact:jar:20.08.00.000-BUILD-SNAPSHOT: Failed to read artifact descriptor for com.mycompany.datatransfer:myartifact:jar:20.08.00.000-BUILD-SNAPSHOT: Could not transfer artifact com.mycompany.datatransfer:myartifact:pom:20.08.00.000-BUILD-SNAPSHOT from/to my-repo (http://mynexusrepo:8081/nexus/content/repositories/public): NullPointerException -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal on project myproject: Could not resolve dependencies for project com.mycompany:myproject:jar:20.08.00.000-BUILD-SNAPSHOT: Failed to collect dependencies at com.mycompany.datatransfer:myartifact:jar:20.08.00.000-BUILD-SNAPSHOT
    at org.apache.maven.lifecycle.internal.LifecycleDependencyResolver.getDependencies(LifecycleDependencyResolver.java:221)
    at org.apache.maven.lifecycle.internal.LifecycleDependencyResolver.resolveProjectDependencies(LifecycleDependencyResolver.java:127)
    at org.apache.maven.lifecycle.internal.MojoExecutor.ensureDependenciesAreResolved(MojoExecutor.java:246)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:200)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:154)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:146)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call(MultiThreadedBuilder.java:200)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call(MultiThreadedBuilder.java:196)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
Caused by: org.apache.maven.project.DependencyResolutionException: Could not resolve dependencies for project com.mycompany:myproject:jar:20.08.00.000-BUILD-SNAPSHOT: Failed to collect dependencies at com.mycompany.datatransfer:myartifact:jar:20.08.00.000-BUILD-SNAPSHOT
    at org.apache.maven.project.DefaultProjectDependenciesResolver.resolve(DefaultProjectDependenciesResolver.java:177)
    at org.apache.maven.lifecycle.internal.LifecycleDependencyResolver.getDependencies(LifecycleDependencyResolver.java:195)
    ... 14 more
Caused by: org.eclipse.aether.collection.DependencyCollectionException: Failed to collect dependencies at com.mycompany.datatransfer:myartifact:jar:20.08.00.000-BUILD-SNAPSHOT
    at org.eclipse.aether.internal.impl.DefaultDependencyCollector.collectDependencies(DefaultDependencyCollector.java:300)
    at org.eclipse.aether.internal.impl.DefaultRepositorySystem.collectDependencies(DefaultRepositorySystem.java:325)
    at org.apache.maven.project.DefaultProjectDependenciesResolver.resolve(DefaultProjectDependenciesResolver.java:169)
    ... 15 more
Caused by: org.eclipse.aether.resolution.ArtifactDescriptorException: Failed to read artifact descriptor for com.mycompany.datatransfer:myartifact:jar:20.08.00.000-BUILD-SNAPSHOT
    at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.loadPom(DefaultArtifactDescriptorReader.java:283)
    at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.readArtifactDescriptor(DefaultArtifactDescriptorReader.java:199)
    at org.eclipse.aether.internal.impl.DefaultDependencyCollector.resolveCachedArtifactDescriptor(DefaultDependencyCollector.java:544)
    at org.eclipse.aether.internal.impl.DefaultDependencyCollector.getArtifactDescriptorResult(DefaultDependencyCollector.java:528)
    at org.eclipse.aether.internal.impl.DefaultDependencyCollector.processDependency(DefaultDependencyCollector.java:418)
    at org.eclipse.aether.internal.impl.DefaultDependencyCollector.processDependency(DefaultDependencyCollector.java:372)
    at org.eclipse.aether.internal.impl.DefaultDependencyCollector.process(DefaultDependencyCollector.java:360)
    at org.eclipse.aether.internal.impl.DefaultDependencyCollector.collectDependencies(DefaultDependencyCollector.java:263)
    ... 17 more
Caused by: org.eclipse.aether.resolution.ArtifactResolutionException: Could not transfer artifact com.mycompany.datatransfer:myartifact:pom:20.08.00.000-BUILD-SNAPSHOT from/to my-repo (http://mynexusrepo:8081/nexus/content/repositories/public): NullPointerException
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:453)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifacts(DefaultArtifactResolver.java:255)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifact(DefaultArtifactResolver.java:232)
    at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.loadPom(DefaultArtifactDescriptorReader.java:268)
    ... 24 more
Caused by: org.eclipse.aether.transfer.ArtifactTransferException: Could not transfer artifact com.mycompany.datatransfer:myartifact:pom:20.08.00.000-BUILD-SNAPSHOT from/to my-repo (http://mynexusrepo:8081/nexus/content/repositories/public): NullPointerException
    at org.eclipse.aether.connector.basic.ArtifactTransportListener.transferFailed(ArtifactTransportListener.java:52)
    at org.eclipse.aether.connector.basic.BasicRepositoryConnector$TaskRunner.run(BasicRepositoryConnector.java:364)
    at org.eclipse.aether.util.concurrency.RunnableErrorForwarder$1.run(RunnableErrorForwarder.java:76)
    at org.eclipse.aether.connector.basic.BasicRepositoryConnector$DirectExecutor.execute(BasicRepositoryConnector.java:590)
    at org.eclipse.aether.connector.basic.BasicRepositoryConnector.get(BasicRepositoryConnector.java:258)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.performDownloads(DefaultArtifactResolver.java:529)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:430)
    ... 27 more
Caused by: java.lang.NullPointerException
    at org.apache.maven.wagon.providers.http.httpclient.impl.conn.SystemDefaultRoutePlanner.determineProxy(SystemDefaultRoutePlanner.java:79)
    at org.apache.maven.wagon.providers.http.httpclient.impl.conn.DefaultRoutePlanner.determineRoute(DefaultRoutePlanner.java:77)
    at org.apache.maven.wagon.providers.http.httpclient.impl.client.InternalHttpClient.determineRoute(InternalHttpClient.java:124)
    at org.apache.maven.wagon.providers.http.httpclient.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:183)
    at org.apache.maven.wagon.providers.http.httpclient.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:82)
    at org.apache.maven.wagon.providers.http.AbstractHttpClientWagon.execute(AbstractHttpClientWagon.java:834)
    at org.apache.maven.wagon.providers.http.AbstractHttpClientWagon.fillInputData(AbstractHttpClientWagon.java:985)
    at org.apache.maven.wagon.providers.http.AbstractHttpClientWagon.fillInputData(AbstractHttpClientWagon.java:962)
    at org.apache.maven.wagon.StreamWagon.getInputStream(StreamWagon.java:126)
    at org.apache.maven.wagon.StreamWagon.getIfNewer(StreamWagon.java:88)
    at org.apache.maven.wagon.StreamWagon.get(StreamWagon.java:61)
    at org.eclipse.aether.transport.wagon.WagonTransporter$GetTaskRunner.run(WagonTransporter.java:569)
    at org.eclipse.aether.transport.wagon.WagonTransporter.execute(WagonTransporter.java:436)
    at org.eclipse.aether.transport.wagon.WagonTransporter.get(WagonTransporter.java:413)
    at org.eclipse.aether.connector.basic.BasicRepositoryConnector$GetTaskRunner.runTask(BasicRepositoryConnector.java:456)
    at org.eclipse.aether.connector.basic.BasicRepositoryConnector$TaskRunner.run(BasicRepositoryConnector.java:359)
    ... 32 more
```