### PR TITLE
Add support for xdg-open URLs

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/support/Tools.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/Tools.java
@@ -258,7 +258,7 @@ public class Tools {
 
                 Runtime.getRuntime().exec("rundll32 url.dll,FileProtocolHandler " + url);
             } else { // assume Unix or Linux
-                String[] browsers = {"firefox", "opera", "konqueror", "epiphany", "mozilla", "netscape"};
+                String[] browsers = {"xdg-open", "firefox", "opera", "konqueror", "epiphany", "mozilla", "netscape", "chromium-browser"};
                 String browser = null;
                 for (int count = 0; count < browsers.length && browser == null; count++) {
                     if (Runtime.getRuntime().exec(new String[]{"which", browsers[count]}).waitFor() == 0) {


### PR DESCRIPTION
Added support to open with the default browser in Linux/Unix.

List and order copied from: [soapui-installer/src/install4j/SoapUI.install4j](https://github.com/SmartBear/soapui/blob/517f36901f754ba413dc6934a0e6d1d03226471b/soapui-installer/src/install4j/SoapUI.install4j#L1175)