### PR TITLE
Update launcher use the same java for everything

### DIFF
--- a/soapui-installer/src/dist/bin/soapui.sh
+++ b/soapui-installer/src/dist/bin/soapui.sh
@@ -43,7 +43,7 @@ SOAPUI_CLASSPATH=$SOAPUI_HOME/bin/${project.src.artifactId}-${project.version}.j
 export SOAPUI_CLASSPATH
 
 JAVA_OPTS="-Xms128m -Xmx1024m -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -Dsoapui.properties=soapui.properties -Dsoapui.home=$SOAPUI_HOME/bin -splash:SoapUI-Spashscreen.png"
-JFXRTPATH=`java -cp $SOAPUI_CLASSPATH com.eviware.soapui.tools.JfxrtLocator`
+JFXRTPATH=`${JAVA_HOME}/bin/java -cp $SOAPUI_CLASSPATH com.eviware.soapui.tools.JfxrtLocator`
 SOAPUI_CLASSPATH=$JFXRTPATH:$SOAPUI_CLASSPATH
 
 if $darwin
@@ -56,8 +56,8 @@ then
     JAVA_OPTS="$JAVA_OPTS -Dsoapui.ext.libraries=$SOAPUI_HOME/bin/ext"
     JAVA_OPTS="$JAVA_OPTS -Dsoapui.ext.listeners=$SOAPUI_HOME/bin/listeners"
     JAVA_OPTS="$JAVA_OPTS -Dsoapui.ext.actions=$SOAPUI_HOME/bin/actions"
-	JAVA_OPTS="$JAVA_OPTS -Djava.library.path=$SOAPUI_HOME/bin"
-	JAVA_OPTS="$JAVA_OPTS -Dwsi.dir=$SOAPUI_HOME/wsi-test-tools"
+    JAVA_OPTS="$JAVA_OPTS -Djava.library.path=$SOAPUI_HOME/bin"
+    JAVA_OPTS="$JAVA_OPTS -Dwsi.dir=$SOAPUI_HOME/wsi-test-tools"
 #uncomment to disable browser component
 #   JAVA_OPTS="$JAVA_OPTS -Dsoapui.browser.disabled=true"
 fi


### PR DESCRIPTION
In the launcher, the JFX library is located using the first `java` executable in the `PATH`, while the main app is launched with `$JAVA_HOME/bin/java`. This change unifies criteria to use `${JAVA_HOME}/bin/java` in both cases.