### PR TITLE
Xml content type fix

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/support/editor/views/xml/source/XmlSourceEditorView.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/views/xml/source/XmlSourceEditorView.java
@@ -634,11 +634,12 @@ public class XmlSourceEditorView<T extends ModelItem> extends AbstractXmlEditorV
             return 2;
         }
         Optional<String> any = Arrays.stream(contentType.split(";"))
+                .map(String::trim)
                 .map(String::toLowerCase)
                 .filter(txt -> !txt.contains("charset"))
                 .filter(txt -> !txt.contains("boundary"))
                 .findAny();
-        return any.filter(s -> s.toLowerCase().endsWith("xml")).map(s -> 2).orElse(0);
+        return any.filter(s -> s.endsWith("xml")).map(s -> 2).orElse(0);
     }
 
     protected ValidationError[] validateXml(String xml) {

--- a/soapui/src/main/java/com/eviware/soapui/support/editor/views/xml/source/XmlSourceEditorView.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/views/xml/source/XmlSourceEditorView.java
@@ -628,7 +628,7 @@ public class XmlSourceEditorView<T extends ModelItem> extends AbstractXmlEditorV
 
     @Override
     public int getSupportScoreForContentType(String contentType ) {
-        return contentType.toLowerCase().endsWith("xml")? 2 : 0;
+        return contentType.toLowerCase().contains("xml")? 2 : 0;
     }
 
     protected ValidationError[] validateXml(String xml) {

--- a/soapui/src/main/java/com/eviware/soapui/support/editor/views/xml/source/XmlSourceEditorView.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/views/xml/source/XmlSourceEditorView.java
@@ -88,7 +88,9 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static com.eviware.soapui.support.JsonUtil.seemsToBeJsonContentType;
 
@@ -628,7 +630,15 @@ public class XmlSourceEditorView<T extends ModelItem> extends AbstractXmlEditorV
 
     @Override
     public int getSupportScoreForContentType(String contentType ) {
-        return contentType.toLowerCase().contains("xml")? 2 : 0;
+        if(contentType.endsWith("xml")){
+            return 2;
+        }
+        Optional<String> any = Arrays.stream(contentType.split(";"))
+                .map(String::toLowerCase)
+                .filter(txt -> !txt.contains("charset"))
+                .filter(txt -> !txt.contains("boundary"))
+                .findAny();
+        return any.filter(s -> s.toLowerCase().endsWith("xml")).map(s -> 2).orElse(0);
     }
 
     protected ValidationError[] validateXml(String xml) {


### PR DESCRIPTION
Alternative soloution to 
https://github.com/SmartBear/soapui/pull/725

We split the content type header with ";" and get rid off the charset and additional boundary Part.
We check for "endswith" xml instead of "contains" so we avoid to set `application/vnd.openxmlformats-officedocument. wordprocessingml.document` as a valid Type.

Tested and works fine

Relates to https://github.com/SmartBear/soapui/issues/721