### PR TITLE
SOAPUIOS-603 Auto-swithing tabs works incorrectly

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/views/content/GraphQLRequestContentView.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/views/content/GraphQLRequestContentView.java
@@ -3,6 +3,7 @@ package com.eviware.soapui.impl.rest.panels.request.views.content;
 import com.eviware.soapui.impl.wsdl.panels.teststeps.GraphQLRequestTestStepDesktopPanel;
 import com.eviware.soapui.impl.wsdl.teststeps.GraphQLTestRequestInterface;
 import com.eviware.soapui.support.DocumentListenerAdapter;
+import com.eviware.soapui.support.JsonUtil;
 import com.eviware.soapui.support.UISupport;
 import com.eviware.soapui.support.editor.views.AbstractXmlEditorView;
 import com.eviware.soapui.support.editor.xml.XmlDocument;
@@ -135,6 +136,6 @@ public class GraphQLRequestContentView extends AbstractXmlEditorView<XmlDocument
 
     @Override
     public int getSupportScoreForContentType(String contentType) {
-        return contentType.toLowerCase().startsWith("application/json")? 2 : 0;
+        return JsonUtil.seemsToBeJsonContentType(contentType)? 2 : 0;
     }
 }

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/views/content/GraphQLRequestContentView.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/views/content/GraphQLRequestContentView.java
@@ -134,7 +134,7 @@ public class GraphQLRequestContentView extends AbstractXmlEditorView<XmlDocument
     }
 
     @Override
-    public boolean supportsContentType(String contentType) {
-        return contentType.toLowerCase().endsWith("json");
+    public int getSupportScoreForContentType(String contentType) {
+        return contentType.toLowerCase().startsWith("application/json")? 2 : 0;
     }
 }

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/views/html/HttpHtmlMessageExchangeResponseView.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/views/html/HttpHtmlMessageExchangeResponseView.java
@@ -232,8 +232,8 @@ public class HttpHtmlMessageExchangeResponseView extends AbstractXmlEditorView<H
     }
 
     @Override
-    public boolean supportsContentType(String contentType ) {
-        return contentType.toLowerCase().endsWith("html");
+    public int getSupportScoreForContentType(String contentType ) {
+        return contentType.toLowerCase().endsWith("html")? 2 : 0;
     }
 
 }

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/views/html/HttpHtmlResponseView.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/views/html/HttpHtmlResponseView.java
@@ -153,8 +153,8 @@ public class HttpHtmlResponseView extends AbstractXmlEditorView<HttpResponseDocu
     }
 
     @Override
-    public boolean supportsContentType(String contentType ) {
-        return contentType.toLowerCase().endsWith("html");
+    public int getSupportScoreForContentType(String contentType ) {
+        return contentType.toLowerCase().endsWith("html")? 2: 0;
     }
 
     public HttpRequestInterface<?> getHttpRequest() {

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/views/json/JsonResponseMessageExchangeView.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/views/json/JsonResponseMessageExchangeView.java
@@ -142,7 +142,7 @@ public class JsonResponseMessageExchangeView extends AbstractXmlEditorView<HttpR
     }
 
     @Override
-    public boolean supportsContentType(String contentType ) {
-        return contentType.toLowerCase().endsWith("json");
+    public int getSupportScoreForContentType(String contentType ) {
+        return contentType.toLowerCase().startsWith("application/json")? 2 : 0;
     }
 }

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/views/json/JsonResponseMessageExchangeView.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/views/json/JsonResponseMessageExchangeView.java
@@ -143,6 +143,6 @@ public class JsonResponseMessageExchangeView extends AbstractXmlEditorView<HttpR
 
     @Override
     public int getSupportScoreForContentType(String contentType ) {
-        return contentType.toLowerCase().startsWith("application/json")? 2 : 0;
+        return JsonUtil.seemsToBeJsonContentType(contentType)? 2 : 0;
     }
 }

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/views/json/JsonResponseView.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/views/json/JsonResponseView.java
@@ -132,6 +132,6 @@ public class JsonResponseView extends AbstractXmlEditorView<HttpResponseDocument
 
     @Override
     public int getSupportScoreForContentType(String contentType ) {
-        return contentType.toLowerCase().startsWith("application/json")? 2 : 0;
+        return JsonUtil.seemsToBeJsonContentType(contentType)? 2 : 0;
     }
 }

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/views/json/JsonResponseView.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/views/json/JsonResponseView.java
@@ -131,7 +131,7 @@ public class JsonResponseView extends AbstractXmlEditorView<HttpResponseDocument
     }
 
     @Override
