### PR TITLE
Bugfix for PropertyExpander (issue #767)

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/model/propertyexpansion/PropertyExpander.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/propertyexpansion/PropertyExpander.java
@@ -145,12 +145,14 @@ public class PropertyExpander implements SoapUIFactoryRegistryListener {
         return expand(context, content, false);
     }
 
+    final static String regexPropertyName = "(?<=\\$\\{)[^\\r\\n]+(?=})";
+
     public String expand(PropertyExpansionContext context, String content, boolean entitize) {
         SoapUIClassLoaderState clState = SoapUIExtensionClassLoader.ensure();
 
         try {
 
-            if (StringUtils.isNullOrEmpty(content)) {
+            if (StringUtils.isNullOrEmpty(content) || !content.matches(regexPropertyName)) {
                 return content;
             }
 


### PR DESCRIPTION
The property expander malforms SOAP-Requests if there are ${ present in it which are not part of a Property name. Property names must always start with ${ and end with } and have not any linebreaks in it. Thus i have added a very simple regex check to verify this before processing the content for expansion. This fixes issue #767.

Here is a simple explanation for the regex:
(?<=\${) is a positive lookbehind assertion that matches the literal characters ${ at the beginning of the substring. This ensures that the match occurs after ${.
[^\r\n]+ matches any non-linebreak character 1..n times
it can be limited to a number of characters by replacing + with {1,256} e.g. from 1 to 256 times. This enforces the maximum length of 256 characters for the substring.
(?=}) is a positive lookahead assertion that matches the literal character } at the end of the substring. This ensures that the match occurs before }.