### PR TITLE
SOAPUIOS-607 Removed xmlpublic lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,6 @@
         <!-- org.apache.xmlbeans -->
         <xmlbeans-version>3.1.1-sb-fixed</xmlbeans-version>
         <xmlbeans-xpath-version>2.6.0</xmlbeans-xpath-version>
-        <xmlbeans-xmlpublic-version>2.6.0</xmlbeans-xmlpublic-version>
         <!-- org.codehaus.mojo -->
         <versions-maven-plugin-version>2.7</versions-maven-plugin-version>
         <exec-maven-plugin-version>1.6.0</exec-maven-plugin-version>

--- a/soapui-maven-plugin/project.xml
+++ b/soapui-maven-plugin/project.xml
@@ -179,12 +179,6 @@
 			<type>jar</type>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.xmlbeans</groupId>
-			<artifactId>xmlbeans-xmlpublic</artifactId>
-			<version>2.6.0</version>
-			<type>jar</type>
-		</dependency>
-		<dependency>
 			<groupId>xmlbeans</groupId>
 			<artifactId>jsr173_1.0_api</artifactId>
 			<version>xmlbeans-2.4.0</version>

--- a/soapui/pom.xml
+++ b/soapui/pom.xml
@@ -136,11 +136,6 @@
             <type>jar</type>
         </dependency>
         <dependency>
-            <groupId>org.apache.xmlbeans</groupId>
-            <artifactId>xmlbeans-xmlpublic</artifactId>
-            <version>${xmlbeans-xmlpublic-version}</version>
-        </dependency>
-        <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jsr173_api</artifactId>
             <version>${jsr173_api.version}</version>


### PR DESCRIPTION
https://smartbear.atlassian.net/browse/SOAPUIOS-607
ReadyAPI doesn't use it.