-    public boolean supportsContentType(String contentType ) {
-        return contentType.toLowerCase().endsWith("json");
+    public int getSupportScoreForContentType(String contentType ) {
+        return contentType.toLowerCase().startsWith("application/json")? 2 : 0;
     }
 }

--- a/soapui/src/main/java/com/eviware/soapui/impl/support/components/ResponseMessageXmlEditor.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/support/components/ResponseMessageXmlEditor.java
@@ -17,6 +17,7 @@
 package com.eviware.soapui.impl.support.components;
 
 import com.eviware.soapui.model.ModelItem;
+import com.eviware.soapui.support.editor.EditorDocument;
 import com.eviware.soapui.support.editor.EditorInspector;
 import com.eviware.soapui.support.editor.EditorView;
 import com.eviware.soapui.support.editor.registry.EditorViewFactory;
@@ -28,6 +29,8 @@ import com.eviware.soapui.support.editor.registry.ResponseInspectorFactory;
 import com.eviware.soapui.support.editor.xml.XmlDocument;
 import com.eviware.soapui.support.editor.xml.XmlEditorView;
 import com.eviware.soapui.support.editor.xml.XmlInspector;
+
+import java.beans.PropertyChangeEvent;
 
 /**
  * XmlEditor for a response-message to a WsdlRequest
@@ -60,6 +63,14 @@ public class ResponseMessageXmlEditor<T extends ModelItem, T2 extends XmlDocumen
             if (inspector != null) {
                 addInspector((EditorInspector<T2>) inspector);
             }
+        }
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        super.propertyChange(evt);
+        if (evt.getPropertyName().equals(EditorDocument.DOCUMENT_PROPERTY)) {
+            selectDefaultView();
         }
     }
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/support/http/HttpRequestContentView.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/support/http/HttpRequestContentView.java
@@ -279,8 +279,8 @@ public class HttpRequestContentView extends AbstractXmlEditorView<HttpRequestDoc
     }
 
     @Override
-    public boolean supportsContentType(String contentType ) {
-        return false;
+    public int getSupportScoreForContentType(String contentType ) {
+        return 0;
     }
 
     public RestParamsTable getParamsTable() {

--- a/soapui/src/main/java/com/eviware/soapui/support/editor/Editor.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/Editor.java
@@ -107,11 +107,10 @@ public class Editor<T extends EditorDocument> extends JPanel implements Property
         }
         if (evt.getPropertyName().equals(EditorDocument.DOCUMENT_PROPERTY)) {
             inputTabsChangeListener.refreshVisibleInspectors();
-            selectDefaultView();
         }
     }
 
-    private void selectDefaultView() {
+    protected void selectDefaultView() {
         String contentType = document.getContentType();
         if( contentType != null ) {
             if (!getCurrentView().supportsContentType(contentType)) {

--- a/soapui/src/main/java/com/eviware/soapui/support/editor/Editor.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/Editor.java
@@ -110,6 +110,9 @@ public class Editor<T extends EditorDocument> extends JPanel implements Property
         }
     }
 
+    /**
+     * Selects the view best suited for the document's content type
+     */
     protected void selectDefaultView() {
         String contentType = document.getContentType();
         if( contentType != null ) {

--- a/soapui/src/main/java/com/eviware/soapui/support/editor/Editor.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/Editor.java
@@ -113,13 +113,17 @@ public class Editor<T extends EditorDocument> extends JPanel implements Property
     protected void selectDefaultView() {
         String contentType = document.getContentType();
         if( contentType != null ) {
-            if (!getCurrentView().supportsContentType(contentType)) {
-                for (EditorView view : views) {
-                    if (view.supportsContentType(contentType)) {
-                        selectView(view.getViewId());
-                        break;
-                    }
+            int maxScore = getCurrentView().getSupportScoreForContentType(contentType);
+            EditorView defaultView = null;
+            for (EditorView view : views) {
+                int score = view.getSupportScoreForContentType(contentType);
+                if (score > maxScore) {
+                    maxScore = score;
+                    defaultView = view;
                 }
+            }
+            if (defaultView != null) {
+                selectView(defaultView.getViewId());
             }
         }
     }

--- a/soapui/src/main/java/com/eviware/soapui/support/editor/EditorView.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/EditorView.java
@@ -59,5 +59,5 @@ public interface EditorView<T extends EditorDocument> extends PropertyChangeNoti
 
     public void requestFocus();
 
-    boolean supportsContentType(String contentType );
+    int getSupportScoreForContentType(String contentType );
 }

--- a/soapui/src/main/java/com/eviware/soapui/support/editor/EditorView.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/EditorView.java
@@ -59,5 +59,11 @@ public interface EditorView<T extends EditorDocument> extends PropertyChangeNoti
 
     public void requestFocus();
 
-    int getSupportScoreForContentType(String contentType );
+    /**
+     * Returns the score of how well a given content type is supported by this editor view
+     * @param contentType http payload's content type
+     * @return a non-negative integer: greater values mean better support,
+     * 0 means the given content type is not supported by this view
+     */
+    int getSupportScoreForContentType(String contentType);
 }

--- a/soapui/src/main/java/com/eviware/soapui/support/editor/support/AbstractEditorView.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/support/AbstractEditorView.java
@@ -162,7 +162,7 @@ public abstract class AbstractEditorView<T extends EditorDocument> implements Ed
     }
 
     @Override
-    public boolean supportsContentType(String contentType) {
-        return false;
+    public int getSupportScoreForContentType(String contentType) {
+        return 0;
     }
 }

--- a/soapui/src/main/java/com/eviware/soapui/support/editor/views/xml/raw/RawXmlEditor.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/views/xml/raw/RawXmlEditor.java
@@ -66,7 +66,7 @@ public abstract class RawXmlEditor<T extends XmlDocument> extends AbstractXmlEdi
     }
 
     @Override
