### PR TITLE
Fix of the Content-Type Response check for XML.

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/support/editor/views/xml/source/XmlSourceEditorView.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/views/xml/source/XmlSourceEditorView.java
@@ -89,6 +89,8 @@ import java.awt.event.MouseEvent;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static com.eviware.soapui.support.JsonUtil.seemsToBeJsonContentType;
 
@@ -628,7 +630,9 @@ public class XmlSourceEditorView<T extends ModelItem> extends AbstractXmlEditorV
 
     @Override
     public int getSupportScoreForContentType(String contentType ) {
-        return contentType.toLowerCase().endsWith("xml")? 2 : 0;
+        Pattern p = Pattern.compile("(?:(xml$)|(/xml;.+))");
+        Matcher m = p.matcher(contentType.toLowerCase());
+        return m.find() ? 2 : 0;
     }
 
     protected ValidationError[] validateXml(String xml) {


### PR DESCRIPTION
This fixes issues [#721](https://github.com/SmartBear/soapui/issues/721) , [#759](https://github.com/SmartBear/soapui/issues/759)
Problem: Response body is displayed in raw tab when Content-Type includes charset
Fixing the content-type response check for XML
