### PR TITLE
SOAPUIOS-577 Correcting the exported file name

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/support/definition/export/AbstractDefinitionExporter.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/support/definition/export/AbstractDefinitionExporter.java
@@ -161,7 +161,10 @@ public abstract class AbstractDefinitionExporter<T extends Interface> implements
         int cnt = 1;
         while (urlToFileMap.containsValue(fileName)) {
             ix = fileName.lastIndexOf('.');
-            fileName = fileName.substring(0, ix) + "_" + cnt + fileName.substring(ix);
+			int iy = fileName.lastIndexOf("_");
+			if (iy == -1) iy = ix;
+			fileName = fileName.substring(0, iy) + "_" + cnt + fileName.substring(ix);
+            //fileName = fileName.substring(0, ix) + "_" + cnt + fileName.substring(ix);
             cnt++;
         }
 


### PR DESCRIPTION
Correcting the exported file name to prevent a FileNotFoundException in Windows Systems and large WSDL files with multiples imported XSDs.
Tkx to "eam" and the post https://community.smartbear.com/t5/SoapUI-Open-Source/Schema-Name-Length-from-Export-Definition/td-p/40284