-    public boolean supportsContentType(String contentType) {
-        return true;
+    public int getSupportScoreForContentType(String contentType) {
+        return 1;
     }
 }

--- a/soapui/src/main/java/com/eviware/soapui/support/editor/views/xml/source/XmlSourceEditorView.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/views/xml/source/XmlSourceEditorView.java
@@ -627,8 +627,8 @@ public class XmlSourceEditorView<T extends ModelItem> extends AbstractXmlEditorV
     }
 
     @Override
-    public boolean supportsContentType(String contentType ) {
-        return contentType.toLowerCase().endsWith("xml");
+    public int getSupportScoreForContentType(String contentType ) {
+        return contentType.toLowerCase().endsWith("xml")? 2 : 0;
     }
 
     protected ValidationError[] validateXml(String xml) {

--- a/soapui/src/main/java/com/eviware/soapui/ui/support/AbstractMockResponseDesktopPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/ui/support/AbstractMockResponseDesktopPanel.java
@@ -36,6 +36,7 @@ import com.eviware.soapui.support.UISupport;
 import com.eviware.soapui.support.actions.ChangeSplitPaneOrientationAction;
 import com.eviware.soapui.support.components.JEditorStatusBarWithProgress;
 import com.eviware.soapui.support.components.JXToolBar;
+import com.eviware.soapui.support.editor.EditorDocument;
 import com.eviware.soapui.support.editor.views.xml.source.XmlSourceEditorView;
 import com.eviware.soapui.support.editor.xml.XmlDocument;
 import com.eviware.soapui.support.swing.SoapUISplitPaneUI;
@@ -311,6 +312,14 @@ public abstract class AbstractMockResponseDesktopPanel<ModelItemType extends Mod
 
             return editor;
         }
+
+        @Override
+        public void propertyChange(PropertyChangeEvent evt) {
+            super.propertyChange(evt);
+            if (evt.getPropertyName().equals(EditorDocument.DOCUMENT_PROPERTY)) {
+                selectDefaultView();
+            }
+        }
     }
 
     public class MockResponseMessageEditor extends ResponseMessageXmlEditor<MockResponse, XmlDocument> {
@@ -339,6 +348,11 @@ public abstract class AbstractMockResponseDesktopPanel<ModelItemType extends Mod
                 JPopupMenu inputPopup = editor.getEditorPopup();
                 inputPopup.insert(new JSeparator(), 2);
             }
+        }
+
+        @Override
+        protected void selectDefaultView() {
+            // not needed for mock responses
         }
 
         public RSyntaxTextArea getInputArea() {


### PR DESCRIPTION
https://smartbear.atlassian.net/browse/SOAPUIOS-603
1. Moved switching only to response editors (and to mock request editors).
2. Avoid switching to Raw tab most of the time, because it returned true for every content type.
3. Compare json content types more correctly.