### PR TITLE
Bugfix so authorizationcode flow is supported.

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/actions/oauth/AuthorizationCodeWebViewUserBrowserFacade.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/actions/oauth/AuthorizationCodeWebViewUserBrowserFacade.java
@@ -1,0 +1,22 @@
+package com.eviware.soapui.impl.rest.actions.oauth;
+
+import com.eviware.soapui.support.components.WebViewBasedBrowserComponent;
+import com.eviware.soapui.support.components.WebViewBasedBrowserComponentFactory;
+
+public class AuthorizationCodeWebViewUserBrowserFacade extends WebViewUserBrowserFacade {
+
+    private final WebViewBasedBrowserComponent browserComponent;
+
+    public AuthorizationCodeWebViewUserBrowserFacade() {
+        this(false);
+    }
+
+    public AuthorizationCodeWebViewUserBrowserFacade(boolean addNavigationBar) {
+        browserComponent = WebViewBasedBrowserComponentFactory.createAuthorizationBrowserComponent(addNavigationBar);
+    }
+
+    @Override
+    public WebViewBasedBrowserComponent getBrowserComponent() {
+        return browserComponent;
+    }
+}

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/actions/oauth/WebViewUserBrowserFacade.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/actions/oauth/WebViewUserBrowserFacade.java
@@ -31,7 +31,7 @@ import java.net.URL;
  */
 public class WebViewUserBrowserFacade implements UserBrowserFacade {
 
-    private WebViewBasedBrowserComponent browserComponent;
+    private final WebViewBasedBrowserComponent browserComponent;
     private JFrame popupWindow;
 
     public WebViewUserBrowserFacade() {
@@ -46,26 +46,26 @@ public class WebViewUserBrowserFacade implements UserBrowserFacade {
     public void open(URL url) {
         popupWindow = new JFrame("Browser");
         popupWindow.setIconImages(SoapUI.getFrameIcons());
-        popupWindow.getContentPane().add(browserComponent.getComponent());
+        popupWindow.getContentPane().add(getBrowserComponent().getComponent());
         popupWindow.setBounds(100, 100, 800, 600);
         popupWindow.setVisible(true);
         popupWindow.addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent e) {
-                browserComponent.close(true);
+                getBrowserComponent().close(true);
             }
         });
-        browserComponent.navigate(url.toString());
+        getBrowserComponent().navigate(url.toString());
     }
 
     @Override
     public void addBrowserListener(BrowserListener listener) {
-        browserComponent.addBrowserStateListener(listener);
+        getBrowserComponent().addBrowserStateListener(listener);
     }
 
     @Override
     public void removeBrowserStateListener(BrowserListener listener) {
-        browserComponent.removeBrowserStateListener(listener);
+        getBrowserComponent().removeBrowserStateListener(listener);
     }
 
     @Override
@@ -79,7 +79,7 @@ public class WebViewUserBrowserFacade implements UserBrowserFacade {
                     popupWindow.dispose();
                 }
             });
-            browserComponent.close(true);
+            getBrowserComponent().close(true);
         } catch (Exception e) {
             SoapUI.log.debug("Could not close window due to unexpected error: " + e.getMessage() + "!");
         }
@@ -88,7 +88,11 @@ public class WebViewUserBrowserFacade implements UserBrowserFacade {
 
     @Override
     public void executeJavaScript(String script) {
-        browserComponent.executeJavaScript(script);
+        getBrowserComponent().executeJavaScript(script);
     }
 
+    public WebViewBasedBrowserComponent getBrowserComponent(){
+        return browserComponent;
+    }
 }
+

--- a/soapui/src/main/java/com/eviware/soapui/support/components/EnabledAuthorizationCodeWebViewBasedBrowserComponent.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/components/EnabledAuthorizationCodeWebViewBasedBrowserComponent.java
@@ -1,0 +1,42 @@
+package com.eviware.soapui.support.components;
+
+import com.eviware.soapui.SoapUI;
+import javafx.application.Platform;
+
+
+class EnabledAuthorizationCodeWebViewBasedBrowserComponent extends EnabledWebViewBasedBrowserComponent {
+    private static final String DEFAULT_ERROR_PAGE = "<html><body><h1>AuthorizationCode request failed</h1></body></html>";
+
+    public String url;
+
+    @Override
+    public String getDefaultErrorPage()
+    {
+        return DEFAULT_ERROR_PAGE;
+    }
+    EnabledAuthorizationCodeWebViewBasedBrowserComponent(boolean addNavigationBar, PopupStrategy popupStrategy)
+     {
+        super(addNavigationBar,popupStrategy);
+    }
+
+    @Override
+    public void navigate(final String url) {
+        navigate(url, DEFAULT_ERROR_PAGE);
+    }
+    @Override
+    public void navigate(final String url, String backupUrl) {
+        if (SoapUI.isBrowserDisabled()) {
+            return;
+        }
+
+        loadUrl(url);
+
+        Platform.runLater(() -> getWebEngine().load(url));
+    }
+
+    private void loadUrl(final String url) {
+        Platform.runLater(() -> getWebEngine().load(url));
+        this.url = url;
+    }
+
+}

--- a/soapui/src/main/java/com/eviware/soapui/support/components/WebViewBasedBrowserComponentFactory.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/components/WebViewBasedBrowserComponentFactory.java
@@ -37,4 +37,16 @@ public class WebViewBasedBrowserComponentFactory {
             return new EnabledWebViewBasedBrowserComponent(addNavigationBar, popupStrategy);
         }
     }
+
+    public static WebViewBasedBrowserComponent createAuthorizationBrowserComponent(boolean addNavigationBar) {
+        return createAuthorizationBrowserComponent(addNavigationBar, WebViewBasedBrowserComponent.PopupStrategy.INTERNAL_BROWSER_NEW_WINDOW);
+    }
+
+    public static WebViewBasedBrowserComponent createAuthorizationBrowserComponent(boolean addNavigationBar, WebViewBasedBrowserComponent.PopupStrategy popupStrategy) {
+        if (SoapUI.isBrowserDisabled()) {
+            return new DisabledWebViewBasedBrowserComponent();
+        } else {
+            return new EnabledAuthorizationCodeWebViewBasedBrowserComponent(addNavigationBar, popupStrategy);
+        }
+    }
 }


### PR DESCRIPTION
- Used inheritance to minimize code changes, Liskuv subsitution is used here
- Created a new component, so working open/closed principle is used. Other browsers and flows are not impacted
- Added logging, so you see to what location you are directed and if you get an error from the IDP, you can see it.
- Added some `@Override` tags, so methods could be overwritten.
- Made a `public final static DEFAULT_ERROR_PAGE `private and made a `getDefaultErrorPage`, so an other default error page can be made with somewhat more specific information ( but honostly, after adding the soapui log, this is not needed)

- No support yet for authrizationcode +pkce, because my java is not what it should be. :) But good enough to suggest this fix.
- No tests created, it is only a new userinterface browsercomponent that was changed. Did test it manually with auth0.com

- Linked issue:

https://github.com/SmartBear/soapui/issues/754