### PR TITLE
Fix sonar issue S1130 'throws' declarations should not be superfluous

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/RecentItemsListener.java
+++ b/soapui/src/main/java/com/eviware/soapui/RecentItemsListener.java
@@ -148,7 +148,7 @@ public class RecentItemsListener extends WorkspaceListenerAdapter implements Wor
         if (history.size() > 0) {
             for (Map.Entry<String, String> entry : history.entrySet()) {
                 String filePath = entry.getKey();
-                DefaultActionMapping<WorkspaceImpl> mapping = new DefaultActionMapping<WorkspaceImpl>(
+                DefaultActionMapping<WorkspaceImpl> mapping = new DefaultActionMapping<>(
                         SwitchWorkspaceAction.SOAPUI_ACTION_ID, null, null, false, filePath);
                 String wsName = entry.getValue();
 
@@ -180,7 +180,7 @@ public class RecentItemsListener extends WorkspaceListenerAdapter implements Wor
         if (history.size() > 0) {
             for (Map.Entry<String, String> entry : history.entrySet()) {
                 String filePath = entry.getKey();
-                DefaultActionMapping<WorkspaceImpl> mapping = new DefaultActionMapping<WorkspaceImpl>(
+                DefaultActionMapping<WorkspaceImpl> mapping = new DefaultActionMapping<>(
                         ImportWsdlProjectAction.SOAPUI_ACTION_ID, null, null, false, filePath);
                 String wsName = entry.getValue();
                 mapping.setName(wsName);
@@ -260,7 +260,7 @@ public class RecentItemsListener extends WorkspaceListenerAdapter implements Wor
         history.put(filePath, project.getName());
         SoapUI.getSettings().setString(RECENT_PROJECTS_SETTING, history.toXml());
 
-        DefaultActionMapping<WorkspaceImpl> mapping = new DefaultActionMapping<WorkspaceImpl>(
+        DefaultActionMapping<WorkspaceImpl> mapping = new DefaultActionMapping<>(
                 ImportWsdlProjectAction.SOAPUI_ACTION_ID, null, null, false, filePath);
         mapping.setName(project.getName());
         mapping.setDescription("Switches to the [" + project.getName() + "] project");
@@ -380,7 +380,7 @@ public class RecentItemsListener extends WorkspaceListenerAdapter implements Wor
         }
 
         String filePath = workspace.getPath();
-        DefaultActionMapping<WorkspaceImpl> mapping = new DefaultActionMapping<WorkspaceImpl>(
+        DefaultActionMapping<WorkspaceImpl> mapping = new DefaultActionMapping<>(
                 SwitchWorkspaceAction.SOAPUI_ACTION_ID, null, null, false, filePath);
         mapping.setName(workspace.getName());
         mapping.setDescription("Switches to the [" + workspace.getName() + "] workspace");
@@ -447,7 +447,7 @@ public class RecentItemsListener extends WorkspaceListenerAdapter implements Wor
             super(modelItem.getName());
 
             putValue(Action.SHORT_DESCRIPTION, "Reopen editor for [" + modelItem.getName() + "]");
-            ref = new WeakReference<ModelItem>(modelItem);
+            ref = new WeakReference<>(modelItem);
         }
 
         public ModelItem getModelItem() {

--- a/soapui/src/main/java/com/eviware/soapui/SoapUI.java
+++ b/soapui/src/main/java/com/eviware/soapui/SoapUI.java
@@ -248,7 +248,7 @@ public class SoapUI {
     public static final String TEST_STEP_ACTIONS = "WsdlTestStepActions";
     // ------------------------------ FIELDS ------------------------------
 
-    private static List<Object> logCache = new ArrayList<Object>();
+    private static List<Object> logCache = new ArrayList<>();
     private static SoapUICore soapUICore;
     private static Timer soapUITimer = new Timer();
     private static JFrame frame;
@@ -1024,7 +1024,7 @@ public class SoapUI {
     }
 
     public static List<Image> getFrameIcons() {
-        List<Image> iconList = new ArrayList<Image>();
+        List<Image> iconList = new ArrayList<>();
         for (String iconPath : FRAME_ICON.split(";")) {
             iconList.add(UISupport.createImageIcon(iconPath).getImage());
         }

--- a/soapui/src/main/java/com/eviware/soapui/SoapUIExtensionClassLoader.java
+++ b/soapui/src/main/java/com/eviware/soapui/SoapUIExtensionClassLoader.java
@@ -47,7 +47,7 @@ public class SoapUIExtensionClassLoader extends URLClassLoader {
         addURL(file.toURI().toURL());
     }
 
-    private static Map<ClassLoader, SoapUIClassLoaderState> clStates = new HashMap<ClassLoader, SoapUIClassLoaderState>();
+    private static Map<ClassLoader, SoapUIClassLoaderState> clStates = new HashMap<>();
 
     public static SoapUIClassLoaderState ensure() {
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
@@ -93,7 +93,7 @@ public class SoapUIExtensionClassLoader extends URLClassLoader {
         String extDir = System.getProperty("soapui.ext.libraries");
 
         File dir = extDir != null ? new File(extDir) : new File(new File(root), "ext");
-        List<URL> urls = new ArrayList<URL>();
+        List<URL> urls = new ArrayList<>();
 
         if (dir.exists() && dir.isDirectory()) {
             File[] files = dir.listFiles();

--- a/soapui/src/main/java/com/eviware/soapui/actions/AnnotatedSettingsPrefs.java
+++ b/soapui/src/main/java/com/eviware/soapui/actions/AnnotatedSettingsPrefs.java
@@ -60,7 +60,7 @@ public class AnnotatedSettingsPrefs implements Prefs {
     }
 
     public List<Setting> getSettings() {
-        ArrayList<Setting> settings = new ArrayList<Setting>();
+        ArrayList<Setting> settings = new ArrayList<>();
         for (Field field : settingsClass.getFields()) {
             Setting annotation = field.getAnnotation(Setting.class);
             if (annotation != null) {

--- a/soapui/src/main/java/com/eviware/soapui/actions/CloseOpenProjectsAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/actions/CloseOpenProjectsAction.java
@@ -41,7 +41,7 @@ public class CloseOpenProjectsAction extends AbstractSoapUIAction<WorkspaceImpl>
     }
 
     public void perform(WorkspaceImpl workspace, Object param) {
-        List<Project> openProjects = new ArrayList<Project>();
+        List<Project> openProjects = new ArrayList<>();
         for (Project project : workspace.getProjectList()) {
             if (project.isOpen()) {
                 openProjects.add(project);

--- a/soapui/src/main/java/com/eviware/soapui/actions/HttpPrefs.java
+++ b/soapui/src/main/java/com/eviware/soapui/actions/HttpPrefs.java
@@ -52,7 +52,7 @@ public class HttpPrefs implements Prefs {
     public static final String DISABLE_RESPONSE_DECOMPRESSION = "Disable Response Decompression";
     public static final String FORWARD_SLASHES = "Normalize Forward Slashes";
 
-    private static TreeMap<String, String> compressionAlgs = new TreeMap<String, String>();
+    private static TreeMap<String, String> compressionAlgs = new TreeMap<>();
 
     static {
         compressionAlgs.put("None", "None");

--- a/soapui/src/main/java/com/eviware/soapui/actions/OpenClosedProjectsAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/actions/OpenClosedProjectsAction.java
@@ -40,7 +40,7 @@ public class OpenClosedProjectsAction extends AbstractSoapUIAction<WorkspaceImpl
     }
 
     public void perform(WorkspaceImpl workspace, Object param) {
-        List<Project> openProjects = new ArrayList<Project>();
+        List<Project> openProjects = new ArrayList<>();
         for (Project project : workspace.getProjectList()) {
             if (!project.isOpen() && !project.isDisabled()) {
                 openProjects.add(project);

--- a/soapui/src/main/java/com/eviware/soapui/actions/ShowSystemPropertiesAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/actions/ShowSystemPropertiesAction.java
@@ -37,7 +37,7 @@ public class ShowSystemPropertiesAction extends AbstractAction {
         StringBuffer buffer = new StringBuffer();
         Properties properties = System.getProperties();
 
-        List<String> keys = new ArrayList<String>();
+        List<String> keys = new ArrayList<>();
         for (Object key : properties.keySet()) {
             keys.add(key.toString());
         }

--- a/soapui/src/main/java/com/eviware/soapui/actions/SoapUIPreferencesAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/actions/SoapUIPreferencesAction.java
@@ -70,8 +70,8 @@ public class SoapUIPreferencesAction extends AbstractAction implements SoapUIFac
     public static final String GLOBAL_SENSITIVE_INFORMATION_TOKENS = "Global Sensitive Information Tokens";
     public static final String VERSIONUPDATE_SETTINGS = "Version Update Settings";
     private SwingConfigurationDialogImpl dialog;
-    private List<Prefs> prefs = new ArrayList<Prefs>();
-    private Map<PrefsFactory, Prefs> prefsFactories = new HashMap<PrefsFactory, Prefs>();
+    private List<Prefs> prefs = new ArrayList<>();
+    private Map<PrefsFactory, Prefs> prefsFactories = new HashMap<>();
 
     private static SoapUIPreferencesAction instance;
     private DefaultListModel<String> prefsListModel;
@@ -204,7 +204,7 @@ public class SoapUIPreferencesAction extends AbstractAction implements SoapUIFac
                 "Set global SoapUI settings", UISupport.OPTIONS_ICON);
         dialog.setSize(new Dimension(1000, 700));
 
-        prefsListModel = new DefaultListModel<String>();
+        prefsListModel = new DefaultListModel<>();
         JList prefItems = new JList(prefsListModel);
         prefItems.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         prefsPanel = new JPanel(new CardLayout());

--- a/soapui/src/main/java/com/eviware/soapui/actions/SumbitUserInfoAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/actions/SumbitUserInfoAction.java
@@ -262,7 +262,7 @@ public class SumbitUserInfoAction {
         }
 
         private boolean validateFormValues() {
-            List<String> fieldErrors = new ArrayList<String>();
+            List<String> fieldErrors = new ArrayList<>();
             if (StringUtils.isNullOrEmpty(getUserFirstName())) {
                 fieldErrors.add("your first name");
             }

--- a/soapui/src/main/java/com/eviware/soapui/actions/ToolsPrefs.java
+++ b/soapui/src/main/java/com/eviware/soapui/actions/ToolsPrefs.java
@@ -79,7 +79,7 @@ public class ToolsPrefs implements Prefs {
     public String[][] getEclipseTools() {
         // Return all tools except .NET related and tools that are part of
         // Eclipse.
-        ArrayList<String[]> list = new ArrayList<String[]>();
+        ArrayList<String[]> list = new ArrayList<>();
         for (String[] s : TOOLS) {
             String tool = s[0];
 

--- a/soapui/src/main/java/com/eviware/soapui/autoupdate/NewSoapUIVersionAvailableDialog.java
+++ b/soapui/src/main/java/com/eviware/soapui/autoupdate/NewSoapUIVersionAvailableDialog.java
@@ -103,7 +103,7 @@ public class NewSoapUIVersionAvailableDialog extends JDialog {
     }
 
     protected JPanel buildToolbar(JDialog dialog) {
-        final JComboBox<String> choice = new JComboBox<String>();
+        final JComboBox<String> choice = new JComboBox<>();
         choice.addItem("1 day");
         choice.addItem("3 days");
         choice.addItem("7 days");

--- a/soapui/src/main/java/com/eviware/soapui/impl/EmptyPanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/EmptyPanelBuilder.java
@@ -53,7 +53,7 @@ public class EmptyPanelBuilder<T extends ModelItem> implements PanelBuilder<T> {
     }
 
     protected JPropertiesTable<T> buildDefaultProperties(T modelItem, String caption) {
-        JPropertiesTable<T> table = new JPropertiesTable<T>(caption, modelItem);
+        JPropertiesTable<T> table = new JPropertiesTable<>(caption, modelItem);
 
         table.addProperty("Name", "name", true);
         table.addProperty("Description", "description", true);

--- a/soapui/src/main/java/com/eviware/soapui/impl/WorkspaceImpl.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/WorkspaceImpl.java
@@ -74,10 +74,10 @@ public class WorkspaceImpl extends AbstractModelItem implements Workspace {
     private final static Logger log = LogManager.getLogger(WorkspaceImpl.class);
     public static final MessageSupport messages = MessageSupport.getMessages(WorkspaceImpl.class);
 
-    private List<Project> projectList = new ArrayList<Project>();
+    private List<Project> projectList = new ArrayList<>();
     private SoapuiWorkspaceDocumentConfig workspaceConfig;
     private String path = null;
-    private Set<WorkspaceListener> listeners = new HashSet<WorkspaceListener>();
+    private Set<WorkspaceListener> listeners = new HashSet<>();
     private ImageIcon workspaceIcon;
     private XmlBeansSettingsImpl settings;
     private StringToStringMap projectOptions;
@@ -223,7 +223,7 @@ public class WorkspaceImpl extends AbstractModelItem implements Workspace {
     }
 
     public Map<String, Project> getProjects() {
-        Map<String, Project> result = new HashMap<String, Project>();
+        Map<String, Project> result = new HashMap<>();
 
         for (Project project : projectList) {
             result.put(project.getName(), project);
@@ -290,7 +290,7 @@ public class WorkspaceImpl extends AbstractModelItem implements Workspace {
                 path = file.getAbsolutePath();
             }
 
-            List<WorkspaceProjectConfig> projects = new ArrayList<WorkspaceProjectConfig>();
+            List<WorkspaceProjectConfig> projects = new ArrayList<>();
 
             // save projects first
             for (int c = 0; c < getProjectCount(); c++) {
@@ -630,7 +630,7 @@ public class WorkspaceImpl extends AbstractModelItem implements Workspace {
     }
 
     public List<Project> getOpenProjectList() {
-        List<Project> availableProjects = new ArrayList<Project>();
+        List<Project> availableProjects = new ArrayList<>();
 
         for (Project project : projectList) {
             if (project.isOpen()) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/actions/multi/MultiAssertionDeleteAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/actions/multi/MultiAssertionDeleteAction.java
@@ -41,7 +41,7 @@ public class MultiAssertionDeleteAction extends AbstractSoapUIMultiAction<ModelI
                 return;
             }
             // remove duplicates
-            Set<TestAssertion> assertions = new HashSet<TestAssertion>();
+            Set<TestAssertion> assertions = new HashSet<>();
 
             for (ModelItem target : targets) {
                 assertions.add((TestAssertion) target);

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/DefaultOAuth2ProfileContainer.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/DefaultOAuth2ProfileContainer.java
@@ -35,8 +35,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class DefaultOAuth2ProfileContainer implements OAuth2ProfileContainer {
     private final WsdlProject project;
     private final OAuth2ProfileContainerConfig configuration;
-    private List<OAuth2Profile> oAuth2ProfileList = new ArrayList<OAuth2Profile>();
-    private List<OAuth2ProfileListener> listeners = new CopyOnWriteArrayList<OAuth2ProfileListener>();
+    private List<OAuth2Profile> oAuth2ProfileList = new ArrayList<>();
+    private List<OAuth2ProfileListener> listeners = new CopyOnWriteArrayList<>();
 
     public DefaultOAuth2ProfileContainer(WsdlProject project, OAuth2ProfileContainerConfig configuration) {
         this.project = project;
@@ -57,7 +57,7 @@ public class DefaultOAuth2ProfileContainer implements OAuth2ProfileContainer {
 
     @Override
     public ArrayList<String> getOAuth2ProfileNameList() {
-        ArrayList<String> profileNameList = new ArrayList<String>();
+        ArrayList<String> profileNameList = new ArrayList<>();
         for (OAuth2Profile profile : getOAuth2ProfileList()) {
             profileNameList.add(profile.getName());
         }

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/OAuth1ProfileContainer.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/OAuth1ProfileContainer.java
@@ -19,8 +19,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class OAuth1ProfileContainer {
     private final WsdlProject project;
     private final OAuth1ProfileContainerConfig configuration;
-    private List<OAuth1Profile> OAuth1ProfileList = new ArrayList<OAuth1Profile>();
-    private List<OAuth1ProfileListener> listeners = new CopyOnWriteArrayList<OAuth1ProfileListener>();
+    private List<OAuth1Profile> OAuth1ProfileList = new ArrayList<>();
+    private List<OAuth1ProfileListener> listeners = new CopyOnWriteArrayList<>();
 
     public OAuth1ProfileContainer(WsdlProject project, OAuth1ProfileContainerConfig configuration) {
         this.project = project;
@@ -38,7 +38,7 @@ public class OAuth1ProfileContainer {
     }
 
     public ArrayList<String> getOAuth1ProfileNameList() {
-        ArrayList<String> profileNameList = new ArrayList<String>();
+        ArrayList<String> profileNameList = new ArrayList<>();
         for (OAuth1Profile profile : getOAuth1ProfileList()) {
             profileNameList.add(profile.getName());
         }

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/RestMethod.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/RestMethod.java
@@ -49,8 +49,8 @@ import java.util.Set;
 
 public class RestMethod extends AbstractWsdlModelItem<RestMethodConfig> implements MutableTestPropertyHolder,
         PropertyChangeListener {
-    private List<RestRequest> requests = new ArrayList<RestRequest>();
-    private List<RestRepresentation> representations = new ArrayList<RestRepresentation>();
+    private List<RestRequest> requests = new ArrayList<>();
+    private List<RestRepresentation> representations = new ArrayList<>();
     private RestResource resource;
     private XmlBeansRestParamsTestPropertyHolder params;
     private RestParamsPropertyHolder overlayParams;
@@ -210,8 +210,8 @@ public class RestMethod extends AbstractWsdlModelItem<RestMethodConfig> implemen
     }
 
     public RestRepresentation[] getRepresentations(RestRepresentation.Type type, String mediaType) {
-        List<RestRepresentation> result = new ArrayList<RestRepresentation>();
-        Set<String> addedTypes = new HashSet<String>();
+        List<RestRepresentation> result = new ArrayList<>();
+        Set<String> addedTypes = new HashSet<>();
 
         for (RestRepresentation representation : representations) {
             if ((type == null || type == representation.getType())
@@ -293,7 +293,7 @@ public class RestMethod extends AbstractWsdlModelItem<RestMethodConfig> implemen
     }
 
     public List<RestRequest> getRequestList() {
-        return new ArrayList<RestRequest>(requests);
+        return new ArrayList<>(requests);
     }
 
     public RestRequest getRequestAt(int index) {
@@ -338,8 +338,8 @@ public class RestMethod extends AbstractWsdlModelItem<RestMethodConfig> implemen
     }
 
     public RestParamProperty[] getDefaultParams() {
-        List<RestParamProperty> result = new ArrayList<RestParamProperty>();
-        Set<String> names = new HashSet<String>();
+        List<RestParamProperty> result = new ArrayList<>();
+        Set<String> names = new HashSet<>();
 
         result.addAll(Arrays.asList(resource.getDefaultParams()));
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/RestRequest.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/RestRequest.java
@@ -111,7 +111,7 @@ public class RestRequest extends AbstractHttpRequest<RestRequestConfig> implemen
     }
 
     public MessagePart[] getRequestParts() {
-        List<MessagePart> result = new ArrayList<MessagePart>();
+        List<MessagePart> result = new ArrayList<>();
 
         for (int c = 0; c < getPropertyCount(); c++) {
             result.add(new ParameterMessagePart(getPropertyAt(c)));
@@ -187,7 +187,7 @@ public class RestRequest extends AbstractHttpRequest<RestRequestConfig> implemen
         }
 
         try {
-            WsdlSubmit<RestRequest> submitter = new WsdlSubmit<RestRequest>(this, getSubmitListeners(),
+            WsdlSubmit<RestRequest> submitter = new WsdlSubmit<>(this, getSubmitListeners(),
                     RequestTransportRegistry.getTransport(endpoint, submitContext));
             submitter.submitRequest(submitContext, async);
             addPropertyChangeListener(AbstractHttpRequest.RESPONSE_PROPERTY, new PropertyChangeListener() {

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/RestResource.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/RestResource.java
@@ -53,8 +53,8 @@ import java.util.Set;
 public class RestResource extends AbstractWsdlModelItem<RestResourceConfig> implements AbstractHttpOperation,
         MutableTestPropertyHolder, RestResourceContainer, PropertyChangeListener {
     public static final String PATH_PROPERTY = "path";
-    private List<RestMethod> methods = new ArrayList<RestMethod>();
-    private List<RestResource> resources = new ArrayList<RestResource>();
+    private List<RestMethod> methods = new ArrayList<>();
+    private List<RestResource> resources = new ArrayList<>();
     private RestResource parentResource;
     private XmlBeansRestParamsTestPropertyHolder params;
     private PropertyChangeListener styleChangeListener = new StyleChangeListener();
@@ -110,7 +110,7 @@ public class RestResource extends AbstractWsdlModelItem<RestResourceConfig> impl
 
     @Override
     public List<? extends ModelItem> getChildren() {
-        List<ModelItem> result = new ArrayList<ModelItem>();
+        List<ModelItem> result = new ArrayList<>();
 
         result.addAll(getRestMethodList());
         result.addAll(getChildResourceList());
@@ -162,7 +162,7 @@ public class RestResource extends AbstractWsdlModelItem<RestResourceConfig> impl
     }
 
     public List<RestResource> getChildResourceList() {
-        return new ArrayList<RestResource>(resources);
+        return new ArrayList<>(resources);
     }
 
     public RestRequest getRequestAt(int index) {
@@ -207,7 +207,7 @@ public class RestResource extends AbstractWsdlModelItem<RestResourceConfig> impl
     }
 
     public List<RestMethod> getRestMethodList() {
-        return new ArrayList<RestMethod>(methods);
+        return new ArrayList<>(methods);
     }
 
     public RestMethod getRestMethodByName(String name) {
@@ -223,7 +223,7 @@ public class RestResource extends AbstractWsdlModelItem<RestResourceConfig> impl
     }
 
     public List<Request> getRequestList() {
-        List<Request> rs = new ArrayList<Request>();
+        List<Request> rs = new ArrayList<>();
         for (RestMethod m : methods) {
             rs.addAll(m.getRequestList());
         }
@@ -272,8 +272,8 @@ public class RestResource extends AbstractWsdlModelItem<RestResourceConfig> impl
     }
 
     public RestParamProperty[] getDefaultParams() {
-        List<RestParamProperty> result = new ArrayList<RestParamProperty>();
-        Set<String> names = new HashSet<String>();
+        List<RestParamProperty> result = new ArrayList<>();
+        Set<String> names = new HashSet<>();
 
         if (parentResource != null) {
             result.addAll(Arrays.asList(parentResource.getDefaultParams()));
@@ -487,7 +487,7 @@ public class RestResource extends AbstractWsdlModelItem<RestResourceConfig> impl
     }
 
     public RestResource[] getAllChildResources() {
-        List<RestResource> result = new ArrayList<RestResource>();
+        List<RestResource> result = new ArrayList<>();
         for (RestResource resource : resources) {
             addResourcesToResult(resource, result);
         }

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/RestService.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/RestService.java
@@ -38,7 +38,7 @@ import java.util.Map;
  */
 
 public class RestService extends AbstractInterface<RestServiceConfig> implements RestResourceContainer {
-    private List<RestResource> resources = new ArrayList<RestResource>();
+    private List<RestResource> resources = new ArrayList<>();
     private WadlDefinitionContext wadlContext;
     private boolean exportChanges = false;
 
@@ -75,7 +75,7 @@ public class RestService extends AbstractInterface<RestServiceConfig> implements
     }
 
     public List<Operation> getOperationList() {
-        return new ArrayList<Operation>(resources);
+        return new ArrayList<>(resources);
     }
 
     public String getBasePath() {
@@ -161,7 +161,7 @@ public class RestService extends AbstractInterface<RestServiceConfig> implements
     }
 
     public List<RestResource> getAllResources() {
-        List<RestResource> result = new ArrayList<RestResource>();
+        List<RestResource> result = new ArrayList<>();
         for (RestResource resource : resources) {
             addResourcesToResult(resource, result);
         }
@@ -170,7 +170,7 @@ public class RestService extends AbstractInterface<RestServiceConfig> implements
     }
 
     public Map<String, RestResource> getResources() {
-        Map<String, RestResource> result = new HashMap<String, RestResource>();
+        Map<String, RestResource> result = new HashMap<>();
 
         for (RestResource resource : getAllResources()) {
             result.put(resource.getFullPath(false), resource);
@@ -198,7 +198,7 @@ public class RestService extends AbstractInterface<RestServiceConfig> implements
     }
 
     public RestResource[] getResourcesByFullPath(String resourcePath) {
-        List<RestResource> result = new ArrayList<RestResource>();
+        List<RestResource> result = new ArrayList<>();
 
         for (RestResource resource : getAllResources()) {
             if (resource.getFullPath().equals(resourcePath)) {
@@ -261,7 +261,7 @@ public class RestService extends AbstractInterface<RestServiceConfig> implements
     }
 
     public List<RestResource> getResourceList() {
-        return new ArrayList<RestResource>(resources);
+        return new ArrayList<>(resources);
     }
 
     public boolean exportChanges() {

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/WadlGenerator.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/WadlGenerator.java
@@ -188,7 +188,7 @@ public class WadlGenerator {
         methodConfig.setId(restMethod.getName());
         Request requestConfig = methodConfig.addNewRequest();
 
-        Map<String, RestParamProperty> defaultParams = new HashMap<String, RestParamProperty>();
+        Map<String, RestParamProperty> defaultParams = new HashMap<>();
         for (RestParamProperty defaultParam : restMethod.getResource().getDefaultParams()) {
             defaultParams.put(defaultParam.getName(), defaultParam);
         }
@@ -207,14 +207,14 @@ public class WadlGenerator {
             }
         }
 
-        Map<String, Response> responses = new HashMap<String, Response>();
+        Map<String, Response> responses = new HashMap<>();
         if (!isWADL11) {
             responses.put(null, methodConfig.addNewResponse());
         }
         for (RestRepresentation representation : restMethod.getRepresentations()) {
             Response response;
             if (isWADL11) {
-                List<Comparable> status = new ArrayList<Comparable>((List<Comparable>) representation.getStatus());
+                List<Comparable> status = new ArrayList<>((List<Comparable>) representation.getStatus());
                 Collections.sort(status);
                 StringBuilder statusStrBuilder = new StringBuilder();
                 for (Object o : status) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/actions/mock/AddRestRequestToMockServiceAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/actions/mock/AddRestRequestToMockServiceAction.java
@@ -42,7 +42,7 @@ public class AddRestRequestToMockServiceAction extends AbstractSoapUIAction<Rest
     private static final String SELECT_MOCKSERVICE_OPTION = "Create new..";
     public static final String SOAPUI_ACTION_ID = "AddRestRequestToMockServiceAction";
     private static final MessageSupport messages = MessageSupport.getMessages(AddRestRequestToMockServiceAction.class);
-    private static List<String> HEADERS_TO_IGNORE = new ArrayList<String>();
+    private static List<String> HEADERS_TO_IGNORE = new ArrayList<>();
 
     static {
         HEADERS_TO_IGNORE.add("#status#");

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/actions/oauth/OAuth2TokenExtractor.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/actions/oauth/OAuth2TokenExtractor.java
@@ -47,7 +47,7 @@ public class OAuth2TokenExtractor {
     public static final String TOKEN = "token";
     public static final String ACCESS_TOKEN = "access_token";
 
-    protected List<BrowserListener> browserListeners = new ArrayList<BrowserListener>();
+    protected List<BrowserListener> browserListeners = new ArrayList<>();
 
     public void extractAccessToken(final OAuth2Parameters parameters) throws OAuthSystemException, MalformedURLException, URISyntaxException, OAuthProblemException {
         OAuth2Profile.OAuth2Flow i = parameters.getOAuth2Flow();

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/actions/resource/NewRestChildResourceAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/actions/resource/NewRestChildResourceAction.java
@@ -41,7 +41,7 @@ public class NewRestChildResourceAction extends NewRestResourceActionBase<RestRe
 
     @Override
     protected List<RestResource> getResourcesFor(RestResource item) {
-        List<RestResource> returnValue = new ArrayList<RestResource>();
+        List<RestResource> returnValue = new ArrayList<>();
         returnValue.add(item);
         returnValue.addAll(Arrays.asList(item.getAllChildResources()));
         return returnValue;

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/actions/service/CreateWadlDocumentationAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/actions/service/CreateWadlDocumentationAction.java
@@ -110,7 +110,7 @@ public class CreateWadlDocumentationAction extends AbstractSoapUIAction<RestServ
     }
 
     protected static void initTransformers() throws Exception {
-        transformers = new HashMap<String, Transformer>();
+        transformers = new HashMap<>();
         TransformerFactory xformFactory = new org.apache.xalan.processor.TransformerFactoryImpl();
 
         transformers.put(

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/mock/RestMockService.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/mock/RestMockService.java
@@ -169,7 +169,7 @@ public class RestMockService extends AbstractMockService<RestMockAction, RESTMoc
     }
 
     public List<MockOperation> addNewMockOperationsFromResource(RestResource restResource) {
-        List<MockOperation> actions = new ArrayList<MockOperation>();
+        List<MockOperation> actions = new ArrayList<>();
         String path = RestUtils.getExpandedPath(restResource.getFullPath(), restResource.getParams(), restResource);
 
         if (restResource.getRestMethodCount() < 1) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/component/RestResourceEditorPopupWindow.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/component/RestResourceEditorPopupWindow.java
@@ -130,7 +130,7 @@ class RestResourceEditorPopupWindow extends JDialog {
     }
 
     private void addResourceFields(RestResource focusedResource, Box contentBox, JLabel changeWarningLabel) {
-        restSubResourceTextFields = new ArrayList<RestSubResourceTextField>();
+        restSubResourceTextFields = new ArrayList<>();
         int rowIndex = contentBox.getComponents().length;
 
         for (RestResource restResource : RestUtils.extractAncestorsParentFirst(targetResource)) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/method/RestMethodPanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/method/RestMethodPanelBuilder.java
@@ -42,7 +42,7 @@ public class RestMethodPanelBuilder extends EmptyPanelBuilder<RestMethod> {
     }
 
     public Component buildOverviewPanel(RestMethod method) {
-        JPropertiesTable<RestMethod> table = new JPropertiesTable<RestMethod>("Method Properties");
+        JPropertiesTable<RestMethod> table = new JPropertiesTable<>("Method Properties");
         table.addProperty("Name", "name", true);
         table.addProperty("Description", "description", true);
         table.addProperty("HTTP Method", "method", RestRequestInterface.HttpMethod.getMethods());

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/method/RestRepresentationsTable.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/method/RestRepresentationsTable.java
@@ -84,7 +84,7 @@ public class RestRepresentationsTable extends JPanel implements PropertyChangeLi
     }
 
     public class RepresentationsTableModel extends AbstractTableModel implements PropertyChangeListener {
-        private List<RestRepresentation> data = new ArrayList<RestRepresentation>();
+        private List<RestRepresentation> data = new ArrayList<>();
 
         public RepresentationsTableModel() {
             initData();
@@ -153,7 +153,7 @@ public class RestRepresentationsTable extends JPanel implements PropertyChangeLi
                     }
 
                     String[] items = value.toString().split(" ");
-                    List<Integer> status = new ArrayList<Integer>();
+                    List<Integer> status = new ArrayList<>();
 
                     for (String item : items) {
                         try {

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/mock/RestMockActionPanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/mock/RestMockActionPanelBuilder.java
@@ -30,7 +30,7 @@ public class RestMockActionPanelBuilder extends EmptyPanelBuilder<RestMockAction
     }
 
     public Component buildOverviewPanel(RestMockAction mockAction) {
-        JPropertiesTable<RestMockAction> table = new JPropertiesTable<RestMockAction>("MockAction Properties");
+        JPropertiesTable<RestMockAction> table = new JPropertiesTable<>("MockAction Properties");
         boolean editable = true;
         table.addProperty("Name", "name", editable);
         table.addProperty("Description", "description", editable);

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/mock/RestMockResponseDesktopPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/mock/RestMockResponseDesktopPanel.java
@@ -180,7 +180,7 @@ class CompleteHttpStatus {
 }
 
 class HttpStatusCodeComboBoxModel extends DefaultComboBoxModel {
-    private static Vector<CompleteHttpStatus> LIST_OF_CODES = new Vector<CompleteHttpStatus>();
+    private static Vector<CompleteHttpStatus> LIST_OF_CODES = new Vector<>();
 
     static {
         final String statusCodePrefix = "SC_";

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/mock/RestMockResponsePanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/mock/RestMockResponsePanelBuilder.java
@@ -42,7 +42,7 @@ public class RestMockResponsePanelBuilder extends EmptyPanelBuilder<RestMockResp
     }
 
     public Component buildOverviewPanel(WsdlMockResponse mockResponse) {
-        JPropertiesTable<WsdlMockResponse> table = new JPropertiesTable<WsdlMockResponse>("MockResponse Properties");
+        JPropertiesTable<WsdlMockResponse> table = new JPropertiesTable<>("MockResponse Properties");
         table.addProperty("Name", "name", true);
         table.addProperty("Description", "description", true);
         table.addProperty("Message Size", "contentLength", false);

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/mock/RestMockServicePanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/mock/RestMockServicePanelBuilder.java
@@ -38,7 +38,7 @@ public class RestMockServicePanelBuilder extends EmptyPanelBuilder<RestMockServi
     }
 
     public Component buildOverviewPanel(RestMockService mockService) {
-        JPropertiesTable<RestMockService> table = new JPropertiesTable<RestMockService>("MockService Properties");
+        JPropertiesTable<RestMockService> table = new JPropertiesTable<>("MockService Properties");
         boolean editable = true;
         table.addProperty("Name", "name", editable);
         table.addProperty("Description", "description", editable);

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/ParameterFinder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/ParameterFinder.java
@@ -30,7 +30,7 @@ class ParameterFinder {
 
     public ParameterFinder(String parametersString) {
         StringTokenizer parser = new StringTokenizer(parametersString, "?&=;", true);
-        List<String> parsedTokens = new ArrayList<String>();
+        List<String> parsedTokens = new ArrayList<>();
         while (parser.hasMoreTokens()) {
             parsedTokens.add(parser.nextToken());
         }

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/RestRequestPanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/RestRequestPanelBuilder.java
@@ -43,7 +43,7 @@ public class RestRequestPanelBuilder extends EmptyPanelBuilder<RestRequest> {
     }
 
     public Component buildOverviewPanel(RestRequest request) {
-        JPropertiesTable<RestRequest> table = new JPropertiesTable<RestRequest>("Request Properties");
+        JPropertiesTable<RestRequest> table = new JPropertiesTable<>("Request Properties");
         table.addProperty("Name", "name");
         table.addProperty("Description", "description", true);
         // table.addProperty( "Method", "method", new Object[]{RequestMethod.GET,

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/inspectors/schema/InferredSchemaInspector.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/inspectors/schema/InferredSchemaInspector.java
@@ -310,7 +310,7 @@ public class InferredSchemaInspector extends AbstractXmlInspector implements Sub
         public Handler(SchemaTabs panel, XmlObject xml) {
             this.panel = panel;
             this.xml = xml;
-            paths = new ArrayList<String>();
+            paths = new ArrayList<>();
         }
 
         public synchronized void run() {

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/inspectors/schema/InferredSchemaManager.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/inspectors/schema/InferredSchemaManager.java
@@ -38,10 +38,10 @@ public class InferredSchemaManager {
     private static Map<String, String> rFilenames;
 
     static {
-        schemas = new HashMap<RestService, InferredSchema>();
-        propertyChangeSupports = new HashMap<RestService, PropertyChangeSupport>();
-        filenames = new HashMap<String, String>();
-        rFilenames = new HashMap<String, String>();
+        schemas = new HashMap<>();
+        propertyChangeSupports = new HashMap<>();
+        filenames = new HashMap<>();
+        rFilenames = new HashMap<>();
     }
 
     public static String filenameForNamespace(String namespace) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/resource/RestParamsTable.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/resource/RestParamsTable.java
@@ -251,13 +251,13 @@ public class RestParamsTable extends JPanel {
     }
 
     private JComponent buildDetails() {
-        paramDetailsModel = new PresentationModel<RestParamProperty>(null);
+        paramDetailsModel = new PresentationModel<>(null);
         detailsForm = new SimpleBindingForm(paramDetailsModel);
 
         detailsForm.addSpace(5);
         detailsForm.appendCheckBox("required", "Required", "Sets if parameter is required");
 
-        List<QName> types = new ArrayList<QName>();
+        List<QName> types = new ArrayList<>();
         for (SchemaType type : XmlBeans.getBuiltinTypeSystem().globalTypes()) {
             types.add(type.getName());
         }

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/resource/RestResourcePanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/resource/RestResourcePanelBuilder.java
@@ -41,7 +41,7 @@ public class RestResourcePanelBuilder extends EmptyPanelBuilder<RestResource> {
     }
 
     public Component buildOverviewPanel(RestResource service) {
-        JPropertiesTable<RestResource> table = new JPropertiesTable<RestResource>("Resource Properties");
+        JPropertiesTable<RestResource> table = new JPropertiesTable<>("Resource Properties");
         table.addProperty("Name", "name", true);
         table.addProperty("Description", "description", true);
         table.addProperty("Path", "path", true);

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/service/RestServiceDesktopPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/service/RestServiceDesktopPanel.java
@@ -95,11 +95,11 @@ import java.util.Map;
 public class RestServiceDesktopPanel extends ModelItemDesktopPanel<RestService> {
     private final static Logger logger = LogManager.getLogger(WsdlInterfaceDesktopPanel.class);
     private JTabbedPane partTabs;
-    private List<RSyntaxTextArea> editors = new ArrayList<RSyntaxTextArea>();
+    private List<RSyntaxTextArea> editors = new ArrayList<>();
     private JTree tree;
-    private Map<String, DefaultMutableTreeNode> groupNodes = new HashMap<String, DefaultMutableTreeNode>();
-    private Map<String, TreePath> pathMap = new HashMap<String, TreePath>();
-    private List<TreePath> navigationHistory = new ArrayList<TreePath>();
+    private Map<String, DefaultMutableTreeNode> groupNodes = new HashMap<>();
+    private Map<String, TreePath> pathMap = new HashMap<>();
+    private List<TreePath> navigationHistory = new ArrayList<>();
     private StringList targetNamespaces = new StringList();
     private int historyIndex;
     private boolean navigating;
@@ -481,11 +481,11 @@ public class RestServiceDesktopPanel extends ModelItemDesktopPanel<RestService> 
     public List<DefaultMutableTreeNode> mapTreeItems(XmlObject xmlObject, DefaultMutableTreeNode treeRoot,
                                                      boolean createEmpty, int tabIndex, String groupName, String query, String nameQuery, boolean sort,
                                                      NodeSelector selector) {
-        List<DefaultMutableTreeNode> resultNodes = new ArrayList<DefaultMutableTreeNode>();
+        List<DefaultMutableTreeNode> resultNodes = new ArrayList<>();
 
         try {
             XmlObject[] items = xmlObject.selectPath(query);
-            List<DefaultMutableTreeNode> treeNodes = new ArrayList<DefaultMutableTreeNode>();
+            List<DefaultMutableTreeNode> treeNodes = new ArrayList<>();
 
             DefaultMutableTreeNode root = treeRoot;
             if (groupName != null) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/service/RestServicePanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/service/RestServicePanelBuilder.java
@@ -41,7 +41,7 @@ public class RestServicePanelBuilder extends EmptyPanelBuilder<RestService> {
     }
 
     public Component buildOverviewPanel(RestService service) {
-        JPropertiesTable<RestService> table = new JPropertiesTable<RestService>("Service Properties");
+        JPropertiesTable<RestService> table = new JPropertiesTable<>("Service Properties");
         table.addProperty("Name", "name", true);
         table.addProperty("Description", "description", true);
         table.addProperty("Base Path", "basePath", true);

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/support/MediaTypeHandlerRegistry.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/support/MediaTypeHandlerRegistry.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class MediaTypeHandlerRegistry {
-    private static List<MediaTypeHandler> mediaTypeHandlers = new ArrayList<MediaTypeHandler>();
+    private static List<MediaTypeHandler> mediaTypeHandlers = new ArrayList<>();
     private static MediaTypeHandler defaultMediaTypeHandler = new DefaultMediaTypeHandler();
 
     static {

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/support/OverlayRestParamsPropertyHolder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/support/OverlayRestParamsPropertyHolder.java
@@ -35,7 +35,7 @@ import java.util.Set;
 public class OverlayRestParamsPropertyHolder implements RestParamsPropertyHolder {
     private RestParamsPropertyHolder parent;
     private RestParamsPropertyHolder overlay;
-    private Set<TestPropertyListener> listeners = new HashSet<TestPropertyListener>();
+    private Set<TestPropertyListener> listeners = new HashSet<>();
 
     public OverlayRestParamsPropertyHolder(RestParamsPropertyHolder parent, RestParamsPropertyHolder overlay) {
         this.parent = parent;
@@ -82,7 +82,7 @@ public class OverlayRestParamsPropertyHolder implements RestParamsPropertyHolder
     }
 
     public Map<String, TestProperty> getProperties() {
-        HashMap<String, TestProperty> result = new HashMap<String, TestProperty>();
+        HashMap<String, TestProperty> result = new HashMap<>();
 
         for (TestProperty p : values()) {
             result.put(p.getName(), p);
@@ -139,7 +139,7 @@ public class OverlayRestParamsPropertyHolder implements RestParamsPropertyHolder
     }
 
     public Set<String> keySet() {
-        Set<String> names = new LinkedHashSet<String>();
+        Set<String> names = new LinkedHashSet<>();
         for (TestProperty prop : values()) {
             names.add(prop.getName());
         }
@@ -209,7 +209,7 @@ public class OverlayRestParamsPropertyHolder implements RestParamsPropertyHolder
     public Collection<TestProperty> values() {
         // List<TestProperty> values = new
         // ArrayList<TestProperty>(overlay.values());
-        List<TestProperty> values = new ArrayList<TestProperty>();
+        List<TestProperty> values = new ArrayList<>();
         for (TestProperty prop : parent.values()) {
             if (overlay.hasProperty(prop.getName())) {
                 values.add(overlay.getProperty(prop.getName()));

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/support/RestRequestConverter.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/support/RestRequestConverter.java
@@ -66,7 +66,7 @@ import java.util.Map;
  */
 public class RestRequestConverter {
 
-    private static Map<Project, Boolean> autoConvert = new HashMap<Project, Boolean>();
+    private static Map<Project, Boolean> autoConvert = new HashMap<>();
     private final static Logger log = LogManager.getLogger(RestRequestConverter.class);
 
     public static void convert(RestResource resource, OldRestRequestConfig oldConfig) {
@@ -87,7 +87,7 @@ public class RestRequestConverter {
                                             "Update REST model for project: " + project.getName()));
         }
         RestMethod method = null;
-        List<String> options = new ArrayList<String>();
+        List<String> options = new ArrayList<>();
         for (int c = 0; c < resource.getRestMethodCount(); c++) {
             RestMethod restMethod = resource.getRestMethodAt(c);
             if (restMethod.getMethod().toString().equals(methodType)) {
@@ -133,7 +133,7 @@ public class RestRequestConverter {
     }
 
     public static RestResource resolveResource(RestTestRequestStep requestStep) {
-        Map<String, RestResource> options = new LinkedHashMap<String, RestResource>();
+        Map<String, RestResource> options = new LinkedHashMap<>();
 
         WsdlProject project = requestStep.getTestCase().getTestSuite().getProject();
         String serviceName = requestStep.getRequestStepConfig().getService();

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/support/RestRequestParamsPropertyHolder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/support/RestRequestParamsPropertyHolder.java
@@ -47,8 +47,8 @@ public class RestRequestParamsPropertyHolder implements RestParamsPropertyHolder
     private RestParamsPropertyHolder methodParams;
     private List<String> sortedPropertyNames;
     private RestRequest restRequest;
-    private Set<TestPropertyListener> listeners = new HashSet<TestPropertyListener>();
-    private Map<RestParamProperty, InternalRestParamProperty> wrappers = new HashMap<RestParamProperty, InternalRestParamProperty>();
+    private Set<TestPropertyListener> listeners = new HashSet<>();
+    private Map<RestParamProperty, InternalRestParamProperty> wrappers = new HashMap<>();
     private String parameterBeingMoved;
 
     public RestRequestParamsPropertyHolder(RestParamsPropertyHolder methodParams, RestRequest restRequest,
@@ -63,14 +63,14 @@ public class RestRequestParamsPropertyHolder implements RestParamsPropertyHolder
     private void buildPropertyNameList() {
         RestRequestConfig requestConfig = restRequest.getConfig();
         List<String> propertyNames;
-        List<String> methodParamNames = new ArrayList<String>(Arrays.asList(methodParams.getPropertyNames()));
+        List<String> methodParamNames = new ArrayList<>(Arrays.asList(methodParams.getPropertyNames()));
         if (requestConfig.isSetParameterOrder()) {
-            propertyNames = new ArrayList<String>(requestConfig.getParameterOrder().getEntryList());
+            propertyNames = new ArrayList<>(requestConfig.getParameterOrder().getEntryList());
             propertyNames.retainAll(methodParamNames);
             methodParamNames.removeAll(propertyNames);
             propertyNames.addAll(methodParamNames);
         } else {
-            propertyNames = new ArrayList<String>(methodParamNames);
+            propertyNames = new ArrayList<>(methodParamNames);
         }
         sortedPropertyNames = propertyNames;
     }
@@ -117,7 +117,7 @@ public class RestRequestParamsPropertyHolder implements RestParamsPropertyHolder
             String description = parameter.getDescription();
             boolean disableURLEncoding = parameter.isDisableUrlEncoding();
             RestParamProperty newParameter;
-            List<String> copyOfSortedPropertyNames = new ArrayList<String>(sortedPropertyNames);
+            List<String> copyOfSortedPropertyNames = new ArrayList<>(sortedPropertyNames);
             if (newLocation == NewRestResourceActionBase.ParamLocation.METHOD) {
                 restRequest.getResource().removeProperty(parameterBeingMoved);
                 newParameter = restRequest.getRestMethod().addProperty(parameterBeingMoved);
@@ -239,7 +239,7 @@ public class RestRequestParamsPropertyHolder implements RestParamsPropertyHolder
     }
 
     public Set<String> keySet() {
-        return new LinkedHashSet<String>(sortedPropertyNames);
+        return new LinkedHashSet<>(sortedPropertyNames);
     }
 
     public void moveProperty(String propertyName, int targetIndex) {
@@ -351,7 +351,7 @@ public class RestRequestParamsPropertyHolder implements RestParamsPropertyHolder
     }
 
     public Collection<TestProperty> values() {
-        List<TestProperty> ret = new ArrayList<TestProperty>();
+        List<TestProperty> ret = new ArrayList<>();
         for (TestProperty p : methodParams.values()) {
             ret.add(getWrapper((RestParamProperty) p));
         }
@@ -618,7 +618,7 @@ public class RestRequestParamsPropertyHolder implements RestParamsPropertyHolder
     }
 
     public List<TestProperty> getPropertyList() {
-        List<TestProperty> propertyList = new ArrayList<TestProperty>();
+        List<TestProperty> propertyList = new ArrayList<>();
         for (InternalRestParamProperty internalRestParamProperty : wrappers.values()) {
             propertyList.add(internalRestParamProperty);
         }

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/support/RestUtils.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/support/RestUtils.java
@@ -331,7 +331,7 @@ public class RestUtils {
     }
 
     public static List<RestResource> extractAncestorsParentFirst(RestResource childResource) {
-        final List<RestResource> resources = new ArrayList<RestResource>();
+        final List<RestResource> resources = new ArrayList<>();
         for (RestResource r = childResource; r != null; r = r.getParentResource()) {
             resources.add(r);
         }

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/support/WadlImporter.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/support/WadlImporter.java
@@ -68,7 +68,7 @@ public class WadlImporter {
     private RestService service;
     private Application application;
     private List<Resources> resourcesList;
-    private Map<String, ApplicationDocument> refCache = new HashMap<String, ApplicationDocument>();
+    private Map<String, ApplicationDocument> refCache = new HashMap<>();
     private boolean isWADL11 = true;
 
     public WadlImporter(RestService service) {
@@ -292,7 +292,7 @@ public class WadlImporter {
                     if ("fault".equals(n.getNodeName())) {
                         String content = XmlUtils.serialize(n, false);
                         try {
-                            Map<Object, Object> map = new HashMap<Object, Object>();
+                            Map<Object, Object> map = new HashMap<>();
                             XmlCursor cursor = response.newCursor();
                             cursor.getAllNamespaces(map);
                             cursor.dispose();
@@ -325,7 +325,7 @@ public class WadlImporter {
         } else {
             Node n = representation.getDomNode().getAttributes().getNamedItem("status");
             if (n != null) {
-                status = new ArrayList<Long>();
+                status = new ArrayList<>();
                 for (String s : n.getNodeValue().split(" ")) {
                     status.add(Long.parseLong(s));
                 }
@@ -541,7 +541,7 @@ public class WadlImporter {
     }
 
     public static Map<String, XmlObject> getDefinitionParts(String wadlUrl) {
-        Map<String, XmlObject> result = new HashMap<String, XmlObject>();
+        Map<String, XmlObject> result = new HashMap<>();
 
         try {
             return SchemaUtils.getSchemas(wadlUrl, new UrlSchemaLoader(wadlUrl));

--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/support/XmlBeansRestParamsTestPropertyHolder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/support/XmlBeansRestParamsTestPropertyHolder.java
@@ -57,9 +57,9 @@ public class XmlBeansRestParamsTestPropertyHolder implements RestParamsPropertyH
     public static final String PROPERTY_STYLE = "style";
     public static final String PARAM_LOCATION = "paramLocation";
     private RestParametersConfig config;
-    private List<RestParamProperty> properties = new ArrayList<RestParamProperty>();
-    private Map<String, RestParamProperty> propertyMap = new HashMap<String, RestParamProperty>();
-    private Set<TestPropertyListener> listeners = new HashSet<TestPropertyListener>();
+    private List<RestParamProperty> properties = new ArrayList<>();
+    private Map<String, RestParamProperty> propertyMap = new HashMap<>();
+    private Set<TestPropertyListener> listeners = new HashSet<>();
     private final ModelItem modelItem;
     private ParamLocation defaultParamLocation;
     private Properties overrideProperties;
@@ -566,7 +566,7 @@ public class XmlBeansRestParamsTestPropertyHolder implements RestParamsPropertyH
     }
 
     public List<TestProperty> getPropertyList() {
-        List<TestProperty> result = new ArrayList<TestProperty>();
+        List<TestProperty> result = new ArrayList<>();
 
         for (TestProperty property : properties) {
             result.add(property);
@@ -576,7 +576,7 @@ public class XmlBeansRestParamsTestPropertyHolder implements RestParamsPropertyH
     }
 
     public Map<String, TestProperty> getProperties() {
-        Map<String, TestProperty> result = new HashMap<String, TestProperty>();
+        Map<String, TestProperty> result = new HashMap<>();
         for (RestParamProperty property : propertyMap.values()) {
             result.put(property.getName(), property);
         }
@@ -640,7 +640,7 @@ public class XmlBeansRestParamsTestPropertyHolder implements RestParamsPropertyH
      * getPropertyExpansions()
      */
     public PropertyExpansion[] getPropertyExpansions() {
-        List<PropertyExpansion> result = new ArrayList<PropertyExpansion>();
+        List<PropertyExpansion> result = new ArrayList<>();
 
         for (RestParamProperty prop : properties) {
             result.addAll(PropertyExpansionUtils.extractPropertyExpansions(getModelItem(), prop, "value"));
@@ -716,7 +716,7 @@ public class XmlBeansRestParamsTestPropertyHolder implements RestParamsPropertyH
     }
 
     public Set<java.util.Map.Entry<String, TestProperty>> entrySet() {
-        HashSet<java.util.Map.Entry<String, TestProperty>> result = new HashSet<Entry<String, TestProperty>>();
+        HashSet<java.util.Map.Entry<String, TestProperty>> result = new HashSet<>();
 
         for (TestProperty p : propertyMap.values()) {
             // This does not compile on JDK 1.5:
@@ -759,7 +759,7 @@ public class XmlBeansRestParamsTestPropertyHolder implements RestParamsPropertyH
     }
 
     public Set<String> keySet() {
-        return new LinkedHashSet<String>(Arrays.asList(getPropertyNames()));
+        return new LinkedHashSet<>(Arrays.asList(getPropertyNames()));
     }
 
     public TestProperty put(String key, TestProperty value) {
@@ -783,7 +783,7 @@ public class XmlBeansRestParamsTestPropertyHolder implements RestParamsPropertyH
     }
 
     public Collection<TestProperty> values() {
-        ArrayList<TestProperty> result = new ArrayList<TestProperty>();
+        ArrayList<TestProperty> result = new ArrayList<>();
         result.addAll(properties);
         return result;
     }

--- a/soapui/src/main/java/com/eviware/soapui/impl/settings/SettingsImpl.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/settings/SettingsImpl.java
@@ -32,7 +32,7 @@ import java.util.Set;
 public class SettingsImpl implements Settings {
     private final Settings parent;
     private final StringToStringMap values = new StringToStringMap();
-    private final Set<SettingsListener> listeners = new HashSet<SettingsListener>();
+    private final Set<SettingsListener> listeners = new HashSet<>();
 
     public SettingsImpl() {
         this(null);

--- a/soapui/src/main/java/com/eviware/soapui/impl/settings/WeakSettingsListener.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/settings/WeakSettingsListener.java
@@ -30,7 +30,7 @@ public final class WeakSettingsListener implements SettingsListener {
     private final WeakReference<SettingsListener> listenerReference;
 
     public WeakSettingsListener(SettingsListener listener) {
-        listenerReference = new WeakReference<SettingsListener>(listener);
+        listenerReference = new WeakReference<>(listener);
     }
 
     public void settingChanged(String name, String newValue, String oldValue) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/settings/XmlBeansSettingsImpl.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/settings/XmlBeansSettingsImpl.java
@@ -41,7 +41,7 @@ public class XmlBeansSettingsImpl implements Settings {
     private final SettingsConfig config;
     private final Map<String, SettingConfig> values = Collections.synchronizedMap(new HashMap<String, SettingConfig>());
     private final Map<String, String> valueCache = Collections.synchronizedMap(new StringToStringMap());
-    private final Set<SettingsListener> listeners = new HashSet<SettingsListener>();
+    private final Set<SettingsListener> listeners = new HashSet<>();
     private final ModelItem item;
     private final SettingsListener settingsListener = new WeakSettingsListener(new InternalSettingsListener());
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/support/AbstractHttpRequest.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/support/AbstractHttpRequest.java
@@ -76,12 +76,12 @@ public abstract class AbstractHttpRequest<T extends AbstractRequestConfig> exten
     public static final String CR_ESCAPE_SEQUENCE = "\\\\_r";
     public static final Principal EMPTY_SSLSTATE = new UserPrincipal("");
 
-    private Set<SubmitListener> submitListeners = new HashSet<SubmitListener>();
+    private Set<SubmitListener> submitListeners = new HashSet<>();
     private String requestContent;
     private RequestIconAnimator<?> iconAnimator;
     private HttpResponse response;
     private SettingPathPropertySupport dumpFile;
-    private List<FileAttachment<?>> attachments = new ArrayList<FileAttachment<?>>();
+    private List<FileAttachment<?>> attachments = new ArrayList<>();
     private IAfterRequestInjection afterRequestInjection;
 
     protected AbstractHttpRequest(T config, AbstractHttpOperation parent, String icon, boolean forLoadTest) {
@@ -191,7 +191,7 @@ public abstract class AbstractHttpRequest<T extends AbstractRequestConfig> exten
      * (java.lang.String)
      */
     public Attachment[] getAttachmentsForPart(String partName) {
-        List<Attachment> result = new ArrayList<Attachment>();
+        List<Attachment> result = new ArrayList<>();
 
         for (Attachment attachment : attachments) {
             if (partName.equals(attachment.getPart())) {
@@ -526,7 +526,7 @@ public abstract class AbstractHttpRequest<T extends AbstractRequestConfig> exten
     }
 
     public Set<String> getBasicAuthenticationProfiles() {
-        Set<String> authTypes = new HashSet<String>();
+        Set<String> authTypes = new HashSet<>();
         CredentialsConfig credentialsConfig = getConfig().getCredentials();
         if (credentialsConfig != null) {
             for (String type : credentialsConfig.getAddedBasicAuthenticationTypesList()) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/support/AbstractInterface.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/support/AbstractInterface.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 public abstract class AbstractInterface<T extends InterfaceConfig> extends AbstractWsdlModelItem<T> implements
         Interface {
-    private Set<InterfaceListener> interfaceListeners = new HashSet<InterfaceListener>();
+    private Set<InterfaceListener> interfaceListeners = new HashSet<>();
 
     protected AbstractInterface(T config, ModelItem parent, String icon) {
         super(config, parent, icon);

--- a/soapui/src/main/java/com/eviware/soapui/impl/support/AbstractMockOperation.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/support/AbstractMockOperation.java
@@ -40,7 +40,7 @@ public abstract class AbstractMockOperation
 
     private MockOperationDispatcher dispatcher;
 
-    private List<MockResponseType> responses = new ArrayList<MockResponseType>();
+    private List<MockResponseType> responses = new ArrayList<>();
 
     protected AbstractMockOperation(BaseMockOperationConfigType config, MockService parent, String icon) {
         super(config, parent, icon);
@@ -70,7 +70,7 @@ public abstract class AbstractMockOperation
     }
 
     public List<MockResponse> getMockResponses() {
-        return new ArrayList<MockResponse>(responses);
+        return new ArrayList<>(responses);
     }
 
     public MockResponseType getMockResponseAt(int index) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/support/AbstractMockService.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/support/AbstractMockService.java
@@ -63,9 +63,9 @@ public abstract class AbstractMockService<MockOperationType extends MockOperatio
     public final static String START_SCRIPT_PROPERTY = AbstractMockService.class.getName() + "@startScript";
     public final static String STOP_SCRIPT_PROPERTY = AbstractMockService.class.getName() + "@stopScript";
 
-    protected List<MockOperation> mockOperations = new ArrayList<MockOperation>();
-    private Set<MockRunListener> mockRunListeners = new HashSet<MockRunListener>();
-    private Set<MockServiceListener> mockServiceListeners = new HashSet<MockServiceListener>();
+    protected List<MockOperation> mockOperations = new ArrayList<>();
+    private Set<MockRunListener> mockRunListeners = new HashSet<>();
+    private Set<MockServiceListener> mockServiceListeners = new HashSet<>();
     private MockServiceIconAnimator iconAnimator;
     private WsdlMockRunner mockRunner;
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/support/definition/export/AbstractDefinitionExporter.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/support/definition/export/AbstractDefinitionExporter.java
@@ -59,7 +59,7 @@ public abstract class AbstractDefinitionExporter<T extends Interface> implements
             throw new Exception("Failed to create directory [" + folderName + "]");
         }
 
-        Map<String, String> urlToFileMap = new HashMap<String, String>();
+        Map<String, String> urlToFileMap = new HashMap<>();
 
         setFilenameForPart(definition.getDefinitionCache().getRootPart(), urlToFileMap, null);
 
@@ -82,7 +82,7 @@ public abstract class AbstractDefinitionExporter<T extends Interface> implements
 
     public StringToStringMap createFilesForExport(String urlPrefix) throws Exception {
         StringToStringMap result = new StringToStringMap();
-        Map<String, String> urlToFileMap = new HashMap<String, String>();
+        Map<String, String> urlToFileMap = new HashMap<>();
 
         if (urlPrefix == null) {
             urlPrefix = "";

--- a/soapui/src/main/java/com/eviware/soapui/impl/support/definition/support/AbstractDefinitionCache.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/support/definition/support/AbstractDefinitionCache.java
@@ -127,7 +127,7 @@ public abstract class AbstractDefinitionCache<T extends AbstractInterface<?>> im
     }
 
     private void initParts() {
-        parts = new ArrayList<InterfaceDefinitionPart>();
+        parts = new ArrayList<>();
 
         List<DefintionPartConfig> partList = definitionCache.getPartList();
         for (DefintionPartConfig part : partList) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/support/definition/support/AbstractDefinitionContext.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/support/definition/support/AbstractDefinitionContext.java
@@ -57,8 +57,8 @@ public abstract class AbstractDefinitionContext<T extends AbstractInterface<?>, 
     private T2 currentLoader;
     private T iface;
 
-    private static Map<String, InterfaceDefinition<?>> definitionCache = new HashMap<String, InterfaceDefinition<?>>();
-    private static Map<String, Integer> urlReferences = new HashMap<String, Integer>();
+    private static Map<String, InterfaceDefinition<?>> definitionCache = new HashMap<>();
+    private static Map<String, Integer> urlReferences = new HashMap<>();
 
     public AbstractDefinitionContext(String url, T iface) {
         this.url = PathUtils.ensureFilePathIsUrl(url);
@@ -316,7 +316,7 @@ public abstract class AbstractDefinitionContext<T extends AbstractInterface<?>, 
         if (this.iface == null && iface != null) {
             if (definition != null) {
                 if (definition.getDefinitionCache().validate()) {
-                    InterfaceConfigDefinitionCache<T> cache = new InterfaceConfigDefinitionCache<T>(iface);
+                    InterfaceConfigDefinitionCache<T> cache = new InterfaceConfigDefinitionCache<>(iface);
                     try {
                         cache.importCache(definition.getDefinitionCache());
                     } catch (Exception e) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/support/definition/support/XmlSchemaBasedInterfaceDefinition.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/support/definition/support/XmlSchemaBasedInterfaceDefinition.java
@@ -52,7 +52,7 @@ public abstract class XmlSchemaBasedInterfaceDefinition<T extends AbstractInterf
     }
 
     public Collection<String> getDefinedNamespaces() throws Exception {
-        Set<String> namespaces = new HashSet<String>();
+        Set<String> namespaces = new HashSet<>();
 
         SchemaTypeSystem schemaTypes = getSchemaTypeSystem();
         if (schemaTypes != null) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/support/http/HttpRequest.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/support/http/HttpRequest.java
@@ -202,7 +202,7 @@ public class HttpRequest extends AbstractHttpRequest<HttpRequestConfig> implemen
     }
 
     public MessagePart[] getRequestParts() {
-        List<MessagePart> result = new ArrayList<MessagePart>();
+        List<MessagePart> result = new ArrayList<>();
 
         for (int c = 0; c < getPropertyCount(); c++) {
             result.add(new ParameterMessagePart(getPropertyAt(c)));
@@ -242,7 +242,7 @@ public class HttpRequest extends AbstractHttpRequest<HttpRequestConfig> implemen
         }
 
         try {
-            WsdlSubmit<HttpRequest> submitter = new WsdlSubmit<HttpRequest>(this, getSubmitListeners(),
+            WsdlSubmit<HttpRequest> submitter = new WsdlSubmit<>(this, getSubmitListeners(),
                     RequestTransportRegistry.getTransport(endpoint, submitContext));
             submitter.submitRequest(submitContext, async);
             return submitter;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wadl/inference/schema/Context.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wadl/inference/schema/Context.java
@@ -52,9 +52,9 @@ public class Context {
         this.system = system;
         this.handler = handler;
         this.cursor = cursor;
-        path = new ArrayList<String>();
-        stack = new ArrayList<List<String>>();
-        attributes = new HashMap<String, String>();
+        path = new ArrayList<>();
+        stack = new ArrayList<>();
+        attributes = new HashMap<>();
     }
 
     /**
@@ -139,7 +139,7 @@ public class Context {
      */
     public void pushPath() {
         stack.add(path);
-        path = new ArrayList<String>();
+        path = new ArrayList<>();
     }
 
     /**

--- a/soapui/src/main/java/com/eviware/soapui/impl/wadl/inference/schema/Schema.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wadl/inference/schema/Schema.java
@@ -56,9 +56,9 @@ public class Schema {
     public Schema(String namespace, SchemaSystem schemaSystem) {
         this.schemaSystem = schemaSystem;
         this.namespace = namespace;
-        prefixes = new HashMap<String, String>();
-        particles = new ArrayList<Particle>();
-        types = new HashMap<String, ComplexType>();
+        prefixes = new HashMap<>();
+        particles = new ArrayList<>();
+        types = new HashMap<>();
         putPrefixForNamespace("xs", Settings.xsdns);
     }
 
@@ -71,9 +71,9 @@ public class Schema {
     public Schema(SchemaConfig xml, SchemaSystem schemaSystem) {
         this.schemaSystem = schemaSystem;
         namespace = xml.getNamespace();
-        prefixes = new HashMap<String, String>();
-        particles = new ArrayList<Particle>();
-        types = new HashMap<String, ComplexType>();
+        prefixes = new HashMap<>();
+        particles = new ArrayList<>();
+        types = new HashMap<>();
         for (MapEntryConfig entry : xml.getPrefixList()) {
             prefixes.put(entry.getKey(), entry.getValue());
         }
@@ -97,7 +97,7 @@ public class Schema {
             mapEntry.setKey(entry.getKey());
             mapEntry.setValue(entry.getValue());
         }
-        List<ParticleConfig> particleList = new ArrayList<ParticleConfig>();
+        List<ParticleConfig> particleList = new ArrayList<>();
         for (Particle item : particles) {
             particleList.add(item.save());
         }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wadl/inference/schema/SchemaSystem.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wadl/inference/schema/SchemaSystem.java
@@ -40,7 +40,7 @@ public class SchemaSystem {
      * Constructs a new SchemaSystem object.
      */
     public SchemaSystem() {
-        schemas = new LinkedHashMap<String, Schema>();
+        schemas = new LinkedHashMap<>();
     }
 
     /**
@@ -49,7 +49,7 @@ public class SchemaSystem {
      * @param xml The XmlObject to which data has previously been saved.
      */
     public SchemaSystem(SchemaSetConfig xml) {
-        schemas = new LinkedHashMap<String, Schema>();
+        schemas = new LinkedHashMap<>();
         for (SchemaConfig item : xml.getSchemaList()) {
             schemas.put(item.getNamespace(), new Schema(item, this));
         }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wadl/inference/schema/content/SequenceContent.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wadl/inference/schema/content/SequenceContent.java
@@ -50,24 +50,24 @@ public class SequenceContent implements Content {
     public SequenceContent(Schema schema, boolean completed) {
         this.schema = schema;
         this.completed = completed;
-        particles = new LinkedHashMap<QName, Particle>(); // LinkedHashMap
+        particles = new LinkedHashMap<>(); // LinkedHashMap
         // preserves order.
-        comesBefore = new HashMap<QName, List<QName>>();
+        comesBefore = new HashMap<>();
     }
 
     public SequenceContent(SequenceContentConfig xml, Schema schema) {
         this.schema = schema;
         completed = xml.getCompleted();
-        particles = new LinkedHashMap<QName, Particle>(); // LinkedHashMap
+        particles = new LinkedHashMap<>(); // LinkedHashMap
         // preserves order.
         for (ParticleConfig particleXml : xml.getParticleList()) {
             Particle p = Particle.Factory.parse(particleXml, schema);
             // TODO: Fix namespace!
             particles.put(p.getName(), p);
         }
-        comesBefore = new HashMap<QName, List<QName>>();
+        comesBefore = new HashMap<>();
         for (ComesBefore item : xml.getComesBeforeList()) {
-            List<QName> others = new ArrayList<QName>();
+            List<QName> others = new ArrayList<>();
             for (QName item2 : item.getOtherList()) {
                 others.add(item2);
             }
@@ -79,7 +79,7 @@ public class SequenceContent implements Content {
     public SequenceContentConfig save() {
         SequenceContentConfig xml = SequenceContentConfig.Factory.newInstance();
         xml.setCompleted(completed);
-        List<ParticleConfig> particleList = new ArrayList<ParticleConfig>();
+        List<ParticleConfig> particleList = new ArrayList<>();
         for (Particle item : particles.values()) {
             particleList.add(item.save());
         }
@@ -99,8 +99,8 @@ public class SequenceContent implements Content {
         XmlCursor cursor = context.getCursor();
 
         // Find element order
-        List<QName> orderSet = new ArrayList<QName>();
-        List<QName> orderList = new ArrayList<QName>();
+        List<QName> orderSet = new ArrayList<>();
+        List<QName> orderList = new ArrayList<>();
         if (!cursor.isEnd()) {
             cursor.push();
             do {
@@ -154,7 +154,7 @@ public class SequenceContent implements Content {
     }
 
     private void fixOrder() {
-        List<QName> order = new ArrayList<QName>();
+        List<QName> order = new ArrayList<>();
         for (QName item : particles.keySet()) {
             int i;
             for (i = order.size(); !canAppend(order.subList(0, i), item); i--) {
@@ -162,7 +162,7 @@ public class SequenceContent implements Content {
             }
             order.add(i, item);
         }
-        LinkedHashMap<QName, Particle> fixedParticles = new LinkedHashMap<QName, Particle>();
+        LinkedHashMap<QName, Particle> fixedParticles = new LinkedHashMap<>();
         for (QName item : order) {
             fixedParticles.put(item, particles.get(item));
         }
@@ -170,7 +170,7 @@ public class SequenceContent implements Content {
     }
 
     private boolean verifyOrder() {
-        List<QName> order = new ArrayList<QName>();
+        List<QName> order = new ArrayList<>();
         order.addAll(particles.keySet());
         for (int i = 1; i < particles.size(); i++) {
             if (!canAppend(order.subList(0, i), order.get(i))) {
@@ -191,7 +191,7 @@ public class SequenceContent implements Content {
     }
 
     private boolean validateOccurances(Context context, List<QName> sequence) throws XmlException {
-        Map<QName, Integer> seen = new HashMap<QName, Integer>();
+        Map<QName, Integer> seen = new HashMap<>();
         for (QName item : particles.keySet()) {
             seen.put(item, 0);
         }
@@ -226,7 +226,7 @@ public class SequenceContent implements Content {
 
     @SuppressWarnings("unchecked")
     private boolean validateOrder(Context context, List<QName> sequence) {
-        List<QName> seen = new ArrayList<QName>();
+        List<QName> seen = new ArrayList<>();
         HashMap<QName, List<QName>> comesBefore = (HashMap<QName, List<QName>>) this.comesBefore.clone();
         for (QName item : sequence) {
             if (!particles.containsKey(item)) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wadl/inference/schema/particles/AttributeParticle.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wadl/inference/schema/particles/AttributeParticle.java
@@ -45,14 +45,14 @@ public class AttributeParticle implements Particle {
         this.schema = schema;
         this.name = name;
         type = Type.Factory.newType(schema);
-        attributes = new HashMap<String, String>();
+        attributes = new HashMap<>();
     }
 
     public AttributeParticle(AttributeParticleConfig xml, Schema schema) {
         this.schema = schema;
         name = xml.getName();
         type = Type.Factory.parse(xml.getType(), schema);
-        attributes = new HashMap<String, String>();
+        attributes = new HashMap<>();
         for (MapEntryConfig entry : xml.getAttributeList()) {
             attributes.put(entry.getKey(), entry.getValue());
         }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wadl/inference/schema/particles/ElementParticle.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wadl/inference/schema/particles/ElementParticle.java
@@ -47,14 +47,14 @@ public class ElementParticle implements Particle {
         this.schema = schema;
         this.name = name;
         type = Type.Factory.newType(schema);
-        attributes = new HashMap<String, String>();
+        attributes = new HashMap<>();
     }
 
     public ElementParticle(ElementParticleConfig xml, Schema schema) {
         this.schema = schema;
         name = xml.getName();
         type = Type.Factory.parse(xml.getType(), schema);
-        attributes = new HashMap<String, String>();
+        attributes = new HashMap<>();
         for (MapEntryConfig entry : xml.getAttributeList()) {
             attributes.put(entry.getKey(), entry.getValue());
         }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wadl/inference/schema/particles/ReferenceParticle.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wadl/inference/schema/particles/ReferenceParticle.java
@@ -45,13 +45,13 @@ public class ReferenceParticle implements Particle {
         this.schema = schema;
         this.reference = reference;
         referenceQName = reference.getName();
-        attributes = new HashMap<String, String>();
+        attributes = new HashMap<>();
     }
 
     public ReferenceParticle(ReferenceParticleConfig xml, Schema schema) {
         this.schema = schema;
         referenceQName = xml.getReference();
-        attributes = new HashMap<String, String>();
+        attributes = new HashMap<>();
         for (MapEntryConfig entry : xml.getAttributeList()) {
             attributes.put(entry.getKey(), entry.getValue());
         }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wadl/inference/schema/types/ComplexType.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wadl/inference/schema/types/ComplexType.java
@@ -59,7 +59,7 @@ public class ComplexType implements Type {
         this.name = name;
         this.completed = completed;
         content = new EmptyContent(schema, completed);
-        attributes = new HashMap<QName, Particle>();
+        attributes = new HashMap<>();
         schema.addType(this);
     }
 
@@ -69,7 +69,7 @@ public class ComplexType implements Type {
         completed = xml.getCompleted();
         mixed = xml.getMixed();
         content = Content.Factory.parse(xml.getContent(), schema);
-        attributes = new HashMap<QName, Particle>();
+        attributes = new HashMap<>();
         for (ParticleConfig item : xml.getAttributeList()) {
             Particle p = Particle.Factory.parse(item, schema);
             attributes.put(new QName("", p.getName().getLocalPart()), p);
@@ -81,7 +81,7 @@ public class ComplexType implements Type {
         xml.setName(name);
         xml.setCompleted(completed);
         xml.setMixed(mixed);
-        List<ParticleConfig> particleList = new ArrayList<ParticleConfig>();
+        List<ParticleConfig> particleList = new ArrayList<>();
         for (Particle item : attributes.values()) {
             particleList.add(item.save());
         }
@@ -101,7 +101,7 @@ public class ComplexType implements Type {
 
     public Type validate(Context context) throws XmlException {
         XmlCursor cursor = context.getCursor();
-        List<QName> seen = new ArrayList<QName>();
+        List<QName> seen = new ArrayList<>();
         cursor.push();
         if (!mixed && isMixed(context)) {
             // TODO: Check with ConflictHandler

--- a/soapui/src/main/java/com/eviware/soapui/impl/wadl/inference/support/InferredSchemaImpl.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wadl/inference/support/InferredSchemaImpl.java
@@ -52,7 +52,7 @@ public class InferredSchemaImpl implements InferredSchema {
     }
 
     public SchemaTypeSystem getSchemaTypeSystem(SchemaTypeSystem sts) {
-        List<XmlObject> schemas = new ArrayList<XmlObject>();
+        List<XmlObject> schemas = new ArrayList<>();
         try {
             for (String namespace : getNamespaces()) {
                 // schemas.add( XmlObject.Factory.parse( getXsdForNamespace(

--- a/soapui/src/main/java/com/eviware/soapui/impl/wadl/inference/support/TypeInferrer.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wadl/inference/support/TypeInferrer.java
@@ -121,7 +121,7 @@ public class TypeInferrer {
     }
 
     private TypeInferrer() {
-        typeTable = new HashMap<XmlAnySimpleType, TypeTree>();
+        typeTable = new HashMap<>();
         TypeTree xmlbool = new TypeTree(XmlBoolean.Factory.newInstance());
         typeTable.put(xmlbool.type, xmlbool);
         TypeTree xmlbool2 = new TypeTree(XmlBoolean.Factory.newInstance());
@@ -202,7 +202,7 @@ public class TypeInferrer {
 
         public TypeTree(XmlAnySimpleType type) {
             this.type = type;
-            children = new ArrayList<TypeTree>();
+            children = new ArrayList<>();
         }
 
         public void addChild(TypeTree type) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wadl/support/WadlValidator.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wadl/support/WadlValidator.java
@@ -53,7 +53,7 @@ public class WadlValidator {
     }
 
     private AssertionError[] assertResponse(RestMessageExchange messageExchange, RestRepresentation.Type type) {
-        List<AssertionError> result = new ArrayList<AssertionError>();
+        List<AssertionError> result = new ArrayList<>();
         QName responseBodyElementName = getResponseBodyElementName(messageExchange);
         RestRequestInterface restRequest = messageExchange.getRestRequest();
         boolean asserted = false;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/AbstractWsdlModelItem.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/AbstractWsdlModelItem.java
@@ -199,7 +199,7 @@ public abstract class AbstractWsdlModelItem<T extends ModelItemConfig>
     }
 
     public List<ExternalDependency> getExternalDependencies() {
-        List<ExternalDependency> result = new ArrayList<ExternalDependency>();
+        List<ExternalDependency> result = new ArrayList<>();
         addExternalDependencies(result);
         return result;
     }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/HttpAttachmentPart.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/HttpAttachmentPart.java
@@ -33,7 +33,7 @@ import java.util.List;
 public final class HttpAttachmentPart extends MessagePart.AttachmentPart {
     public static final String ANONYMOUS_NAME = "<anonymous>";
     private String name;
-    private List<String> contentTypes = new ArrayList<String>();
+    private List<String> contentTypes = new ArrayList<>();
     private Attachment.AttachmentType type;
     private boolean anonymous;
     private SchemaType schemaType;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/InterfaceFactoryRegistry.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/InterfaceFactoryRegistry.java
@@ -27,7 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class InterfaceFactoryRegistry {
-    private static Map<String, InterfaceFactory<?>> factories = new HashMap<String, InterfaceFactory<?>>();
+    private static Map<String, InterfaceFactory<?>> factories = new HashMap<>();
 
     static {
         factories.put(WsdlInterfaceFactory.WSDL_TYPE, new WsdlInterfaceFactory());

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/WsdlInterface.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/WsdlInterface.java
@@ -85,7 +85,7 @@ public class WsdlInterface extends AbstractInterface<WsdlInterfaceConfig> {
     public static final String XML_ACTIONS = "xml";
 
     private final static Logger log = LogManager.getLogger(WsdlInterface.class);
-    private List<WsdlOperation> operations = new ArrayList<WsdlOperation>();
+    private List<WsdlOperation> operations = new ArrayList<>();
     private WsdlProject project;
     private SoapMessageBuilder soapMessageBuilder;
     private WsdlContext wsdlContext;
@@ -413,8 +413,8 @@ public class WsdlInterface extends AbstractInterface<WsdlInterfaceConfig> {
     @SuppressWarnings("unchecked")
     public void transferOperations(Binding binding, boolean createRequests) {
         // prepare for transfer of operations/requests
-        List<BindingOperation> newOperations = new ArrayList<BindingOperation>(binding.getBindingOperations());
-        Map<String, WsdlOperation> oldOperations = new HashMap<String, WsdlOperation>();
+        List<BindingOperation> newOperations = new ArrayList<>(binding.getBindingOperations());
+        Map<String, WsdlOperation> oldOperations = new HashMap<>();
         for (int c = 0; c < operations.size(); c++) {
             oldOperations.put(operations.get(c).getBindingOperationName(), operations.get(c));
         }
@@ -442,7 +442,7 @@ public class WsdlInterface extends AbstractInterface<WsdlInterfaceConfig> {
             String name = i.next();
 
             if (newOperations.size() > 0) {
-                List<String> list = new ArrayList<String>();
+                List<String> list = new ArrayList<>();
                 list.add("none - delete operation");
                 for (int c = 0; c < newOperations.size(); c++) {
                     list.add(newOperations.get(c).getName());
@@ -576,7 +576,7 @@ public class WsdlInterface extends AbstractInterface<WsdlInterfaceConfig> {
     }
 
     public Map<String, Operation> getOperations() {
-        Map<String, Operation> result = new HashMap<String, Operation>();
+        Map<String, Operation> result = new HashMap<>();
         for (Operation operation : operations) {
             result.put(operation.getName(), operation);
         }
@@ -633,7 +633,7 @@ public class WsdlInterface extends AbstractInterface<WsdlInterfaceConfig> {
     }
 
     public List<Operation> getOperationList() {
-        return new ArrayList<Operation>(operations);
+        return new ArrayList<>(operations);
     }
 
     public static class BindingTuple {
@@ -666,7 +666,7 @@ public class WsdlInterface extends AbstractInterface<WsdlInterfaceConfig> {
     }
 
     public List<AbstractWsdlModelItem<?>> getAllMessages() {
-        ArrayList<AbstractWsdlModelItem<?>> list = new ArrayList<AbstractWsdlModelItem<?>>();
+        ArrayList<AbstractWsdlModelItem<?>> list = new ArrayList<>();
         getAllMessages(getProject(), list);
         return list;
     }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/WsdlOperation.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/WsdlOperation.java
@@ -73,7 +73,7 @@ public class WsdlOperation extends AbstractWsdlModelItem<OperationConfig> implem
 
     public final static Logger log = LogManager.getLogger(WsdlOperation.class);
     public static final String ICON_NAME = "/operation.png";
-    private List<WsdlRequest> requests = new ArrayList<WsdlRequest>();
+    private List<WsdlRequest> requests = new ArrayList<>();
     private WsdlInterface iface;
     private ImageIcon oneWayIcon;
 
@@ -404,7 +404,7 @@ public class WsdlOperation extends AbstractWsdlModelItem<OperationConfig> implem
             getConfig().setReceivesAttachments(multipartOutput != null);
             if (multipartOutput != null) {
                 List<MIMEPart> parts = multipartOutput.getMIMEParts();
-                Map<String, Part> partMap = new HashMap<String, Part>();
+                Map<String, Part> partMap = new HashMap<>();
 
                 for (int c = 0; c < parts.size(); c++) {
                     List<MIMEContent> contentParts = WsdlUtils.getExtensiblityElements(parts.get(c)
@@ -439,7 +439,7 @@ public class WsdlOperation extends AbstractWsdlModelItem<OperationConfig> implem
             getConfig().setSendsAttachments(multipartInput != null);
             if (multipartInput != null) {
                 List<MIMEPart> parts = multipartInput.getMIMEParts();
-                Map<String, Part> partMap = new HashMap<String, Part>();
+                Map<String, Part> partMap = new HashMap<>();
 
                 for (int c = 0; c < parts.size(); c++) {
                     List<MIMEContent> contentParts = WsdlUtils.getExtensiblityElements(parts.get(c)
@@ -641,13 +641,13 @@ public class WsdlOperation extends AbstractWsdlModelItem<OperationConfig> implem
     }
 
     public List<Request> getRequestList() {
-        return new ArrayList<Request>(requests);
+        return new ArrayList<>(requests);
     }
 
     public MessagePart[] getDefaultRequestParts() {
         try {
             // init
-            List<MessagePart> result = new ArrayList<MessagePart>();
+            List<MessagePart> result = new ArrayList<>();
             WsdlContext wsdlContext = getInterface().getWsdlContext();
             BindingOperation bindingOperation = findBindingOperation(wsdlContext.getDefinition());
 
@@ -710,7 +710,7 @@ public class WsdlOperation extends AbstractWsdlModelItem<OperationConfig> implem
     public MessagePart[] getDefaultResponseParts() {
         try {
             // init
-            List<MessagePart> result = new ArrayList<MessagePart>();
+            List<MessagePart> result = new ArrayList<>();
             WsdlContext wsdlContext = getInterface().getWsdlContext();
             BindingOperation bindingOperation = findBindingOperation(wsdlContext.getDefinition());
 
@@ -774,7 +774,7 @@ public class WsdlOperation extends AbstractWsdlModelItem<OperationConfig> implem
         BindingOperation bindingOperation = getBindingOperation();
         Map<?, ?> bindingFaults = bindingOperation.getBindingFaults();
 
-        List<FaultPart> result = new ArrayList<FaultPart>();
+        List<FaultPart> result = new ArrayList<>();
         for (Object key : bindingFaults.keySet()) {
             result.add(new WsdlFaultPart((String) key));
         }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/WsdlProject.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/WsdlProject.java
@@ -147,18 +147,18 @@ public class WsdlProject extends AbstractTestPropertyHolderWsdlModelItem<Project
     private static final String XML_FILE_TYPE = "XML Files (*.xml)";
     private static final String XML_EXTENSION = ".xml";
     protected String path;
-    protected List<AbstractInterface<?>> interfaces = new ArrayList<AbstractInterface<?>>();
-    protected List<WsdlTestSuite> testSuites = new ArrayList<WsdlTestSuite>();
-    protected List<WsdlMockService> mockServices = new ArrayList<WsdlMockService>();
-    protected List<RestMockService> restMockServices = new ArrayList<RestMockService>();
-    protected Set<ProjectListener> projectListeners = new HashSet<ProjectListener>();
+    protected List<AbstractInterface<?>> interfaces = new ArrayList<>();
+    protected List<WsdlTestSuite> testSuites = new ArrayList<>();
+    protected List<WsdlMockService> mockServices = new ArrayList<>();
+    protected List<RestMockService> restMockServices = new ArrayList<>();
+    protected Set<ProjectListener> projectListeners = new HashSet<>();
     protected SoapuiProjectDocumentConfig projectDocument;
     protected EndpointStrategy endpointStrategy = new DefaultEndpointStrategy();
     protected long lastModified;
     protected DefaultWssContainer wssContainer;
     protected OAuth2ProfileContainer oAuth2ProfileContainer;
     protected OAuth1ProfileContainer oAuth1ProfileContainer;
-    protected Set<EnvironmentListener> environmentListeners = new HashSet<EnvironmentListener>();
+    protected Set<EnvironmentListener> environmentListeners = new HashSet<>();
     protected ProjectEncryptionStatus encryptionStatus = ProjectEncryptionStatus.NOT_ENCRYPTED;
     protected EndpointSupport endpointSupport;
     private WorkspaceImpl workspace;
@@ -178,7 +178,7 @@ public class WsdlProject extends AbstractTestPropertyHolderWsdlModelItem<Project
     private ImageIcon closedEncyptedIcon;
     private SoapUIScriptEngine afterRunScriptEngine;
     private SoapUIScriptEngine beforeRunScriptEngine;
-    private Set<ProjectRunListener> runListeners = new HashSet<ProjectRunListener>();
+    private Set<ProjectRunListener> runListeners = new HashSet<>();
     private Environment environment;
 
     public WsdlProject() throws XmlException, IOException, SoapUIException {
@@ -1301,11 +1301,11 @@ public class WsdlProject extends AbstractTestPropertyHolderWsdlModelItem<Project
     }
 
     public List<TestSuite> getTestSuiteList() {
-        return new ArrayList<TestSuite>(testSuites);
+        return new ArrayList<>(testSuites);
     }
 
     public List<WsdlMockService> getMockServiceList() {
-        return new ArrayList<WsdlMockService>(mockServices);
+        return new ArrayList<>(mockServices);
     }
 
     public List<RestMockService> getRestMockServiceList() {
@@ -1313,11 +1313,11 @@ public class WsdlProject extends AbstractTestPropertyHolderWsdlModelItem<Project
     }
 
     public List<Interface> getInterfaceList() {
-        return new ArrayList<Interface>(interfaces);
+        return new ArrayList<>(interfaces);
     }
 
     public Map<String, Interface> getInterfaces() {
-        Map<String, Interface> result = new HashMap<String, Interface>();
+        Map<String, Interface> result = new HashMap<>();
         for (Interface iface : interfaces) {
             result.put(iface.getName(), iface);
         }
@@ -1326,7 +1326,7 @@ public class WsdlProject extends AbstractTestPropertyHolderWsdlModelItem<Project
     }
 
     public Map<String, TestSuite> getTestSuites() {
-        Map<String, TestSuite> result = new HashMap<String, TestSuite>();
+        Map<String, TestSuite> result = new HashMap<>();
         for (TestSuite iface : testSuites) {
             result.put(iface.getName(), iface);
         }
@@ -1335,7 +1335,7 @@ public class WsdlProject extends AbstractTestPropertyHolderWsdlModelItem<Project
     }
 
     public Map<String, MockService> getMockServices() {
-        Map<String, MockService> result = new HashMap<String, MockService>();
+        Map<String, MockService> result = new HashMap<>();
         for (MockService mockService : mockServices) {
             result.put(mockService.getName(), mockService);
         }
@@ -1458,7 +1458,7 @@ public class WsdlProject extends AbstractTestPropertyHolderWsdlModelItem<Project
     }
 
     public List<? extends ModelItem> getChildren() {
-        ArrayList<ModelItem> list = new ArrayList<ModelItem>();
+        ArrayList<ModelItem> list = new ArrayList<>();
         list.addAll(getInterfaceList());
         list.addAll(getTestSuiteList());
         list.addAll(getMockServiceList());
@@ -1572,7 +1572,7 @@ public class WsdlProject extends AbstractTestPropertyHolderWsdlModelItem<Project
     }
 
     public PropertyExpansion[] getPropertyExpansions() {
-        List<PropertyExpansion> result = new ArrayList<PropertyExpansion>();
+        List<PropertyExpansion> result = new ArrayList<>();
 
         result.addAll(Arrays.asList(wssContainer.getPropertyExpansions()));
         result.addAll(Arrays.asList(oAuth2ProfileContainer.getPropertyExpansions()));
@@ -1679,7 +1679,7 @@ public class WsdlProject extends AbstractTestPropertyHolderWsdlModelItem<Project
     }
 
     public List<AbstractInterface<?>> getInterfaces(String type) {
-        ArrayList<AbstractInterface<?>> result = new ArrayList<AbstractInterface<?>>();
+        ArrayList<AbstractInterface<?>> result = new ArrayList<>();
 
         for (AbstractInterface<?> iface : interfaces) {
             if (iface.getType().equals(type)) {
@@ -1727,7 +1727,7 @@ public class WsdlProject extends AbstractTestPropertyHolderWsdlModelItem<Project
             for (int cnt2 = 0; cnt2 < config.getTestCaseList().size(); cnt2++) {
                 TestCaseConfig newTestCase = config.getTestCaseList().get(cnt2);
                 TestCaseConfig importTestCaseConfig = newTestSuiteConfig.getTestSuite().getTestCaseList().get(cnt2);
-                LinkedHashMap<String, String> oldNewIds = new LinkedHashMap<String, String>();
+                LinkedHashMap<String, String> oldNewIds = new LinkedHashMap<>();
                 for (int cnt = 0; cnt < importTestCaseConfig.getTestStepList().size(); cnt++) {
                     oldNewIds.put(importTestCaseConfig.getTestStepList().get(cnt).getId(), newTestCase.getTestStepList()
                             .get(cnt).getId());

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/WsdlRequest.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/WsdlRequest.java
@@ -213,7 +213,7 @@ public class WsdlRequest extends AbstractHttpRequest<WsdlRequestConfig> implemen
         }
 
         try {
-            WsdlSubmit<WsdlRequest> submitter = new WsdlSubmit<WsdlRequest>(this, getSubmitListeners(),
+            WsdlSubmit<WsdlRequest> submitter = new WsdlSubmit<>(this, getSubmitListeners(),
                     RequestTransportRegistry.getTransport(endpoint, submitContext));
             submitter.submitRequest(submitContext, async);
             return submitter;
@@ -265,7 +265,7 @@ public class WsdlRequest extends AbstractHttpRequest<WsdlRequestConfig> implemen
                         false, isMtomEnabled());
             } catch (Exception e) {
                 log.warn(e.toString());
-                definedAttachmentParts = new ArrayList<HttpAttachmentPart>();
+                definedAttachmentParts = new ArrayList<>();
             } finally {
                 UISupport.resetCursor();
             }
@@ -359,7 +359,7 @@ public class WsdlRequest extends AbstractHttpRequest<WsdlRequestConfig> implemen
 
     public MessagePart[] getRequestParts() {
         try {
-            List<MessagePart> result = new ArrayList<MessagePart>();
+            List<MessagePart> result = new ArrayList<>();
             result.addAll(Arrays.asList(getOperation().getDefaultRequestParts()));
             result.addAll(Arrays.asList(getDefinedAttachmentParts()));
 
@@ -372,7 +372,7 @@ public class WsdlRequest extends AbstractHttpRequest<WsdlRequestConfig> implemen
 
     public MessagePart[] getResponseParts() {
         try {
-            List<MessagePart> result = new ArrayList<MessagePart>();
+            List<MessagePart> result = new ArrayList<>();
             result.addAll(Arrays.asList(getOperation().getDefaultResponseParts()));
 
             if (getResponse() != null) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/WsdlTestSuite.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/WsdlTestSuite.java
@@ -68,9 +68,9 @@ public class WsdlTestSuite extends AbstractTestPropertyHolderWsdlModelItem<TestS
     public static final String ICON_NAME = "/test_suite.png";
 
     private final WsdlProject project;
-    private List<WsdlTestCase> testCases = new ArrayList<WsdlTestCase>();
-    private Set<TestSuiteListener> testSuiteListeners = new HashSet<TestSuiteListener>();
-    private Set<TestSuiteRunListener> testSuiteRunListeners = new HashSet<TestSuiteRunListener>();
+    private List<WsdlTestCase> testCases = new ArrayList<>();
+    private Set<TestSuiteListener> testSuiteListeners = new HashSet<>();
+    private Set<TestSuiteRunListener> testSuiteRunListeners = new HashSet<>();
     private SoapUIScriptEngine setupScriptEngine;
     private SoapUIScriptEngine tearDownScriptEngine;
 
@@ -342,7 +342,7 @@ public class WsdlTestSuite extends AbstractTestPropertyHolderWsdlModelItem<TestS
     }
 
     public List<TestCase> getTestCaseList() {
-        List<TestCase> result = new ArrayList<TestCase>();
+        List<TestCase> result = new ArrayList<>();
         for (WsdlTestCase testCase : testCases) {
             result.add(testCase);
         }
@@ -351,7 +351,7 @@ public class WsdlTestSuite extends AbstractTestPropertyHolderWsdlModelItem<TestS
     }
 
     public Map<String, TestCase> getTestCases() {
-        Map<String, TestCase> result = new HashMap<String, TestCase>();
+        Map<String, TestCase> result = new HashMap<>();
         for (TestCase testCase : testCases) {
             result.put(testCase.getName(), testCase);
         }
@@ -617,7 +617,7 @@ public class WsdlTestSuite extends AbstractTestPropertyHolderWsdlModelItem<TestS
 			 * Create tarnsition table ( old id , new id ) and use it to replace
 			 * all old ids in new imported test case.
 			 */
-            LinkedHashMap<String, String> oldNewIds = new LinkedHashMap<String, String>();
+            LinkedHashMap<String, String> oldNewIds = new LinkedHashMap<>();
             for (int cnt = 0; cnt < importTestCaseConfig.getTestStepList().size(); cnt++) {
                 oldNewIds.put(importTestCaseConfig.getTestStepList().get(cnt).getId(), newTestCase.getTestStepList()
                         .get(cnt).getId());

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/AddJMSEndpointAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/AddJMSEndpointAction.java
@@ -100,7 +100,7 @@ public class AddJMSEndpointAction extends AbstractSoapUIAction<AbstractInterface
 
     private String[] getSessionOptions(AbstractInterface<?> iface, String hermesConfigPath) {
 
-        List<Hermes> hermesList = new ArrayList<Hermes>();
+        List<Hermes> hermesList = new ArrayList<>();
         try {
             Context ctx = getHermesContext(iface, hermesConfigPath);
             if (ctx != null) {
@@ -116,7 +116,7 @@ public class AddJMSEndpointAction extends AbstractSoapUIAction<AbstractInterface
             SoapUI.logError(e);
             SoapUI.log.warn("no HermesJMS context!");
         }
-        List<String> hermesSessionList = new ArrayList<String>();
+        List<String> hermesSessionList = new ArrayList<>();
         for (Hermes h : hermesList) {
             if (!h.getSessionConfig().getId().equals("<new>")) {
                 hermesSessionList.add(h.getSessionConfig().getId());
@@ -154,7 +154,7 @@ public class AddJMSEndpointAction extends AbstractSoapUIAction<AbstractInterface
     }
 
     private void updateDestinations(Hermes hermes) {
-        destinationNameList = new ArrayList<Destination>();
+        destinationNameList = new ArrayList<>();
         destinationNameList.add(new Destination(JMSEndpoint.JMS_EMPTY_DESTIONATION, Domain.UNKNOWN));
         extractDestinations(hermes, destinationNameList);
         mainForm.setOptions(SEND, destinationNameList.toArray());

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/AddJMSEndpointAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/AddJMSEndpointAction.java
@@ -162,7 +162,7 @@ public class AddJMSEndpointAction extends AbstractSoapUIAction<AbstractInterface
     }
 
     private Context getHermesContext(AbstractInterface<?> iface, String hermesConfigPath)
-            throws MalformedURLException, NamingException, IOException {
+            throws NamingException, IOException {
         WsdlProject project = iface.getProject();
         HermesUtils.flushHermesCache();
         Context ctx = HermesUtils.hermesContext(project, hermesConfigPath);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/CloneInterfaceAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/CloneInterfaceAction.java
@@ -43,7 +43,7 @@ public class CloneInterfaceAction extends AbstractSoapUIAction<WsdlInterface> {
         WorkspaceImpl workspace = iface.getProject().getWorkspace();
         String[] names = ModelSupport.getNames(workspace.getOpenProjectList(), new String[]{"<Create New>"});
 
-        List<String> asList = new ArrayList<String>(Arrays.asList(names));
+        List<String> asList = new ArrayList<>(Arrays.asList(names));
         asList.remove(iface.getProject().getName());
 
         String targetProjectName = UISupport.prompt("Select target Project for cloned Interface", "Clone Interface",

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/CreateWsdlDocumentationAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/CreateWsdlDocumentationAction.java
@@ -104,7 +104,7 @@ public class CreateWsdlDocumentationAction extends AbstractSoapUIAction<WsdlInte
     }
 
     protected static void initTransformers() throws Exception {
-        transformers = new HashMap<String, Transformer>();
+        transformers = new HashMap<>();
         TransformerFactory xformFactory = TransformerFactory.newInstance();
 
         Transformer transformer = xformFactory.newTransformer(new StreamSource(SoapUI.class

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/UpdateInterfaceAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/UpdateInterfaceAction.java
@@ -141,7 +141,7 @@ public class UpdateInterfaceAction extends AbstractSoapUIAction<WsdlInterface> {
             boolean keepExisting = dialog.getBooleanValue(Form.KEEP_EXISTING);
             boolean keepHeaders = dialog.getBooleanValue(Form.KEEP_HEADERS);
 
-            List<ModelItem> updated = new ArrayList<ModelItem>();
+            List<ModelItem> updated = new ArrayList<>();
 
             updated.addAll(recreateRequests(iface, buildOptional, createBackups, keepExisting, keepHeaders));
 
@@ -167,7 +167,7 @@ public class UpdateInterfaceAction extends AbstractSoapUIAction<WsdlInterface> {
                                                  boolean keepExisting, boolean keepHeaders) {
         int count = 0;
 
-        List<Request> result = new ArrayList<Request>();
+        List<Request> result = new ArrayList<>();
 
         // first check operations
         for (int c = 0; c < iface.getOperationCount(); c++) {
@@ -208,7 +208,7 @@ public class UpdateInterfaceAction extends AbstractSoapUIAction<WsdlInterface> {
                                                                  boolean createBackups, boolean keepExisting, boolean keepHeaders) {
         int count = 0;
 
-        List<WsdlTestRequestStep> result = new ArrayList<WsdlTestRequestStep>();
+        List<WsdlTestRequestStep> result = new ArrayList<>();
 
         // now check testsuites..
         for (TestSuite testSuite : iface.getProject().getTestSuiteList()) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/gsoap/GSoapAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/gsoap/GSoapAction.java
@@ -201,7 +201,7 @@ public class GSoapAction extends AbstractToolsAction<Interface> {
             return;
         }
 
-        List<ProcessBuilder> builders = new ArrayList<ProcessBuilder>();
+        List<ProcessBuilder> builders = new ArrayList<>();
 
         if (values.getBoolean(WSDL2H)) {
             ProcessBuilder wsdl2hBuilder = new ProcessBuilder();

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/soapui/LoadTestRunnerAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/soapui/LoadTestRunnerAction.java
@@ -194,7 +194,7 @@ public class LoadTestRunnerAction extends AbstractToolsAction<WsdlProject> {
 
     protected StringToStringMap initValues(WsdlProject modelItem, Object param) {
         if (modelItem != null && mainForm != null) {
-            List<String> endpoints = new ArrayList<String>();
+            List<String> endpoints = new ArrayList<>();
 
             for (Interface iface : modelItem.getInterfaceList()) {
                 for (String endpoint : iface.getEndpoints()) {
@@ -346,8 +346,8 @@ public class LoadTestRunnerAction extends AbstractToolsAction<WsdlProject> {
 
         updating = true;
 
-        List<String> testCases = new ArrayList<String>();
-        List<String> loadTests = new ArrayList<String>();
+        List<String> testCases = new ArrayList<>();
+        List<String> loadTests = new ArrayList<>();
 
         TestSuite ts = getModelItem().getTestSuiteByName(mainForm.getComponentValue(TESTSUITE));
         String testCaseName = mainForm.getComponentValue(TESTCASE);
@@ -404,7 +404,7 @@ public class LoadTestRunnerAction extends AbstractToolsAction<WsdlProject> {
     }
 
     private void addPropertyArguments(ArgumentBuilder builder) {
-        List<String> propertyArguments = new ArrayList<String>();
+        List<String> propertyArguments = new ArrayList<>();
 
         addProperties(propertyArguments, GLOBALPROPERTIES, "-G");
         addProperties(propertyArguments, SYSTEMPROPERTIES, "-D");

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/soapui/SecurityTestRunnerAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/soapui/SecurityTestRunnerAction.java
@@ -90,7 +90,7 @@ public class SecurityTestRunnerAction extends AbstractToolsAction<WsdlProject> {
                 new XFormFieldListener() {
 
                     public void valueChanged(XFormField sourceField, String newValue, String oldValue) {
-                        List<String> testCases = new ArrayList<String>();
+                        List<String> testCases = new ArrayList<>();
                         String tc = mainForm.getComponentValue(TESTCASE);
 
                         if (newValue.equals(ALL_VALUE)) {
@@ -120,7 +120,7 @@ public class SecurityTestRunnerAction extends AbstractToolsAction<WsdlProject> {
         mainForm.addComboBox(TESTCASE, new String[]{}, "TestCase").addFormFieldListener(new XFormFieldListener() {
 
             public void valueChanged(XFormField sourceField, String newValue, String oldValue) {
-                List<String> securityTests = new ArrayList<String>();
+                List<String> securityTests = new ArrayList<>();
                 String st = mainForm.getComponentValue(SECURITY_TEST_NAME);
 
                 if (newValue.equals(ALL_VALUE)) {
@@ -178,7 +178,7 @@ public class SecurityTestRunnerAction extends AbstractToolsAction<WsdlProject> {
 
     protected StringToStringMap initValues(WsdlProject modelItem, Object param) {
         if (modelItem != null && mainForm != null) {
-            List<String> endpoints = new ArrayList<String>();
+            List<String> endpoints = new ArrayList<>();
 
             for (Interface iface : modelItem.getInterfaceList()) {
                 for (String endpoint : iface.getEndpoints()) {
@@ -200,7 +200,7 @@ public class SecurityTestRunnerAction extends AbstractToolsAction<WsdlProject> {
 
             mainForm.setOptions(TESTSUITE, ModelSupport.getNames(new String[]{ALL_VALUE}, testSuites));
 
-            List<String> testCases = new ArrayList<String>();
+            List<String> testCases = new ArrayList<>();
 
             for (TestSuite testSuite : testSuites) {
                 for (TestCase testCase : testSuite.getTestCaseList()) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/soapui/TestRunnerAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/soapui/TestRunnerAction.java
@@ -123,7 +123,7 @@ public class TestRunnerAction extends AbstractToolsAction<WsdlProject> {
                 new XFormFieldListener() {
 
                     public void valueChanged(XFormField sourceField, String newValue, String oldValue) {
-                        List<String> testCases = new ArrayList<String>();
+                        List<String> testCases = new ArrayList<>();
                         String tc = mainForm.getComponentValue(TESTCASE);
 
                         if (newValue.equals(ALL_VALUE)) {
@@ -230,7 +230,7 @@ public class TestRunnerAction extends AbstractToolsAction<WsdlProject> {
 
     protected StringToStringMap initValues(WsdlProject modelItem, Object param) {
         if (modelItem != null && mainForm != null) {
-            List<String> endpoints = new ArrayList<String>();
+            List<String> endpoints = new ArrayList<>();
 
             for (Interface iface : modelItem.getInterfaceList()) {
                 for (String endpoint : iface.getEndpoints()) {
@@ -253,7 +253,7 @@ public class TestRunnerAction extends AbstractToolsAction<WsdlProject> {
 
             mainForm.setOptions(TESTSUITE, ModelSupport.getNames(new String[]{ALL_VALUE}, testSuites));
 
-            List<String> testCases = new ArrayList<String>();
+            List<String> testCases = new ArrayList<>();
 
             for (TestSuite testSuite : testSuites) {
                 for (TestCase testCase : testSuite.getTestCaseList()) {
@@ -386,7 +386,7 @@ public class TestRunnerAction extends AbstractToolsAction<WsdlProject> {
     }
 
     protected void addPropertyArguments(ArgumentBuilder builder) {
-        List<String> propertyArguments = new ArrayList<String>();
+        List<String> propertyArguments = new ArrayList<>();
 
         addProperties(propertyArguments, GLOBALPROPERTIES, "-G");
         addProperties(propertyArguments, SYSTEMPROPERTIES, "-D");

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/support/ArgumentBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/support/ArgumentBuilder.java
@@ -33,11 +33,11 @@ import java.util.Map;
 public class ArgumentBuilder {
     private static final String SHADOW = "XXXXXX";
     private final StringToStringMap values;
-    private List<String> args = new ArrayList<String>();
+    private List<String> args = new ArrayList<>();
     /**
      * List of arguments that needs to be shadowed.
      */
-    private List<String> argsToShadow = new ArrayList<String>();
+    private List<String> argsToShadow = new ArrayList<>();
     private boolean isUnix;
 
     public ArgumentBuilder(StringToStringMap values) {
@@ -56,13 +56,13 @@ public class ArgumentBuilder {
                 buf.append(escapeUnixArg(args.get(c)));
             }
 
-            ArrayList<String> result = new ArrayList<String>();
+            ArrayList<String> result = new ArrayList<>();
             result.add(args.get(0));
             result.add(args.get(1));
             result.add(buf.toString());
             return result;
         } else {
-            return new ArrayList<String>(args);
+            return new ArrayList<>(args);
         }
     }
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/support/NamespaceTable.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/support/NamespaceTable.java
@@ -81,7 +81,7 @@ public class NamespaceTable extends AbstractSwingXFormField<JPanel> {
     }
 
     private class NamespaceTableModel extends AbstractTableModel {
-        private List<String> namespaces = new ArrayList<String>();
+        private List<String> namespaces = new ArrayList<>();
         private List<String> packages;
 
         public NamespaceTableModel() {
@@ -93,7 +93,7 @@ public class NamespaceTable extends AbstractSwingXFormField<JPanel> {
                 SoapUI.logError(e);
             }
 
-            packages = new ArrayList<String>(Arrays.asList(new String[namespaces.size()]));
+            packages = new ArrayList<>(Arrays.asList(new String[namespaces.size()]));
         }
 
         public void setMappings(StringToStringMap mapping) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/support/ProcessDialog.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/support/ProcessDialog.java
@@ -58,7 +58,7 @@ public class ProcessDialog extends JDialog implements RunnerContext {
     private final static Logger log = LogManager.getLogger("toolLogger");
 
     public ProcessDialog(String title, String description, boolean showLog, boolean allowCancel)
-            throws HeadlessException {
+    {
         super(UISupport.getMainFrame());
         setTitle(title);
         setModal(true);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/support/SecurityTestRunnerAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/support/SecurityTestRunnerAction.java
@@ -76,7 +76,7 @@ public class SecurityTestRunnerAction extends TestRunnerAction {
 
     protected StringToStringMap initValues(WsdlProject modelItem, Object param) {
         if (modelItem != null && mainForm != null) {
-            List<String> endpoints = new ArrayList<String>();
+            List<String> endpoints = new ArrayList<>();
 
             for (Interface iface : modelItem.getInterfaceList()) {
                 for (String endpoint : iface.getEndpoints()) {
@@ -99,7 +99,7 @@ public class SecurityTestRunnerAction extends TestRunnerAction {
 
             mainForm.setOptions(TESTSUITE, ModelSupport.getNames(new String[]{ALL_VALUE}, testSuites));
 
-            List<String> testCases = new ArrayList<String>();
+            List<String> testCases = new ArrayList<>();
 
             for (TestSuite testSuite : testSuites) {
                 for (TestCase testCase : testSuite.getTestCaseList()) {
@@ -112,7 +112,7 @@ public class SecurityTestRunnerAction extends TestRunnerAction {
             testCases.add(0, ALL_VALUE);
             mainForm.setOptions(TESTCASE, testCases.toArray());
 
-            List<String> securityTests = new ArrayList<String>();
+            List<String> securityTests = new ArrayList<>();
 
             for (TestSuite testSuite : testSuites) {
                 for (TestCase testCase : testSuite.getTestCaseList()) {
@@ -158,7 +158,7 @@ public class SecurityTestRunnerAction extends TestRunnerAction {
                 new XFormFieldListener() {
 
                     public void valueChanged(XFormField sourceField, String newValue, String oldValue) {
-                        List<String> testCases = new ArrayList<String>();
+                        List<String> testCases = new ArrayList<>();
                         String tc = mainForm.getComponentValue(TESTCASE);
 
                         if (newValue.equals(ALL_VALUE)) {
@@ -189,7 +189,7 @@ public class SecurityTestRunnerAction extends TestRunnerAction {
                 new XFormFieldListener() {
 
                     public void valueChanged(XFormField sourceField, String newValue, String oldValue) {
-                        List<String> securityTests = new ArrayList<String>();
+                        List<String> securityTests = new ArrayList<>();
                         String st = mainForm.getComponentValue(SECURITYTEST);
 
                         if (newValue.equals(ALL_VALUE)) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/support/ShowConfigFileAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/support/ShowConfigFileAction.java
@@ -64,7 +64,7 @@ public abstract class ShowConfigFileAction extends AbstractAction {
     public class ContentDialog extends JDialog {
         private JTextArea contentArea;
 
-        public ContentDialog(String title, String description) throws HeadlessException {
+        public ContentDialog(String title, String description) {
             super(UISupport.getMainFrame());
             setTitle(title);
             setModal(true);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/tcpmon/TcpMonAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/iface/tools/tcpmon/TcpMonAction.java
@@ -83,7 +83,7 @@ public class TcpMonAction extends AbstractToolsAction<WsdlInterface> {
 
     protected StringToStringMap initValues(WsdlInterface modelItem, Object param) {
         if (modelItem != null) {
-            List<String> endpoints = new ArrayList<String>(Arrays.asList(modelItem.getEndpoints()));
+            List<String> endpoints = new ArrayList<>(Arrays.asList(modelItem.getEndpoints()));
             endpoints.add(0, null);
             mainForm.setOptions(ENDPOINT, endpoints.toArray());
         } else if (mainForm != null) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/mockservice/AddNewMockOperationAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/mockservice/AddNewMockOperationAction.java
@@ -44,7 +44,7 @@ public class AddNewMockOperationAction extends AbstractSoapUIAction<WsdlMockServ
     }
 
     public void perform(WsdlMockService mockService, Object param) {
-        List<OperationWrapper> operations = new ArrayList<OperationWrapper>();
+        List<OperationWrapper> operations = new ArrayList<>();
 
         WsdlProject project = mockService.getProject();
         List<AbstractInterface<?>> interfaces = project.getInterfaces(WsdlInterfaceFactory.WSDL_TYPE);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/mockservice/CloneMockServiceAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/mockservice/CloneMockServiceAction.java
@@ -161,7 +161,7 @@ public class CloneMockServiceAction extends AbstractSoapUIAction<WsdlMockService
     }
 
     private Set<WsdlInterface> getRequiredInterfaces(WsdlMockService mockService, WsdlProject targetProject) {
-        Set<WsdlInterface> requiredInterfaces = new HashSet<WsdlInterface>();
+        Set<WsdlInterface> requiredInterfaces = new HashSet<>();
 
         for (int i = 0; i < mockService.getMockOperationCount(); i++) {
             WsdlOperation operation = mockService.getMockOperationAt(i).getOperation();
@@ -171,7 +171,7 @@ public class CloneMockServiceAction extends AbstractSoapUIAction<WsdlMockService
         }
 
         if (requiredInterfaces.size() > 0 && targetProject.getInterfaceCount() > 0) {
-            Map<String, WsdlInterface> bindings = new HashMap<String, WsdlInterface>();
+            Map<String, WsdlInterface> bindings = new HashMap<>();
             for (WsdlInterface iface : requiredInterfaces) {
                 bindings.put(iface.getTechnicalId(), iface);
             }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/request/AbstractAddRequestToTestCaseAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/request/AbstractAddRequestToTestCaseAction.java
@@ -50,7 +50,7 @@ public abstract class AbstractAddRequestToTestCaseAction<T extends AbstractHttpR
 
         Project targetProject = testCase.getTestSuite().getProject();
         if (targetProject != source.getOperation().getInterface().getProject()) {
-            HashSet<Interface> requiredInterfaces = new HashSet<Interface>();
+            HashSet<Interface> requiredInterfaces = new HashSet<>();
             requiredInterfaces.add(source.getOperation().getInterface());
 
             if (!DragAndDropSupport

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/support/AbstractAddToTestCaseAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/support/AbstractAddToTestCaseAction.java
@@ -40,9 +40,9 @@ public abstract class AbstractAddToTestCaseAction<T extends ModelItem> extends A
     }
 
     public static WsdlTestCase getTargetTestCase(WsdlProject project) {
-        List<WsdlTestCase> testCases = new ArrayList<WsdlTestCase>();
-        List<WsdlTestSuite> testSuites = new ArrayList<WsdlTestSuite>();
-        List<String> testCaseNames = new ArrayList<String>();
+        List<WsdlTestCase> testCases = new ArrayList<>();
+        List<WsdlTestSuite> testSuites = new ArrayList<>();
+        List<String> testCaseNames = new ArrayList<>();
         WsdlTestCase testCase;
 
         if (project.getTestSuiteCount() == 0) {
@@ -65,7 +65,7 @@ public abstract class AbstractAddToTestCaseAction<T extends ModelItem> extends A
         }
 
         if (testCases.size() == 0) {
-            List<String> testSuiteNames = new ArrayList<String>();
+            List<String> testSuiteNames = new ArrayList<>();
 
             for (int c = 0; c < project.getTestSuiteCount(); c++) {
                 TestSuite testSuite = project.getTestSuiteAt(c);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/testcase/CloneTestCaseAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/testcase/CloneTestCaseAction.java
@@ -122,7 +122,7 @@ public class CloneTestCaseAction extends AbstractSoapUIAction<WsdlTestCase> {
 
             WsdlProject project = testCase.getTestSuite().getProject();
             WsdlTestSuite targetTestSuite = null;
-            Set<Interface> requiredInterfaces = new HashSet<Interface>();
+            Set<Interface> requiredInterfaces = new HashSet<>();
 
             // to another project project?
             if (!targetProjectName.equals(project.getName())) {
@@ -151,7 +151,7 @@ public class CloneTestCaseAction extends AbstractSoapUIAction<WsdlTestCase> {
                 }
 
                 if (requiredInterfaces.size() > 0 && project.getInterfaceCount() > 0) {
-                    Map<String, Interface> bindings = new HashMap<String, Interface>();
+                    Map<String, Interface> bindings = new HashMap<>();
                     for (Interface iface : requiredInterfaces) {
                         bindings.put(iface.getTechnicalId(), iface);
                     }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/testcase/WsdlTestCaseAddStepSoapUIActionGroup.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/testcase/WsdlTestCaseAddStepSoapUIActionGroup.java
@@ -36,7 +36,7 @@ public class WsdlTestCaseAddStepSoapUIActionGroup extends DefaultSoapUIActionGro
     }
 
     public SoapUIActionMappingList<WsdlTestCase> getActionMappings(WsdlTestCase modelItem) {
-        SoapUIActionMappingList<WsdlTestCase> actions = new SoapUIActionMappingList<WsdlTestCase>();
+        SoapUIActionMappingList<WsdlTestCase> actions = new SoapUIActionMappingList<>();
 
         WsdlTestStepRegistry registry = WsdlTestStepRegistry.getInstance();
         WsdlTestStepFactory[] factories = (WsdlTestStepFactory[]) registry.getFactories();
@@ -44,7 +44,7 @@ public class WsdlTestCaseAddStepSoapUIActionGroup extends DefaultSoapUIActionGro
         for (int c = 0; c < factories.length; c++) {
             WsdlTestStepFactory factory = factories[c];
             if (factory.canCreate()) {
-                DefaultActionMapping<WsdlTestCase> actionMapping = new DefaultActionMapping<WsdlTestCase>(
+                DefaultActionMapping<WsdlTestCase> actionMapping = new DefaultActionMapping<>(
                         AddWsdlTestStepAction.SOAPUI_ACTION_ID, null, factory.getTestStepIconPath(), false, factory);
 
                 actionMapping.setName(factory.getTestStepName());

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/teststep/CloneTestStepAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/teststep/CloneTestStepAction.java
@@ -127,7 +127,7 @@ public class CloneTestStepAction extends AbstractSoapUIAction<WsdlTestStep> {
             WsdlProject project = testStep.getTestCase().getTestSuite().getProject();
             WsdlTestSuite targetTestSuite = null;
             WsdlTestCase targetTestCase = null;
-            Set<Interface> requiredInterfaces = new HashSet<Interface>();
+            Set<Interface> requiredInterfaces = new HashSet<>();
 
             // to another project project?
             if (!targetProjectName.equals(project.getName())) {
@@ -153,7 +153,7 @@ public class CloneTestStepAction extends AbstractSoapUIAction<WsdlTestStep> {
                 }
 
                 if (requiredInterfaces.size() > 0 && project.getInterfaceCount() > 0) {
-                    Map<String, Interface> bindings = new HashMap<String, Interface>();
+                    Map<String, Interface> bindings = new HashMap<>();
                     for (Interface iface : requiredInterfaces) {
                         bindings.put(iface.getTechnicalId(), iface);
                     }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/teststep/WsdlTestStepInsertStepSoapUIActionGroup.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/teststep/WsdlTestStepInsertStepSoapUIActionGroup.java
@@ -35,7 +35,7 @@ public class WsdlTestStepInsertStepSoapUIActionGroup extends DefaultSoapUIAction
     }
 
     public SoapUIActionMappingList<WsdlTestStep> getActionMappings(WsdlTestStep modelItem) {
-        SoapUIActionMappingList<WsdlTestStep> actions = new SoapUIActionMappingList<WsdlTestStep>();
+        SoapUIActionMappingList<WsdlTestStep> actions = new SoapUIActionMappingList<>();
 
         WsdlTestStepRegistry registry = WsdlTestStepRegistry.getInstance();
         WsdlTestStepFactory[] factories = (WsdlTestStepFactory[]) registry.getFactories();
@@ -43,7 +43,7 @@ public class WsdlTestStepInsertStepSoapUIActionGroup extends DefaultSoapUIAction
         for (int c = 0; c < factories.length; c++) {
             WsdlTestStepFactory factory = factories[c];
             if (factory.canCreate()) {
-                DefaultActionMapping<WsdlTestStep> actionMapping = new DefaultActionMapping<WsdlTestStep>(
+                DefaultActionMapping<WsdlTestStep> actionMapping = new DefaultActionMapping<>(
                         InsertWsdlTestStepAction.SOAPUI_ACTION_ID, null, factory.getTestStepIconPath(), false, factory);
 
                 actionMapping.setName(factory.getTestStepName());

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/teststep/WsdlTestStepSoapUIActionGroup.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/teststep/WsdlTestStepSoapUIActionGroup.java
@@ -47,7 +47,7 @@ public class WsdlTestStepSoapUIActionGroup extends DefaultSoapUIActionGroup<Wsdl
 
             // add open-editor action
             if (modelItem.hasEditor()) {
-                DefaultActionMapping<WsdlTestStep> actionMapping = new DefaultActionMapping<WsdlTestStep>(
+                DefaultActionMapping<WsdlTestStep> actionMapping = new DefaultActionMapping<>(
                         ShowDesktopPanelAction.SOAPUI_ACTION_ID, "ENTER", null, true, null);
 
                 actionMapping.setName("Open Editor");
@@ -57,7 +57,7 @@ public class WsdlTestStepSoapUIActionGroup extends DefaultSoapUIActionGroup<Wsdl
                 insertIndex++;
             }
 
-            toggleDisabledActionMapping = new DefaultActionMapping<WsdlTestStep>(
+            toggleDisabledActionMapping = new DefaultActionMapping<>(
                     ToggleDisableTestStepAction.SOAPUI_ACTION_ID, null, null, false, null);
 
             actions.add(insertIndex, toggleDisabledActionMapping);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/testsuite/CloneTestSuiteAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/actions/testsuite/CloneTestSuiteAction.java
@@ -189,7 +189,7 @@ public class CloneTestSuiteAction extends AbstractSoapUIAction<WsdlTestSuite> {
     }
 
     public static Set<Interface> getRequiredInterfaces(WsdlTestSuite testSuite, WsdlProject targetProject) {
-        Set<Interface> requiredInterfaces = new HashSet<Interface>();
+        Set<Interface> requiredInterfaces = new HashSet<>();
 
         for (int i = 0; i < testSuite.getTestCaseCount(); i++) {
             WsdlTestCase testCase = testSuite.getTestCaseAt(i);
@@ -201,7 +201,7 @@ public class CloneTestSuiteAction extends AbstractSoapUIAction<WsdlTestSuite> {
         }
 
         if (requiredInterfaces.size() > 0 && targetProject.getInterfaceCount() > 0) {
-            Map<String, Interface> bindings = new HashMap<String, Interface>();
+            Map<String, Interface> bindings = new HashMap<>();
             for (Interface iface : requiredInterfaces) {
                 bindings.put(iface.getTechnicalId(), iface);
             }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/endpoint/DefaultEndpointStrategy.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/endpoint/DefaultEndpointStrategy.java
@@ -61,7 +61,7 @@ import java.util.Set;
 public class DefaultEndpointStrategy implements EndpointStrategy, PropertyExpansionContainer {
     private WsdlProject project;
     private DefaultEndpointStrategyConfig config;
-    private Map<String, EndpointDefaults> defaults = new HashMap<String, EndpointDefaults>();
+    private Map<String, EndpointDefaults> defaults = new HashMap<>();
     private PropertyChangeListener propertyChangeListener = new InternalPropertyChangeListener();
     private ProjectListener projectListener = new InternalProjectListener();
     private DefaultEndpointStrategyConfigurationPanel configurationPanel;
@@ -108,7 +108,7 @@ public class DefaultEndpointStrategy implements EndpointStrategy, PropertyExpans
             return;
         }
 
-        Set<String> endpoints = new HashSet<String>();
+        Set<String> endpoints = new HashSet<>();
 
         for (Interface iface : project.getInterfaceList()) {
             endpoints.addAll(Arrays.asList(iface.getEndpoints()));

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/endpoint/DefaultEndpointStrategyConfigurationPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/endpoint/DefaultEndpointStrategyConfigurationPanel.java
@@ -214,7 +214,7 @@ public class DefaultEndpointStrategyConfigurationPanel extends JPanel implements
             String selectedEndpoint = tableModel.getEndpointAt(selectedIndex);
             EndpointDefaults defaults = tableModel.getDefaultsAt(selectedIndex);
 
-            List<String> list = new ArrayList<String>(Arrays.asList(iface.getEndpoints()));
+            List<String> list = new ArrayList<>(Arrays.asList(iface.getEndpoints()));
             list.add(0, ALL_REQUESTS);
             list.add(1, ALL_TEST_REQUESTS);
             list.add(2, ALL_REQUESTS_AND_TEST_REQUESTS);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/loadtest/WsdlLoadTest.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/loadtest/WsdlLoadTest.java
@@ -102,10 +102,10 @@ public class WsdlLoadTest extends AbstractWsdlModelItem<LoadTestConfig> implemen
     private LoadTestLog loadTestLog;
 
     private LoadStrategyConfigurationChangeListener loadStrategyListener = new LoadStrategyConfigurationChangeListener();
-    private List<LoadTestAssertion> assertions = new ArrayList<LoadTestAssertion>();
+    private List<LoadTestAssertion> assertions = new ArrayList<>();
     private ConfigurationChangePropertyListener configurationChangeListener = new ConfigurationChangePropertyListener();
-    private Set<LoadTestListener> loadTestListeners = new HashSet<LoadTestListener>();
-    private Set<LoadTestRunListener> loadTestRunListeners = new HashSet<LoadTestRunListener>();
+    private Set<LoadTestListener> loadTestListeners = new HashSet<>();
+    private Set<LoadTestRunListener> loadTestRunListeners = new HashSet<>();
     private List<LoadTestLogErrorEntry> assertionErrors = new TreeList();
     private WsdlLoadTestRunner runner;
     private StatisticsLogger statisticsLogger = new StatisticsLogger();
@@ -663,7 +663,7 @@ public class WsdlLoadTest extends AbstractWsdlModelItem<LoadTestConfig> implemen
 
     public class StatisticsLogger implements Runnable {
         private boolean stopped;
-        private List<PrintWriter> writers = new ArrayList<PrintWriter>();
+        private List<PrintWriter> writers = new ArrayList<>();
         private long startTime;
 
         public void run() {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/loadtest/WsdlLoadTestRunner.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/loadtest/WsdlLoadTestRunner.java
@@ -62,7 +62,7 @@ import java.util.Set;
 
 public class WsdlLoadTestRunner implements LoadTestRunner {
     private final WsdlLoadTest loadTest;
-    private Set<InternalTestCaseRunner> runners = new HashSet<InternalTestCaseRunner>();
+    private Set<InternalTestCaseRunner> runners = new HashSet<>();
     private long startTime = 0;
     private InternalPropertyChangeListener internalPropertyChangeListener = new InternalPropertyChangeListener();
     private InternalTestRunListener testRunListener = new InternalTestRunListener();
@@ -382,7 +382,7 @@ public class WsdlLoadTestRunner implements LoadTestRunner {
     }
 
     private final class TestCaseStarter extends Worker.WorkerAdapter {
-        private List<WsdlTestCase> testCases = new ArrayList<WsdlTestCase>();
+        private List<WsdlTestCase> testCases = new ArrayList<>();
         private boolean canceled;
 
         public Object construct(XProgressMonitor monitor) {
@@ -545,7 +545,7 @@ public class WsdlLoadTestRunner implements LoadTestRunner {
 
         // get list of active runners
         Iterator<InternalTestCaseRunner> iterator = runners.iterator();
-        List<InternalTestCaseRunner> activeRunners = new ArrayList<InternalTestCaseRunner>();
+        List<InternalTestCaseRunner> activeRunners = new ArrayList<>();
         while (iterator.hasNext()) {
             InternalTestCaseRunner runner = iterator.next();
             if (!runner.isCanceled()) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/loadtest/assertions/LoadTestAssertionRegistry.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/loadtest/assertions/LoadTestAssertionRegistry.java
@@ -36,7 +36,7 @@ import java.util.Map;
 
 public class LoadTestAssertionRegistry {
     private static LoadTestAssertionRegistry instance;
-    private Map<String, Class<? extends AbstractLoadTestAssertion>> availableAssertions = new HashMap<String, Class<? extends AbstractLoadTestAssertion>>();
+    private Map<String, Class<? extends AbstractLoadTestAssertion>> availableAssertions = new HashMap<>();
     @SuppressWarnings("unused")
     private final static Logger logger = LogManager.getLogger(LoadTestAssertionRegistry.class);
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/loadtest/data/LoadTestSamples.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/loadtest/data/LoadTestSamples.java
@@ -41,8 +41,8 @@ import java.util.List;
 
 public class LoadTestSamples extends AbstractTableModel {
     private final LoadTest loadTest;
-    private List<List<LoadTestStepSample[]>> samples = new ArrayList<List<LoadTestStepSample[]>>();
-    private List<Long> timestamps = new ArrayList<Long>();
+    private List<List<LoadTestStepSample[]>> samples = new ArrayList<>();
+    private List<Long> timestamps = new ArrayList<>();
     private InternalLoadTestRunListener loadTestRunListener = new InternalLoadTestRunListener();
     private InternalTestSuiteListener testSuiteListener = new InternalTestSuiteListener();
     private final static Logger log = LogManager.getLogger(LoadTestSamples.class);
@@ -123,12 +123,12 @@ public class LoadTestSamples extends AbstractTableModel {
         public void afterTestCase(LoadTestRunner loadTestRunner, LoadTestRunContext context, TestCaseRunner testRunner,
                                   TestCaseRunContext runContext) {
             long timestamp = System.currentTimeMillis();
-            List<LoadTestStepSample[]> s = new ArrayList<LoadTestStepSample[]>();
+            List<LoadTestStepSample[]> s = new ArrayList<>();
             List<TestStepResult> testResults = testRunner.getResults();
 
             for (int c = 0; c < loadTest.getTestCase().getTestStepCount(); c++) {
                 TestStep testStep = loadTest.getTestCase().getTestStepAt(c);
-                List<LoadTestStepSample> results = new ArrayList<LoadTestStepSample>();
+                List<LoadTestStepSample> results = new ArrayList<>();
 
                 for (int i = 0; i < testResults.size(); i++) {
                     TestStepResult stepResult = testResults.get(i);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/loadtest/data/LoadTestStatistics.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/loadtest/data/LoadTestStatistics.java
@@ -84,7 +84,7 @@ public final class LoadTestStatistics extends AbstractTableModel implements Runn
 
     private boolean changed;
     private long updateFrequency = DEFAULT_SAMPLE_INTERVAL;
-    private Queue<SamplesHolder> samplesStack = new ConcurrentLinkedQueue<SamplesHolder>();
+    private Queue<SamplesHolder> samplesStack = new ConcurrentLinkedQueue<>();
     private long currentThreadCountStartTime;
     private long totalAverageSum;
     private boolean resetStatistics;
@@ -610,7 +610,7 @@ public final class LoadTestStatistics extends AbstractTableModel implements Runn
         return result;
     }
 
-    private final static Map<Integer, Statistic> statisticIndexMap = new HashMap<Integer, Statistic>();
+    private final static Map<Integer, Statistic> statisticIndexMap = new HashMap<>();
 
     private Updater updater = new Updater();
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/loadtest/data/SamplesModel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/loadtest/data/SamplesModel.java
@@ -43,7 +43,7 @@ import java.util.Map;
 
 public class SamplesModel extends AbstractTableModel {
     private final LoadTest loadTest;
-    private List<TestSample[]> samples = new ArrayList<TestSample[]>();
+    private List<TestSample[]> samples = new ArrayList<>();
     private InternalTestRunListener testRunListener;
     private InternalTestSuiteListener testSuiteListener;
     private InternalPropertyChangeListener propertyChangeListener;
@@ -115,7 +115,7 @@ public class SamplesModel extends AbstractTableModel {
     private class InternalTestRunListener extends LoadTestRunListenerAdapter {
         public void afterTestCase(LoadTestRunner loadTestRunner, LoadTestRunContext context, TestCaseRunner testRunner,
                                   TestCaseRunContext runContext) {
-            Map<TestStep, TestSample> samplesMap = new HashMap<TestStep, TestSample>();
+            Map<TestStep, TestSample> samplesMap = new HashMap<>();
             List<TestStepResult> results = testRunner.getResults();
 
             for (int c = 0; c < results.size(); c++) {
@@ -179,7 +179,7 @@ public class SamplesModel extends AbstractTableModel {
             }
 
             if (results == null) {
-                results = new ArrayList<TestStepResult>();
+                results = new ArrayList<>();
             }
 
             results.add(result);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/loadtest/data/StatisticsHistory.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/loadtest/data/StatisticsHistory.java
@@ -42,10 +42,10 @@ import java.util.Map;
 
 public class StatisticsHistory {
     private final LoadTestStatistics statistics;
-    private List<long[][]> data = new ArrayList<long[][]>();
-    private List<Long> threadCounts = new ArrayList<Long>();
-    private Map<Integer, TestStepStatisticsHistory> testStepStatisticHistories = new HashMap<Integer, TestStepStatisticsHistory>();
-    private EnumMap<Statistic, StatisticsValueHistory> statisticsValueHistories = new EnumMap<Statistic, StatisticsValueHistory>(
+    private List<long[][]> data = new ArrayList<>();
+    private List<Long> threadCounts = new ArrayList<>();
+    private Map<Integer, TestStepStatisticsHistory> testStepStatisticHistories = new HashMap<>();
+    private EnumMap<Statistic, StatisticsValueHistory> statisticsValueHistories = new EnumMap<>(
             Statistic.class);
 
     @SuppressWarnings("unused")

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/loadtest/log/LoadTestLog.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/loadtest/log/LoadTestLog.java
@@ -40,8 +40,8 @@ public class LoadTestLog extends AbstractListModel implements Runnable {
     private List<LoadTestLogEntry> entries = Collections.synchronizedList(new ArrayList<LoadTestLogEntry>());
     private final WsdlLoadTest loadTest;
     private int totalErrorCount;
-    private Map<String, Integer> errorCounts = new HashMap<String, Integer>();
-    private Queue<LoadTestLogEntry> entriesStack = new ConcurrentLinkedQueue<LoadTestLogEntry>();
+    private Map<String, Integer> errorCounts = new HashMap<>();
+    private Queue<LoadTestLogEntry> entriesStack = new ConcurrentLinkedQueue<>();
     private Thread modelThread;
     private InternalTestSuiteListener testSuiteListener = new InternalTestSuiteListener();
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/loadtest/strategy/LoadStrategyRegistry.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/loadtest/strategy/LoadStrategyRegistry.java
@@ -29,7 +29,7 @@ import java.util.Map;
 
 public class LoadStrategyRegistry {
     private static LoadStrategyRegistry instance;
-    private Map<String, LoadStrategyFactory> factories = new HashMap<String, LoadStrategyFactory>();
+    private Map<String, LoadStrategyFactory> factories = new HashMap<>();
 
     public LoadStrategyRegistry() {
         addFactory(new SimpleLoadStrategy.Factory());

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/mock/MockRunnerManagerImpl.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/mock/MockRunnerManagerImpl.java
@@ -29,11 +29,11 @@ import java.util.Vector;
 public class MockRunnerManagerImpl implements MockRunnerManager {
     private final static Logger log = LogManager.getLogger(MockRunnerManagerImpl.class);
 
-    private static Map<String, MockRunnerManager> managers = new HashMap<String, MockRunnerManager>();
+    private static Map<String, MockRunnerManager> managers = new HashMap<>();
 
-    private Map<String, WsdlMockService> mockServices = new HashMap<String, WsdlMockService>();
+    private Map<String, WsdlMockService> mockServices = new HashMap<>();
 
-    private Vector<WsdlMockRunner> mockRunners = new Vector<WsdlMockRunner>();
+    private Vector<WsdlMockRunner> mockRunners = new Vector<>();
 
     private Project project;
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/mock/WsdlMockDispatcher.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/mock/WsdlMockDispatcher.java
@@ -359,7 +359,7 @@ public class WsdlMockDispatcher extends AbstractMockDispatcher {
         out.print("</ul></p></body></html>");
     }
 
-    public void returnFile(HttpServletResponse response, File file) throws FileNotFoundException, IOException {
+    public void returnFile(HttpServletResponse response, File file) throws IOException {
         FileInputStream in = new FileInputStream(file);
         response.setStatus(HttpServletResponse.SC_OK);
         long length = file.length();

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/mock/WsdlMockDispatcher.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/mock/WsdlMockDispatcher.java
@@ -59,7 +59,7 @@ public class WsdlMockDispatcher extends AbstractMockDispatcher {
     private WsdlMockService mockService;
     private WsdlMockRunContext mockContext;
 
-    private final Map<String, StringToStringMap> wsdlCache = new HashMap<String, StringToStringMap>();
+    private final Map<String, StringToStringMap> wsdlCache = new HashMap<>();
     private final static Logger log = LogManager.getLogger(WsdlMockDispatcher.class);
 
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/mock/WsdlMockResponse.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/mock/WsdlMockResponse.java
@@ -101,7 +101,7 @@ public class WsdlMockResponse extends AbstractMockResponse<MockResponseConfig> i
     public static final String OUGOING_WSS = WsdlMockResponse.class.getName() + "@outgoing-wss";
     public static final String ICON_NAME = "/mockResponse.gif";
 
-    protected List<FileAttachment<WsdlMockResponse>> attachments = new ArrayList<FileAttachment<WsdlMockResponse>>();
+    protected List<FileAttachment<WsdlMockResponse>> attachments = new ArrayList<>();
     private List<HttpAttachmentPart> definedAttachmentParts;
     private IconAnimator<WsdlMockResponse> iconAnimator;
     private WsaConfig wsaConfig;
@@ -117,7 +117,7 @@ public class WsdlMockResponse extends AbstractMockResponse<MockResponseConfig> i
             config.setEncoding("UTF-8");
         }
 
-        iconAnimator = new IconAnimator<WsdlMockResponse>(this, "/mockResponse.gif", "/exec_request.png", 4);
+        iconAnimator = new IconAnimator<>(this, "/mockResponse.gif", "/exec_request.png", 4);
     }
 
     @Override
@@ -158,7 +158,7 @@ public class WsdlMockResponse extends AbstractMockResponse<MockResponseConfig> i
 
     public MessagePart[] getRequestParts() {
         try {
-            List<MessagePart> result = new ArrayList<MessagePart>();
+            List<MessagePart> result = new ArrayList<>();
             result.addAll(Arrays.asList(getMockOperation().getOperation().getDefaultRequestParts()));
 
             if (getMockResult() != null) {
@@ -181,7 +181,7 @@ public class WsdlMockResponse extends AbstractMockResponse<MockResponseConfig> i
                 return new MessagePart[0];
             }
 
-            List<MessagePart> result = new ArrayList<MessagePart>();
+            List<MessagePart> result = new ArrayList<>();
             WsdlContext wsdlContext = op.getInterface().getWsdlContext();
             BindingOperation bindingOperation = op.findBindingOperation(wsdlContext.getDefinition());
 
@@ -271,7 +271,7 @@ public class WsdlMockResponse extends AbstractMockResponse<MockResponseConfig> i
             try {
                 WsdlOperation operation = (WsdlOperation) getMockOperation().getOperation();
                 if (operation == null) {
-                    definedAttachmentParts = new ArrayList<HttpAttachmentPart>();
+                    definedAttachmentParts = new ArrayList<>();
                 } else {
                     UISupport.setHourglassCursor();
                     definedAttachmentParts = AttachmentUtils.extractAttachmentParts(operation, getResponseContent(), true,
@@ -299,7 +299,7 @@ public class WsdlMockResponse extends AbstractMockResponse<MockResponseConfig> i
     }
 
     public Attachment[] getAttachmentsForPart(String partName) {
-        List<Attachment> result = new ArrayList<Attachment>();
+        List<Attachment> result = new ArrayList<>();
 
         for (Attachment attachment : attachments) {
             if (attachment.getPart().equals(partName)) {
@@ -514,7 +514,7 @@ public class WsdlMockResponse extends AbstractMockResponse<MockResponseConfig> i
     }
 
     public PropertyExpansion[] getPropertyExpansions() {
-        List<PropertyExpansion> result = new ArrayList<PropertyExpansion>();
+        List<PropertyExpansion> result = new ArrayList<>();
 
         result.addAll(PropertyExpansionUtils.extractPropertyExpansions(this, this, "responseContent"));
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/mock/WsdlMockRunner.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/mock/WsdlMockRunner.java
@@ -49,7 +49,7 @@ public class WsdlMockRunner implements MockRunner {
     private MockDispatcher dispatcher;
 
     public WsdlMockRunner(MockService mockService, WsdlTestRunContext context) throws Exception {
-        Set<WsdlInterface> interfaces = new HashSet<WsdlInterface>();
+        Set<WsdlInterface> interfaces = new HashSet<>();
 
         // TODO: move this code elsewhere when the rest counterpoint is in place
         if (mockService instanceof WsdlMockService) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/mock/WsdlMockService.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/mock/WsdlMockService.java
@@ -139,7 +139,7 @@ public class WsdlMockService extends AbstractMockService<WsdlMockOperation, Mock
     }
 
     public WsdlInterface[] getMockedInterfaces() {
-        Set<WsdlInterface> result = new HashSet<WsdlInterface>();
+        Set<WsdlInterface> result = new HashSet<>();
 
         for (MockOperation mockOperation : getMockOperationList()) {
             WsdlOperation operation = (WsdlOperation) mockOperation.getOperation();
@@ -250,7 +250,7 @@ public class WsdlMockService extends AbstractMockService<WsdlMockOperation, Mock
     }
 
     public List<WsdlOperation> getMockedOperations() {
-        List<WsdlOperation> result = new ArrayList<WsdlOperation>();
+        List<WsdlOperation> result = new ArrayList<>();
 
         for (MockOperation mockOperation : mockOperations) {
             result.add((WsdlOperation) mockOperation.getOperation());

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/mock/dispatch/MockOperationDispatchRegistry.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/mock/dispatch/MockOperationDispatchRegistry.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class MockOperationDispatchRegistry {
-    private static Map<String, MockOperationDispatchFactory> factories = new HashMap<String, MockOperationDispatchFactory>();
+    private static Map<String, MockOperationDispatchFactory> factories = new HashMap<>();
 
     static {
         putFactory(MockOperationDispatchStyleConfig.SEQUENCE.toString(), new SequenceMockOperationDispatcher.Factory());

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/mock/dispatch/QueryMatchMockOperationDispatcher.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/mock/dispatch/QueryMatchMockOperationDispatcher.java
@@ -70,7 +70,7 @@ import java.util.Map;
 public class QueryMatchMockOperationDispatcher extends AbstractMockOperationDispatcher implements
         PropertyChangeListener {
     private MockOperationQueryMatchDispatchConfig conf;
-    private List<Query> queries = new ArrayList<Query>();
+    private List<Query> queries = new ArrayList<>();
     private PresentationModel<Query> queryDetailFormPresentationModel;
     private QueryItemListModel queryItemListModel;
     private JList itemList;
@@ -174,7 +174,7 @@ public class QueryMatchMockOperationDispatcher extends AbstractMockOperationDisp
     }
 
     protected Component buildQueryDetailComponent() {
-        queryDetailFormPresentationModel = new PresentationModel<Query>(null);
+        queryDetailFormPresentationModel = new PresentationModel<>(null);
         detailForm = new SimpleBindingForm(queryDetailFormPresentationModel);
 
         detailForm.setDefaultTextAreaRows(5);
@@ -210,7 +210,7 @@ public class QueryMatchMockOperationDispatcher extends AbstractMockOperationDisp
 
     public WsdlMockResponse selectMockResponse(MockRequest request, MockResult result)
             throws DispatchException {
-        Map<String, XmlCursor> cursorCache = new HashMap<String, XmlCursor>();
+        Map<String, XmlCursor> cursorCache = new HashMap<>();
 
         try {
             XmlObject xmlObject = request.getRequestXmlObject();

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/monitor/ContentTypes.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/monitor/ContentTypes.java
@@ -34,7 +34,7 @@ public class ContentTypes {
     }
 
     public static ContentTypes of(String contentTypes) {
-        List<ContentType> contentTypeList = new ArrayList<ContentType>();
+        List<ContentType> contentTypeList = new ArrayList<>();
         for (String ct : contentTypes.split(",")) {
             try {
                 contentTypeList.add(new ContentType(ct.trim()));

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/monitor/JProxyServletWsdlMonitorMessageExchange.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/monitor/JProxyServletWsdlMonitorMessageExchange.java
@@ -200,7 +200,7 @@ public class JProxyServletWsdlMonitorMessageExchange extends WsdlMonitorMessageE
                 }
             } catch (Exception e) {
                 if (responseWssResult == null) {
-                    responseWssResult = new Vector<Object>();
+                    responseWssResult = new Vector<>();
                 }
                 responseWssResult.add(e);
             }
@@ -284,7 +284,7 @@ public class JProxyServletWsdlMonitorMessageExchange extends WsdlMonitorMessageE
 
         String soapAction = SoapUtils.getSoapAction(soapVersion, requestHeaders);
 
-        List<WsdlOperation> operations = new ArrayList<WsdlOperation>();
+        List<WsdlOperation> operations = new ArrayList<>();
         for (WsdlInterface iface : ModelSupport.getChildren(project, WsdlInterface.class)) {
             for (Operation operation : iface.getOperationList()) {
                 operations.add((WsdlOperation) operation);
@@ -311,7 +311,7 @@ public class JProxyServletWsdlMonitorMessageExchange extends WsdlMonitorMessageE
                 }
             } catch (Exception e) {
                 if (requestWssResult == null) {
-                    requestWssResult = new Vector<Object>();
+                    requestWssResult = new Vector<>();
                 }
                 requestWssResult.add(e);
             }
@@ -479,7 +479,7 @@ public class JProxyServletWsdlMonitorMessageExchange extends WsdlMonitorMessageE
 
     public void setHttpRequestParameters(HttpServletRequest httpRequest) {
         Enumeration<String> parameterNames = httpRequest.getParameterNames();
-        Map<String, String> parameterMap = new HashMap<String, String>();
+        Map<String, String> parameterMap = new HashMap<>();
         while (parameterNames.hasMoreElements()) {
             String name = parameterNames.nextElement();
             parameterMap.put(name, httpRequest.getParameter(name));

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/monitor/SoapMonitor.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/monitor/SoapMonitor.java
@@ -125,7 +125,7 @@ public class SoapMonitor extends JPanel {
     // private JButton addToRestTestCaseButton;
     private JButton createRequestButton;
     private JButton addToMockServiceButton;
-    private Stack<WsdlMonitorMessageExchange> messageExchangeStack = new Stack<WsdlMonitorMessageExchange>();
+    private Stack<WsdlMonitorMessageExchange> messageExchangeStack = new Stack<>();
     private StackProcessor stackProcessor = new StackProcessor();
     private PatternFilter operationFilter;
     private PatternFilter interfaceFilter;
@@ -184,7 +184,7 @@ public class SoapMonitor extends JPanel {
     private JComponent buildContent() {
         inspectorPanel = JInspectorPanelFactory.build(buildLog());
 
-        JComponentInspector<JComponent> viewInspector = new JComponentInspector<JComponent>(buildViewer(),
+        JComponentInspector<JComponent> viewInspector = new JComponentInspector<>(buildViewer(),
                 "Message Content", "Shows message content", true);
         inspectorPanel.addInspector(viewInspector);
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/monitor/SoapMonitorListenerCallBack.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/monitor/SoapMonitorListenerCallBack.java
@@ -30,7 +30,7 @@ import java.util.Set;
  * @author Prakash
  */
 public class SoapMonitorListenerCallBack {
-    private SoapUIListenerSupport<MonitorListener> listeners = new SoapUIListenerSupport<MonitorListener>(
+    private SoapUIListenerSupport<MonitorListener> listeners = new SoapUIListenerSupport<>(
             MonitorListener.class);
 
     public void fireAddMessageExchange(WsdlMonitorMessageExchange messageExchange) {
@@ -87,7 +87,7 @@ public class SoapMonitorListenerCallBack {
     }
 
     public static class SoapUIListenerSupport<T> {
-        private Set<T> listeners = new HashSet<T>();
+        private Set<T> listeners = new HashSet<>();
         @SuppressWarnings("unused")
         private final Class<T> listenerClass;
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/monitor/TcpMonWsdlMonitorMessageExchange.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/monitor/TcpMonWsdlMonitorMessageExchange.java
@@ -318,7 +318,7 @@ public class TcpMonWsdlMonitorMessageExchange extends WsdlMonitorMessageExchange
 
         String soapAction = SoapUtils.getSoapAction(soapVersion, requestHeaders);
 
-        List<WsdlOperation> operations = new ArrayList<WsdlOperation>();
+        List<WsdlOperation> operations = new ArrayList<>();
         for (WsdlInterface iface : ModelSupport.getChildren(project, WsdlInterface.class)) {
             for (Operation operation : iface.getOperationList()) {
                 operations.add((WsdlOperation) operation);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/monitor/jettyproxy/ProxyServlet.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/monitor/jettyproxy/ProxyServlet.java
@@ -78,7 +78,7 @@ public class ProxyServlet implements Servlet {
     protected Settings settings;
     protected final SoapMonitorListenerCallBack listenerCallBack;
     private ContentTypes includedContentTypes = SoapMonitorAction.defaultContentTypes();
-    static HashSet<String> dontProxyHeaders = new HashSet<String>();
+    static HashSet<String> dontProxyHeaders = new HashSet<>();
 
     static {
         dontProxyHeaders.add("proxy-connection");

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/assertions/AddAssertionPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/assertions/AddAssertionPanel.java
@@ -246,7 +246,7 @@ public class AddAssertionPanel extends SimpleDialog {
     protected void populateNonSelectableAssertionIndexes() {
         getAssertionsTable().setSelectable(true);
         SortedSet<AssertionListEntry> assertionsList = getCategoriesAssertionsMap().get(getSelectedCategory());
-        List<Integer> assertionsIndexList = new ArrayList<Integer>();
+        List<Integer> assertionsIndexList = new ArrayList<>();
         for (int i = 0; i < assertionsList.size(); i++) {
             AssertionListEntry assertionListEntry = (AssertionListEntry) assertionsList.toArray()[i];
             if (!isAssertionApplicable(assertionListEntry.getTypeId())) {
@@ -258,7 +258,7 @@ public class AddAssertionPanel extends SimpleDialog {
 
     protected void populateSelectableCategoriesIndexes() {
         getCategoriesListTable().setSelectable(true);
-        List<Integer> categoriesIndexList = new ArrayList<Integer>();
+        List<Integer> categoriesIndexList = new ArrayList<>();
         Set<String> ctgs = getCategoriesAssertionsMap().keySet();
         for (int j = 0; j < ctgs.size(); j++) {
             String selCat = (String) ctgs.toArray()[j];

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/assertions/AssertionCategoryMapping.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/assertions/AssertionCategoryMapping.java
@@ -53,7 +53,7 @@ public class AssertionCategoryMapping {
      */
     private static SortedSet<AssertionListEntry> createRecentlyUsedSet(Assertable assertable,
                                                                        RecentAssertionHandler recentAssertionHandler) {
-        SortedSet<AssertionListEntry> recentlyUsedSet = new TreeSet<AssertionListEntry>();
+        SortedSet<AssertionListEntry> recentlyUsedSet = new TreeSet<>();
 
         for (String name : recentAssertionHandler.get()) {
             String type = recentAssertionHandler.getAssertionTypeByName(name);
@@ -77,7 +77,7 @@ public class AssertionCategoryMapping {
      */
     public static LinkedHashMap<String, SortedSet<AssertionListEntry>> getCategoriesAssertionsMap(
             Assertable assertable, RecentAssertionHandler recentAssertionHandler) {
-        LinkedHashMap<String, SortedSet<AssertionListEntry>> categoriesAssertionsMap = new LinkedHashMap<String, SortedSet<AssertionListEntry>>();
+        LinkedHashMap<String, SortedSet<AssertionListEntry>> categoriesAssertionsMap = new LinkedHashMap<>();
 
         SortedSet<AssertionListEntry> recentlyUsedSet = createRecentlyUsedSet(assertable, recentAssertionHandler);
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/iface/WsdlInterfaceDesktopPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/iface/WsdlInterfaceDesktopPanel.java
@@ -108,11 +108,11 @@ import java.util.Map;
 public class WsdlInterfaceDesktopPanel extends ModelItemDesktopPanel<WsdlInterface> {
     private final static Logger logger = LogManager.getLogger(WsdlInterfaceDesktopPanel.class);
     private JTabbedPane partTabs;
-    private List<RSyntaxTextArea> editors = new ArrayList<RSyntaxTextArea>();
+    private List<RSyntaxTextArea> editors = new ArrayList<>();
     private JTree tree;
-    private Map<String, DefaultMutableTreeNode> groupNodes = new HashMap<String, DefaultMutableTreeNode>();
-    private Map<String, TreePath> pathMap = new HashMap<String, TreePath>();
-    private List<TreePath> navigationHistory = new ArrayList<TreePath>();
+    private Map<String, DefaultMutableTreeNode> groupNodes = new HashMap<>();
+    private Map<String, TreePath> pathMap = new HashMap<>();
+    private List<TreePath> navigationHistory = new ArrayList<>();
     private StringList targetNamespaces = new StringList();
     private int historyIndex;
     private boolean navigating;
@@ -597,11 +597,11 @@ public class WsdlInterfaceDesktopPanel extends ModelItemDesktopPanel<WsdlInterfa
     public List<DefaultMutableTreeNode> mapTreeItems(XmlObject xmlObject, DefaultMutableTreeNode treeRoot,
                                                      boolean createEmpty, int tabIndex, String groupName, String query, String nameQuery, boolean sort,
                                                      NodeSelector selector) {
-        List<DefaultMutableTreeNode> resultNodes = new ArrayList<DefaultMutableTreeNode>();
+        List<DefaultMutableTreeNode> resultNodes = new ArrayList<>();
 
         try {
             XmlObject[] items = xmlObject.selectPath(query);
-            List<DefaultMutableTreeNode> treeNodes = new ArrayList<DefaultMutableTreeNode>();
+            List<DefaultMutableTreeNode> treeNodes = new ArrayList<>();
 
             DefaultMutableTreeNode root = treeRoot;
             if (groupName != null) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/iface/WsdlInterfacePanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/iface/WsdlInterfacePanelBuilder.java
@@ -37,7 +37,7 @@ public class WsdlInterfacePanelBuilder extends EmptyPanelBuilder<WsdlInterface> 
     }
 
     public Component buildOverviewPanel(WsdlInterface iface) {
-        JPropertiesTable<WsdlInterface> table = new JPropertiesTable<WsdlInterface>("Interface Properties");
+        JPropertiesTable<WsdlInterface> table = new JPropertiesTable<>("Interface Properties");
         table.addProperty("Name", "name", true);
         table.addProperty("Description", "description", true);
         table.addProperty("Definition URL", "definition", true);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/loadtest/JLoadTestLogTable.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/loadtest/JLoadTestLogTable.java
@@ -170,7 +170,7 @@ public class JLoadTestLogTable extends JPanel {
         toolbar.add(exportButton);
         toolbar.addGlue();
 
-        List<Object> steps = new ArrayList<Object>();
+        List<Object> steps = new ArrayList<>();
         steps.add("- All -");
         steps.add("Message");
         for (LoadTestAssertion assertion : loadTestLog.getLoadTest().getAssertionList()) {
@@ -203,7 +203,7 @@ public class JLoadTestLogTable extends JPanel {
         toolbar.add(typesFilterComboBox);
         toolbar.addSeparator();
 
-        List<Object> types = new ArrayList<Object>();
+        List<Object> types = new ArrayList<>();
         types.add("- All -");
         for (TestStep testStep : loadTestLog.getLoadTest().getTestCase().getTestStepList()) {
             types.add(testStep.getName());

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/mock/WsdlMockServiceDesktopPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/mock/WsdlMockServiceDesktopPanel.java
@@ -458,7 +458,7 @@ public class WsdlMockServiceDesktopPanel<MockServiceType extends MockService>
 
     public class OperationListModel extends AbstractListModel implements ListModel, MockServiceListener,
             PropertyChangeListener {
-        private List<MockOperation> operations = new ArrayList<MockOperation>();
+        private List<MockOperation> operations = new ArrayList<>();
 
         public OperationListModel() {
             for (int c = 0; c < getModelItem().getMockOperationCount(); c++) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/mock/WsdlMockServicePanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/mock/WsdlMockServicePanelBuilder.java
@@ -45,7 +45,7 @@ public class WsdlMockServicePanelBuilder extends EmptyPanelBuilder<WsdlMockServi
     }
 
     public Component buildOverviewPanel(WsdlMockService mockService) {
-        JPropertiesTable<WsdlMockService> table = new JPropertiesTable<WsdlMockService>("MockService Properties");
+        JPropertiesTable<WsdlMockService> table = new JPropertiesTable<>("MockService Properties");
         table.addProperty("Name", "name", true);
         table.addProperty("Description", "description", true);
         table.addProperty("Path", "path");

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/mockoperation/WsdlMockOperationDesktopPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/mockoperation/WsdlMockOperationDesktopPanel.java
@@ -82,7 +82,7 @@ public class WsdlMockOperationDesktopPanel extends AbstractMockOperationDesktopP
                 OpenRequestForMockOperationAction.SOAPUI_ACTION_ID, getModelItem(), null, "/open_request.gif")));
         toolbar.addUnrelatedGap();
 
-        ModelItemNames<WsdlInterface> names = new ModelItemNames<WsdlInterface>(ModelSupport.getChildren(getModelItem()
+        ModelItemNames<WsdlInterface> names = new ModelItemNames<>(ModelSupport.getChildren(getModelItem()
                 .getMockService().getProject(), WsdlInterface.class));
 
         interfaceCombo = new JComboBox(names.getNames());
@@ -160,7 +160,7 @@ public class WsdlMockOperationDesktopPanel extends AbstractMockOperationDesktopP
             } else {
                 currentInterface = (WsdlInterface) getModelItem().getMockService().getProject()
                         .getInterfaceByName(selectedItem.toString());
-                ModelItemNames<Operation> names = new ModelItemNames<Operation>(currentInterface.getOperationList());
+                ModelItemNames<Operation> names = new ModelItemNames<>(currentInterface.getOperationList());
                 operationCombo.setModel(new ExtendedComboBoxModel(names.getNames()));
 
                 currentInterface.addInterfaceListener(interfaceListener);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/mockoperation/WsdlMockOperationPanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/mockoperation/WsdlMockOperationPanelBuilder.java
@@ -35,8 +35,8 @@ public class WsdlMockOperationPanelBuilder extends EmptyPanelBuilder<WsdlMockOpe
     }
 
     public Component buildOverviewPanel(WsdlMockOperation mockOperation) {
-        JPropertiesTable<WsdlMockOperation> table = new JPropertiesTable<WsdlMockOperation>("Mock Operation");
-        table = new JPropertiesTable<WsdlMockOperation>("MockOperation Properties");
+        JPropertiesTable<WsdlMockOperation> table = new JPropertiesTable<>("Mock Operation");
+        table = new JPropertiesTable<>("MockOperation Properties");
         table.addProperty("Name", "name", true);
         table.addProperty("Description", "description", true);
         table.addProperty("WSDL Operation", "wsdlOperationName", false);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/mockoperation/WsdlMockResponsePanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/mockoperation/WsdlMockResponsePanelBuilder.java
@@ -46,7 +46,7 @@ public class WsdlMockResponsePanelBuilder extends EmptyPanelBuilder<WsdlMockResp
     }
 
     public Component buildOverviewPanel(WsdlMockResponse mockResponse) {
-        JPropertiesTable<WsdlMockResponse> table = new JPropertiesTable<WsdlMockResponse>("MockResponse Properties");
+        JPropertiesTable<WsdlMockResponse> table = new JPropertiesTable<>("MockResponse Properties");
         table.addProperty("Name", "name", true);
         table.addProperty("Description", "description", true);
         table.addProperty("Message Size", "contentLength", false);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/mockoperation/actions/CreateFaultWsdlMockResponseAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/mockoperation/actions/CreateFaultWsdlMockResponseAction.java
@@ -57,7 +57,7 @@ public class CreateFaultWsdlMockResponseAction extends AbstractAction {
             MessagePart[] faultParts = operation.getFaultParts();
 
             if (faultParts != null && faultParts.length > 0) {
-                List<String> names = new ArrayList<String>();
+                List<String> names = new ArrayList<>();
                 for (int c = 0; c < faultParts.length; c++) {
                     names.add(faultParts[c].getName());
                 }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/operation/WsdlOperationPanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/operation/WsdlOperationPanelBuilder.java
@@ -35,7 +35,7 @@ public class WsdlOperationPanelBuilder extends EmptyPanelBuilder<WsdlOperation> 
     }
 
     public JPanel buildOverviewPanel(WsdlOperation operation) {
-        JPropertiesTable<WsdlOperation> table = new JPropertiesTable<WsdlOperation>("Operation Properties");
+        JPropertiesTable<WsdlOperation> table = new JPropertiesTable<>("Operation Properties");
         table.addProperty("Description", "description", true);
         table.addProperty("SOAPAction", "action");
         table.addProperty("Operation", "bindingOperationName");

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/project/JProjectTestSuiteList.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/project/JProjectTestSuiteList.java
@@ -68,7 +68,7 @@ import java.util.Map;
  */
 
 public class JProjectTestSuiteList extends JPanel {
-    private Map<TestSuite, TestSuiteListPanel> panels = new HashMap<TestSuite, TestSuiteListPanel>();
+    private Map<TestSuite, TestSuiteListPanel> panels = new HashMap<>();
     private final WsdlProject project;
     private final InternalTestSuiteListener testSuiteListener = new InternalTestSuiteListener();
     private TestSuiteListPanel selectedTestSuite;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/project/WSSTabPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/project/WSSTabPanel.java
@@ -585,7 +585,7 @@ public class WSSTabPanel extends JPanel {
         private List<WssCrypto> cryptos;
 
         public CryptoTableModel(CryptoType cryptoType) {
-            cryptos = new ArrayList<WssCrypto>();
+            cryptos = new ArrayList<>();
             for (WssCrypto crypto : wssContainer.getCryptoList()) {
                 if (crypto.getType() == cryptoType) {
                     cryptos.add(crypto);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/project/WsdlProjectDesktopPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/project/WsdlProjectDesktopPanel.java
@@ -93,7 +93,7 @@ public class WsdlProjectDesktopPanel extends ModelItemDesktopPanel<WsdlProject> 
     private PropertyHolderTable propertiesTable;
     private JUndoableTextArea descriptionArea;
     private InternalTreeModelListener treeModelListener;
-    private Set<String> interfaceNameSet = new HashSet<String>();
+    private Set<String> interfaceNameSet = new HashSet<>();
     private WSSTabPanel wssTabPanel;
     protected MetricsPanel metrics;
     private GroovyEditorComponent loadScriptGroovyEditor;
@@ -179,7 +179,7 @@ public class WsdlProjectDesktopPanel extends ModelItemDesktopPanel<WsdlProject> 
 
         metrics.setMetric("File Path", getModelItem().getPath());
 
-        Set<String> newNames = new HashSet<String>();
+        Set<String> newNames = new HashSet<>();
         boolean rebuilt = false;
         for (Interface iface : getModelItem().getInterfaceList()) {
             if (!metrics.hasMetric(iface.getName())) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/project/WsdlProjectPanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/project/WsdlProjectPanelBuilder.java
@@ -35,7 +35,7 @@ public class WsdlProjectPanelBuilder extends EmptyPanelBuilder<WsdlProject> {
     }
 
     public JPanel buildOverviewPanel(WsdlProject project) {
-        JPropertiesTable<WsdlProject> table = new JPropertiesTable<WsdlProject>("Project Properties", project);
+        JPropertiesTable<WsdlProject> table = new JPropertiesTable<>("Project Properties", project);
 
         if (project.isOpen()) {
             table.addProperty("Name", "name", true);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/request/StringToStringMapTableModel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/request/StringToStringMapTableModel.java
@@ -113,7 +113,7 @@ public class StringToStringMapTableModel extends AbstractTableModel implements T
     public void setData(StringToStringMap data) {
         this.data = data == null ? new StringToStringMap() : data;
 
-        keyList = new ArrayList<String>(this.data.keySet());
+        keyList = new ArrayList<>(this.data.keySet());
         fireTableDataChanged();
     }
 }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/request/StringToStringsMapTableModel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/request/StringToStringsMapTableModel.java
@@ -32,7 +32,7 @@ import java.util.List;
 public class StringToStringsMapTableModel extends AbstractTableModel implements TableModel {
     private final String keyCaption;
     private final String valueCaption;
-    private List<NameValuePair> keyList = new ArrayList<NameValuePair>();
+    private List<NameValuePair> keyList = new ArrayList<>();
     private final boolean editable;
     private StringToStringsMap data;
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/request/WsdlRequestPanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/request/WsdlRequestPanelBuilder.java
@@ -43,7 +43,7 @@ public class WsdlRequestPanelBuilder extends EmptyPanelBuilder<WsdlRequest> {
     }
 
     public JPanel buildOverviewPanel(WsdlRequest request) {
-        JPropertiesTable<WsdlRequest> table = new JPropertiesTable<WsdlRequest>("Request Properties", request);
+        JPropertiesTable<WsdlRequest> table = new JPropertiesTable<>("Request Properties", request);
 
         // basic properties
         table.addProperty("Name", "name", true);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/support/MockProjectRunner.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/support/MockProjectRunner.java
@@ -34,6 +34,6 @@ public class MockProjectRunner extends AbstractMockTestRunner<WsdlProject> imple
     }
 
     public List<TestSuiteRunner> getResults() {
-        return new ArrayList<TestSuiteRunner>();
+        return new ArrayList<>();
     }
 }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/support/MockTestRunner.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/support/MockTestRunner.java
@@ -48,7 +48,7 @@ public class MockTestRunner extends AbstractMockTestRunner<WsdlTestCase> impleme
     }
 
     public List<TestStepResult> getResults() {
-        return new ArrayList<TestStepResult>();
+        return new ArrayList<>();
     }
 
     public TestCaseRunContext getRunContext() {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/support/MockTestSuiteRunner.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/support/MockTestSuiteRunner.java
@@ -31,7 +31,7 @@ public class MockTestSuiteRunner extends AbstractMockTestRunner<WsdlTestSuite> i
     }
 
     public List<TestCaseRunner> getResults() {
-        return new ArrayList<TestCaseRunner>();
+        return new ArrayList<>();
     }
 
     public TestSuite getTestSuite() {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/support/TestRunComponentEnabler.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/support/TestRunComponentEnabler.java
@@ -34,8 +34,8 @@ import java.util.List;
  */
 
 public class TestRunComponentEnabler extends TestMonitorListenerAdapter {
-    private final List<JComponent> components = new ArrayList<JComponent>();
-    private final List<Boolean> states = new ArrayList<Boolean>();
+    private final List<JComponent> components = new ArrayList<>();
+    private final List<Boolean> states = new ArrayList<>();
     private final TestCase testCase;
 
     public TestRunComponentEnabler(TestCase testCase) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/testcase/JTestRunLog.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/testcase/JTestRunLog.java
@@ -66,7 +66,7 @@ public class JTestRunLog extends JPanel implements TestRunLog {
     private JList testLogList;
     private boolean errorsOnly = false;
     private final Settings settings;
-    private Set<String> boldTexts = new HashSet<String>();
+    private Set<String> boldTexts = new HashSet<>();
     private boolean follow = true;
     protected int selectedIndex;
     private XFormDialog optionsDialog;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/testcase/TestOnDemandPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/testcase/TestOnDemandPanel.java
@@ -86,7 +86,7 @@ public class TestOnDemandPanel extends JPanel {
     private Action sendTestCaseAction;
 
     @Nonnull
-    private static List<Location> locationsCache = new ArrayList<Location>();
+    private static List<Location> locationsCache = new ArrayList<>();
 
     @Nonnull
     JLabel serverIPAddressesLabel = new JLabel();

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/testcase/WsdlTestCasePanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/testcase/WsdlTestCasePanelBuilder.java
@@ -42,7 +42,7 @@ public class WsdlTestCasePanelBuilder<T extends WsdlTestCase> extends EmptyPanel
     }
 
     public Component buildOverviewPanel(T modelItem) {
-        JPropertiesTable<WsdlTestCase> table = new JPropertiesTable<WsdlTestCase>("TestCase Properties", modelItem);
+        JPropertiesTable<WsdlTestCase> table = new JPropertiesTable<>("TestCase Properties", modelItem);
 
         table.addProperty("Name", "name", true);
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/testcase/actions/SetEndpointAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/testcase/actions/SetEndpointAction.java
@@ -47,8 +47,8 @@ public class SetEndpointAction extends AbstractAction {
     }
 
     public void actionPerformed(ActionEvent e) {
-        Set<String> endpointSet = new TreeSet<String>();
-        Set<String> currentEndpointSet = new HashSet<String>();
+        Set<String> endpointSet = new TreeSet<>();
+        Set<String> currentEndpointSet = new HashSet<>();
 
         endpointSet.add(USE_CURRENT);
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/AssertionsPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/AssertionsPanel.java
@@ -299,7 +299,7 @@ public class AssertionsPanel extends JPanel {
     }
 
     protected class AssertionListModel extends AbstractListModel implements PropertyChangeListener, AssertionsListener {
-        protected List<Object> items = new ArrayList<Object>();
+        protected List<Object> items = new ArrayList<>();
 
         public AssertionListModel() {
             init();
@@ -474,7 +474,7 @@ public class AssertionsPanel extends JPanel {
 
         public void actionPerformed(ActionEvent e) {
 
-            List<TestAssertion> removeAssertionList = new ArrayList<TestAssertion>();
+            List<TestAssertion> removeAssertionList = new ArrayList<>();
             int indices[] = assertionList.getSelectedIndices();
 
             if (indices.length == 0) {
@@ -522,7 +522,7 @@ public class AssertionsPanel extends JPanel {
         private void removeMultipleAssertions(List<TestAssertion> removeAssertionList) {
             if (UISupport.confirm("Remove all selected assertions?", "Remove Multiple Assertions")) {
                 // remove duplicates
-                Set<TestAssertion> assertions = new HashSet<TestAssertion>();
+                Set<TestAssertion> assertions = new HashSet<>();
 
                 for (ModelItem target : removeAssertionList) {
                     assertions.add((TestAssertion) target);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/HttpTestRequestPanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/HttpTestRequestPanelBuilder.java
@@ -46,7 +46,7 @@ public class HttpTestRequestPanelBuilder extends EmptyPanelBuilder<HttpTestReque
 
     public JPanel buildOverviewPanel(HttpTestRequestStep testStep) {
         HttpTestRequestInterface<?> request = testStep.getTestRequest();
-        JPropertiesTable<HttpTestRequestInterface<?>> table = new JPropertiesTable<HttpTestRequestInterface<?>>(
+        JPropertiesTable<HttpTestRequestInterface<?>> table = new JPropertiesTable<>(
                 "HTTP TestRequest Properties");
 
         // basic properties

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/JdbcRequest.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/JdbcRequest.java
@@ -50,7 +50,7 @@ import java.util.Set;
 
 public class JdbcRequest extends AbstractModelItem implements Assertable, TestRequest, AnimatableItem {
     private final JdbcRequestTestStep testStep;
-    private Set<SubmitListener> submitListeners = new HashSet<SubmitListener>();
+    private Set<SubmitListener> submitListeners = new HashSet<>();
     private JdbcResponse response;
     final static Logger logger = LogManager.getLogger(JdbcRequest.class);
     private ImageIcon validRequestIcon;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/JdbcRequestTestStepDesktopPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/JdbcRequestTestStepDesktopPanel.java
@@ -328,7 +328,7 @@ public class JdbcRequestTestStepDesktopPanel extends ModelItemDesktopPanel<JdbcR
                 return new DefaultPropertyHolderTableModel(holder) {
                     @Override
                     public String[] getPropertyNames() {
-                        List<String> propertyNamesList = new ArrayList<String>();
+                        List<String> propertyNamesList = new ArrayList<>();
                         for (String name : holder.getPropertyNames()) {
                             if (name.equals(WsdlTestStepWithProperties.RESPONSE_AS_XML)) {
                                 continue;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/JdbcResponse.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/JdbcResponse.java
@@ -32,7 +32,7 @@ public class JdbcResponse extends AbstractResponse<JdbcRequest> {
     private final String rawSql;
 
     public JdbcResponse(JdbcRequest request, Statement statement, String rawSql) throws SQLException,
-            ParserConfigurationException, TransformerConfigurationException, TransformerException {
+            ParserConfigurationException, TransformerException {
         super(request);
         this.rawSql = rawSql;
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/MockResponseStepPanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/MockResponseStepPanelBuilder.java
@@ -43,7 +43,7 @@ public class MockResponseStepPanelBuilder extends EmptyPanelBuilder<WsdlMockResp
     }
 
     public Component buildOverviewPanel(WsdlMockResponseTestStep mockResponseStep) {
-        JPropertiesTable<WsdlMockResponseTestStep> table = new JPropertiesTable<WsdlMockResponseTestStep>(
+        JPropertiesTable<WsdlMockResponseTestStep> table = new JPropertiesTable<>(
                 "MockResponse Properties");
         table.addProperty("Name", "name", true);
         table.addProperty("Description", "description", true);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/PropertiesStepPanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/PropertiesStepPanelBuilder.java
@@ -42,7 +42,7 @@ public class PropertiesStepPanelBuilder extends EmptyPanelBuilder<WsdlProperties
     }
 
     public JPanel buildOverviewPanel(WsdlPropertiesTestStep testStep) {
-        JPropertiesTable<WsdlPropertiesTestStep> table = new JPropertiesTable<WsdlPropertiesTestStep>(
+        JPropertiesTable<WsdlPropertiesTestStep> table = new JPropertiesTable<>(
                 "PropertiesStep Properties");
 
         table.addProperty("Name", "name", true);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/PropertyTransfersDesktopPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/PropertyTransfersDesktopPanel.java
@@ -219,7 +219,7 @@ public class PropertyTransfersDesktopPanel extends ModelItemDesktopPanel<Propert
         splitPane.setDividerLocation(120);
 
         inspectorPanel = JInspectorPanelFactory.build(splitPane);
-        logInspector = new JComponentInspector<JComponent>(buildLog(), "Transfer Log (0)",
+        logInspector = new JComponentInspector<>(buildLog(), "Transfer Log (0)",
                 "A log of performed transfers while the editor was open", true);
         inspectorPanel.addInspector(logInspector);
         add(inspectorPanel.getComponent(), BorderLayout.CENTER);
@@ -782,7 +782,7 @@ public class PropertyTransfersDesktopPanel extends ModelItemDesktopPanel<Propert
 
                 // remove read-only properties from target property
                 if (propertyCombo == targetPropertyCombo) {
-                    List<String> names = new ArrayList<String>();
+                    List<String> names = new ArrayList<>();
                     for (String name : propertyNames) {
                         TestProperty property = selectedItem.getProperty(name);
                         if (property != null && !property.isReadOnly()) {
@@ -1236,7 +1236,7 @@ public class PropertyTransfersDesktopPanel extends ModelItemDesktopPanel<Propert
     }
 
     private class TransfersTableModel extends AbstractTableModel {
-        private List<PropertyTransfersTestStep.PropertyTransferResult> results = new ArrayList<PropertyTransfersTestStep.PropertyTransferResult>();
+        private List<PropertyTransfersTestStep.PropertyTransferResult> results = new ArrayList<>();
 
         public synchronized int getRowCount() {
             int sum = 0;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/RestTestRequestPanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/RestTestRequestPanelBuilder.java
@@ -44,7 +44,7 @@ public class RestTestRequestPanelBuilder extends EmptyPanelBuilder<RestTestReque
 
     public JPanel buildOverviewPanel(RestTestRequestStep testStep) {
         RestTestRequestInterface request = testStep.getTestRequest();
-        JPropertiesTable<RestTestRequestInterface> table = new JPropertiesTable<RestTestRequestInterface>(
+        JPropertiesTable<RestTestRequestInterface> table = new JPropertiesTable<>(
                 "REST TestRequest Properties");
 
         // basic properties

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/WsdlMockResponseStepDesktopPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/WsdlMockResponseStepDesktopPanel.java
@@ -96,12 +96,12 @@ public class WsdlMockResponseStepDesktopPanel extends AbstractWsdlMockResponseDe
 
         assertionsPanel = buildAssertionsPanel();
 
-        assertionInspector = new JComponentInspector<JComponent>(assertionsPanel, "Assertions ("
+        assertionInspector = new JComponentInspector<>(assertionsPanel, "Assertions ("
                 + getModelItem().getAssertionCount() + ")", "Assertions for this Request", true);
 
         inspectorPanel.addInspector(assertionInspector);
 
-        logInspector = new JComponentInspector<JComponent>(buildLogPanel(), "Request Log (0)", "Log of requests", true);
+        logInspector = new JComponentInspector<>(buildLogPanel(), "Request Log (0)", "Log of requests", true);
         inspectorPanel.addInspector(logInspector);
 
         inspectorPanel.addInspector(new JComponentInspector<JComponent>(buildQueryMatchPanel(), "Query/Match",
@@ -200,7 +200,7 @@ public class WsdlMockResponseStepDesktopPanel extends AbstractWsdlMockResponseDe
     private Component buildMatchEditor() {
         JPanel panel = new JPanel(new BorderLayout());
 
-        matchEditorModel = new ModelItemPropertyEditorModel<WsdlMockResponseTestStep>(getModelItem(), "match");
+        matchEditorModel = new ModelItemPropertyEditorModel<>(getModelItem(), "match");
         panel.add(UISupport.getEditorFactory().buildXmlEditor(matchEditorModel), BorderLayout.CENTER);
 
         UISupport.addTitledBorder(panel, "Matching Value");
@@ -211,7 +211,7 @@ public class WsdlMockResponseStepDesktopPanel extends AbstractWsdlMockResponseDe
     private Component buildQueryEditor() {
         JPanel panel = new JPanel(new BorderLayout());
 
-        queryEditorModel = new ModelItemPropertyEditorModel<WsdlMockResponseTestStep>(getModelItem(), "query");
+        queryEditorModel = new ModelItemPropertyEditorModel<>(getModelItem(), "query");
         panel.add(UISupport.getEditorFactory().buildXPathEditor(queryEditorModel), BorderLayout.CENTER);
 
         UISupport.addTitledBorder(panel, "XPath Query");

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/WsdlTestRequestPanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/WsdlTestRequestPanelBuilder.java
@@ -46,7 +46,7 @@ public class WsdlTestRequestPanelBuilder extends EmptyPanelBuilder<WsdlTestReque
 
     public JPanel buildOverviewPanel(WsdlTestRequestStep testStep) {
         WsdlTestRequest request = testStep.getTestRequest();
-        JPropertiesTable<WsdlTestRequest> table = new JPropertiesTable<WsdlTestRequest>("TestRequest Properties");
+        JPropertiesTable<WsdlTestRequest> table = new JPropertiesTable<>("TestRequest Properties");
 
         // basic properties
         table.addProperty("Name", "name", true);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/amf/AMFRequest.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/amf/AMFRequest.java
@@ -65,7 +65,7 @@ public class AMFRequest extends AbstractModelItem implements Assertable, TestReq
     public static final String AMF_RESPONSE_PROPERTY = "response";
 
     private final AMFRequestTestStep testStep;
-    private Set<SubmitListener> submitListeners = new HashSet<SubmitListener>();
+    private Set<SubmitListener> submitListeners = new HashSet<>();
     private AMFResponse response;
     private SoapUIScriptEngine scriptEngine;
     private String endpoint;
@@ -73,7 +73,7 @@ public class AMFRequest extends AbstractModelItem implements Assertable, TestReq
     private String script;
     private HashMap<String, TestProperty> propertyMap;
     private String[] propertyNames;
-    private List<Object> arguments = new ArrayList<Object>();
+    private List<Object> arguments = new ArrayList<>();
     private StringToStringsMap httpHeaders;
     private StringToObjectMap amfHeaders;
     private StringToStringMap amfHeadersString;
@@ -103,8 +103,8 @@ public class AMFRequest extends AbstractModelItem implements Assertable, TestReq
 
     public boolean executeAmfScript(SubmitContext context) {
         boolean scriptOK = true;
-        HashMap<String, Object> parameters = new HashMap<String, Object>();
-        HashMap<String, Object> amfHeadersTemp = new HashMap<String, Object>();
+        HashMap<String, Object> parameters = new HashMap<>();
+        HashMap<String, Object> amfHeadersTemp = new HashMap<>();
         try {
             scriptEngine.setScript(script);
             scriptEngine.setVariable("parameters", parameters);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/amf/AMFRequestTestStepDesktopPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/amf/AMFRequestTestStepDesktopPanel.java
@@ -337,7 +337,7 @@ public class AMFRequestTestStepDesktopPanel extends ModelItemDesktopPanel<AMFReq
                 return new DefaultPropertyHolderTableModel(holder) {
                     @Override
                     public String[] getPropertyNames() {
-                        List<String> propertyNamesList = new ArrayList<String>();
+                        List<String> propertyNamesList = new ArrayList<>();
                         for (String name : holder.getPropertyNames()) {
                             if (name.equals(WsdlTestStepWithProperties.RESPONSE_AS_XML)) {
                                 continue;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/amf/AMFResponse.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/amf/AMFResponse.java
@@ -53,7 +53,7 @@ public class AMFResponse extends AbstractResponse<AMFRequest> {
     private byte[] rawResponseBody;
 
     public AMFResponse(AMFRequest request, SubmitContext submitContext, Object responseContent) throws SQLException,
-            ParserConfigurationException, TransformerConfigurationException, TransformerException {
+            ParserConfigurationException, TransformerException {
         super(request);
 
         this.request = request;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/amf/SoapUIAMFConnection.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/amf/SoapUIAMFConnection.java
@@ -106,7 +106,7 @@ public class SoapUIAMFConnection {
      */
     public void addAmfHeader(String name, boolean mustUnderstand, Object data) {
         if (amfHeaders == null) {
-            amfHeaders = new ArrayList<MessageHeader>();
+            amfHeaders = new ArrayList<>();
         }
 
         MessageHeader header = new MessageHeader(name, mustUnderstand, data);
@@ -161,7 +161,7 @@ public class SoapUIAMFConnection {
      */
     public void addHttpRequestHeader(String name, String value) {
         if (httpRequestHeaders == null) {
-            httpRequestHeaders = new HashMap<String, String>();
+            httpRequestHeaders = new HashMap<>();
         }
 
         httpRequestHeaders.put(name, value);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/support/PropertyHolderTable.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/teststeps/support/PropertyHolderTable.java
@@ -354,7 +354,7 @@ public class PropertyHolderTable extends JPanel {
                     String line = reader.readLine();
                     int count = 0;
 
-                    Set<String> names = new HashSet<String>(Arrays.asList(holder.getPropertyNames()));
+                    Set<String> names = new HashSet<>(Arrays.asList(holder.getPropertyNames()));
 
                     while (line != null) {
                         if (line.trim().length() > 0 && !(line.charAt(0) == '#')) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/testsuite/JTestSuiteTestCaseList.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/testsuite/JTestSuiteTestCaseList.java
@@ -67,7 +67,7 @@ import java.util.Map;
  */
 
 public class JTestSuiteTestCaseList extends JPanel {
-    private Map<TestCase, TestCaseListPanel> panels = new HashMap<TestCase, TestCaseListPanel>();
+    private Map<TestCase, TestCaseListPanel> panels = new HashMap<>();
     private final WsdlTestSuite testSuite;
     private final InternalTestSuiteListener testSuiteListener = new InternalTestSuiteListener();
     private TestCaseListPanel selectedTestCase;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/testsuite/WsdlTestSuitePanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/panels/testsuite/WsdlTestSuitePanelBuilder.java
@@ -42,7 +42,7 @@ public class WsdlTestSuitePanelBuilder<T extends WsdlTestSuite> extends EmptyPan
     }
 
     public Component buildOverviewPanel(T modelItem) {
-        JPropertiesTable<WsdlTestSuite> table = new JPropertiesTable<WsdlTestSuite>("TestSuite Properties", modelItem);
+        JPropertiesTable<WsdlTestSuite> table = new JPropertiesTable<>("TestSuite Properties", modelItem);
 
         table.addProperty("Name", "name", true);
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/AbstractRestMessageExchange.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/AbstractRestMessageExchange.java
@@ -40,7 +40,7 @@ public abstract class AbstractRestMessageExchange<T extends ModelItem> extends A
     }
 
     public Attachment[] getResponseAttachmentsForPart(String name) {
-        List<Attachment> result = new ArrayList<Attachment>();
+        List<Attachment> result = new ArrayList<>();
 
         if (getResponseAttachments() != null) {
             for (Attachment attachment : getResponseAttachments()) {
@@ -54,7 +54,7 @@ public abstract class AbstractRestMessageExchange<T extends ModelItem> extends A
     }
 
     public Attachment[] getRequestAttachmentsForPart(String name) {
-        List<Attachment> result = new ArrayList<Attachment>();
+        List<Attachment> result = new ArrayList<>();
 
         for (Attachment attachment : getRequestAttachments()) {
             if (attachment.getPart().equals(name)) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/AbstractWsdlMessageExchange.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/AbstractWsdlMessageExchange.java
@@ -44,7 +44,7 @@ public abstract class AbstractWsdlMessageExchange<T extends ModelItem> extends A
     public abstract WsdlOperation getOperation();
 
     public Attachment[] getResponseAttachmentsForPart(String name) {
-        List<Attachment> result = new ArrayList<Attachment>();
+        List<Attachment> result = new ArrayList<>();
 
         if (getResponseAttachments() != null) {
             for (Attachment attachment : getResponseAttachments()) {
@@ -58,7 +58,7 @@ public abstract class AbstractWsdlMessageExchange<T extends ModelItem> extends A
     }
 
     public Attachment[] getRequestAttachmentsForPart(String name) {
-        List<Attachment> result = new ArrayList<Attachment>();
+        List<Attachment> result = new ArrayList<>();
 
         for (Attachment attachment : getRequestAttachments()) {
             if (attachment.getPart().equals(name)) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/RequestTransportRegistry.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/RequestTransportRegistry.java
@@ -58,8 +58,8 @@ public class RequestTransportRegistry {
     public static final String HTTPS = "https";
     public static final String JMS = "jms";
 
-    private static Map<String, RequestTransport> transports = new HashMap<String, RequestTransport>();
-    private static Map<String, List<RequestFilter>> addedCustomRequestFilters = new HashMap<String, List<RequestFilter>>();
+    private static Map<String, RequestTransport> transports = new HashMap<>();
+    private static Map<String, List<RequestFilter>> addedCustomRequestFilters = new HashMap<>();
 
     private static WsdlPackagingRequestFilter wsdlPackagingRequestFilter;
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/filters/GlobalHttpHeadersRequestFilter.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/filters/GlobalHttpHeadersRequestFilter.java
@@ -51,7 +51,7 @@ public class GlobalHttpHeadersRequestFilter extends AbstractRequestFilter {
     private static StringToStringsMap globalHeadersToAdd = new StringToStringsMap();
 
     private StringToStringsMap headersToAdd;
-    private Map<AbstractHttpRequest, StringToStringsMap> savedHeaders = new HashMap<AbstractHttpRequest, StringToStringsMap>();
+    private Map<AbstractHttpRequest, StringToStringsMap> savedHeaders = new HashMap<>();
 
     @Override
     public void filterAbstractHttpRequest(SubmitContext context, AbstractHttpRequest<?> request) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/filters/HttpRequestFilter.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/filters/HttpRequestFilter.java
@@ -291,7 +291,7 @@ public class HttpRequestFilter extends AbstractRequestFilter {
             } else {
                 String requestContent = PropertyExpander.expandProperties(context, request.getRequestContent(),
                         request.isEntitizeProperties());
-                List<Attachment> attachments = new ArrayList<Attachment>();
+                List<Attachment> attachments = new ArrayList<>();
 
                 for (Attachment attachment : request.getAttachments()) {
                     if (attachment.getContentType().equals(request.getMediaType())) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/filters/OAuth2RequestFilter.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/filters/OAuth2RequestFilter.java
@@ -117,7 +117,7 @@ public class OAuth2RequestFilter extends AbstractRequestFilter {
         return !(issuedTime <= 0 || expirationTime <= 0) && expirationTime < (currentTime + 10) - issuedTime;
     }
 
-    private long convertExpirationTimeToSeconds(String expirationTimeString, TimeUnitConfig.Enum timeUnit) throws IllegalArgumentException {
+    private long convertExpirationTimeToSeconds(String expirationTimeString, TimeUnitConfig.Enum timeUnit) {
         long expirationTime;
         try {
             expirationTime = Long.valueOf(expirationTimeString.trim());

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/BaseHttpResponse.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/BaseHttpResponse.java
@@ -65,7 +65,7 @@ public abstract class BaseHttpResponse implements HttpResponse {
 
     public BaseHttpResponse(ExtendedHttpMethod httpMethod, AbstractHttpRequestInterface<?> httpRequest,
                             PropertyExpansionContext context) {
-        this.httpRequest = new WeakReference<AbstractHttpRequestInterface<?>>(httpRequest);
+        this.httpRequest = new WeakReference<>(httpRequest);
         this.timeTaken = httpMethod.getTimeTaken();
 
         SoapUIMetrics metrics = httpMethod.getMetrics();

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/HTMLPageSourceDownloader.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/HTMLPageSourceDownloader.java
@@ -41,7 +41,7 @@ import java.util.List;
 
 public class HTMLPageSourceDownloader {
     WebClient client = new WebClient();
-    List<String> missingResourcesList = new ArrayList<String>();
+    List<String> missingResourcesList = new ArrayList<>();
     public static final String MISSING_RESOURCES_LIST = "MissingResourcesList";
 
     public static final HashMap<String, String> acceptTypes = new HashMap<String, String>() {
@@ -53,7 +53,7 @@ public class HTMLPageSourceDownloader {
         }
     };
 
-    List<Attachment> attachmentList = new ArrayList<Attachment>();
+    List<Attachment> attachmentList = new ArrayList<>();
 
     protected List<Attachment> downloadCssAndImages(String endpoint, HttpRequest request)
             throws MalformedURLException, IOException {
@@ -61,7 +61,7 @@ public class HTMLPageSourceDownloader {
         String xPathExpression = "//*[name() = 'img' or name() = 'link' and @type = 'text/css']";
         List<?> resultList = htmlPage.getByXPath(xPathExpression);
         byte[] bytes = null;
-        List<Attachment> attachmentList = new ArrayList<Attachment>();
+        List<Attachment> attachmentList = new ArrayList<>();
         Iterator<?> i = resultList.iterator();
         while (i.hasNext()) {
             try {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/HTMLPageSourceDownloader.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/HTMLPageSourceDownloader.java
@@ -56,7 +56,7 @@ public class HTMLPageSourceDownloader {
     List<Attachment> attachmentList = new ArrayList<>();
 
     protected List<Attachment> downloadCssAndImages(String endpoint, HttpRequest request)
-            throws MalformedURLException, IOException {
+            throws IOException {
         HtmlPage htmlPage = client.getPage(endpoint);
         String xPathExpression = "//*[name() = 'img' or name() = 'link' and @type = 'text/css']";
         List<?> resultList = htmlPage.getByXPath(xPathExpression);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/HttpClientRequestTransport.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/HttpClientRequestTransport.java
@@ -75,7 +75,7 @@ import java.util.List;
  */
 
 public class HttpClientRequestTransport implements BaseHttpRequestTransport {
-    private List<RequestFilter> filters = new ArrayList<RequestFilter>();
+    private List<RequestFilter> filters = new ArrayList<>();
     public static final String USER_TOKEN_FOR_SSL = "http.user-token-ssl";
 
     public HttpClientRequestTransport() {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/support/attachments/AttachmentUtils.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/support/attachments/AttachmentUtils.java
@@ -88,7 +88,7 @@ public class AttachmentUtils {
     public static final long MAX_SIZE_IN_MEMORY_ATTACHMENT = 500 * 1024;
 
     public static boolean prepareMessagePart(WsdlAttachmentContainer container, MimeMultipart mp,
-                                             MessageXmlPart messagePart, StringToStringMap contentIds) throws Exception, MessagingException {
+                                             MessageXmlPart messagePart, StringToStringMap contentIds) throws Exception {
         boolean isXop = false;
 
         XmlObjectTreeModel treeModel = null;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/support/attachments/AttachmentUtils.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/support/attachments/AttachmentUtils.java
@@ -410,7 +410,7 @@ public class AttachmentUtils {
 
     public static List<HttpAttachmentPart> extractAttachmentParts(WsdlOperation operation, String messageContent,
                                                                   boolean addAnonymous, boolean isResponse, boolean forceMtom) {
-        List<HttpAttachmentPart> result = new ArrayList<HttpAttachmentPart>();
+        List<HttpAttachmentPart> result = new ArrayList<>();
 
         PartsConfig messageParts = isResponse ? operation.getConfig().getResponseParts() : operation.getConfig()
                 .getRequestParts();
@@ -502,7 +502,7 @@ public class AttachmentUtils {
             }
         } else {
             // first identify if any part has more than one attachments
-            Map<String, List<Attachment>> attachmentsMap = new HashMap<String, List<Attachment>>();
+            Map<String, List<Attachment>> attachmentsMap = new HashMap<>();
             for (int c = 0; c < attachments.size(); c++) {
                 Attachment att = attachments.get(c);
                 if (att.getAttachmentType() == Attachment.AttachmentType.CONTENT) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/support/attachments/HttpRequestMimeMessageRequestEntity.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/support/attachments/HttpRequestMimeMessageRequestEntity.java
@@ -83,7 +83,7 @@ public class HttpRequestMimeMessageRequestEntity extends AbstractHttpEntity {
     }
 
     @Override
-    public InputStream getContent() throws IOException, IllegalStateException {
+    public InputStream getContent() throws IOException {
         try {
             return message.getInputStream();
         } catch (MessagingException e) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/support/attachments/MimeMessageMockResponseEntity.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/support/attachments/MimeMessageMockResponseEntity.java
@@ -99,7 +99,7 @@ public class MimeMessageMockResponseEntity extends AbstractHttpEntity {
     }
 
     @Override
-    public InputStream getContent() throws IOException, IllegalStateException {
+    public InputStream getContent() throws IOException {
         try {
             return message.getInputStream();
         } catch (MessagingException e) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/support/attachments/MultipartMessageSupport.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/support/attachments/MultipartMessageSupport.java
@@ -42,7 +42,7 @@ import java.util.List;
  */
 
 public class MultipartMessageSupport {
-    private final List<BodyPartAttachment> attachments = new ArrayList<BodyPartAttachment>();
+    private final List<BodyPartAttachment> attachments = new ArrayList<>();
     private Attachment rootPart;
     private MimeMessage message;
     private String responseContent;
@@ -107,7 +107,7 @@ public class MultipartMessageSupport {
     }
 
     public Attachment[] getAttachmentsForPart(String partName) {
-        List<Attachment> results = new ArrayList<Attachment>();
+        List<Attachment> results = new ArrayList<>();
 
         for (Attachment attachment : attachments) {
             if (attachment.getPart().equals(partName)) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/support/attachments/RestRequestMimeMessageRequestEntity.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/support/attachments/RestRequestMimeMessageRequestEntity.java
@@ -83,7 +83,7 @@ public class RestRequestMimeMessageRequestEntity extends AbstractHttpEntity {
     }
 
     @Override
-    public InputStream getContent() throws IOException, IllegalStateException {
+    public InputStream getContent() throws IOException {
         try {
             return message.getInputStream();
         } catch (MessagingException e) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/support/attachments/WsdlMimeMessageResponse.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/support/attachments/WsdlMimeMessageResponse.java
@@ -98,7 +98,7 @@ public class WsdlMimeMessageResponse extends MimeMessageResponse implements Wsdl
                 }
             } catch (Exception e) {
                 if (wssResult == null) {
-                    wssResult = new Vector<Object>();
+                    wssResult = new Vector<>();
                 }
                 wssResult.add(e);
             }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/support/attachments/WsdlSinglePartHttpResponse.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/http/support/attachments/WsdlSinglePartHttpResponse.java
@@ -52,7 +52,7 @@ public class WsdlSinglePartHttpResponse extends SinglePartHttpResponse implement
                 }
             } catch (Exception e) {
                 if (wssResult == null) {
-                    wssResult = new Vector<Object>();
+                    wssResult = new Vector<>();
                 }
                 wssResult.add(e);
             }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/jms/HermesJmsRequestTransport.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/jms/HermesJmsRequestTransport.java
@@ -86,7 +86,7 @@ public class HermesJmsRequestTransport implements RequestTransport {
     protected boolean sendAsBytesMessage;
     protected boolean addSoapAction;
     protected Hermes hermes;
-    protected static List<RequestFilter> filters = new ArrayList<RequestFilter>();
+    protected static List<RequestFilter> filters = new ArrayList<>();
 
     public Response sendRequest(SubmitContext submitContext, Request request) throws Exception {
         long timeStarted = Calendar.getInstance().getTimeInMillis();

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/jms/JMSEndpoint.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/jms/JMSEndpoint.java
@@ -93,7 +93,7 @@ public class JMSEndpoint {
         }
     }
 
-    private boolean checkParameterIndex(int parameterIndex, String[] parameters) throws IllegalArgumentException {
+    private boolean checkParameterIndex(int parameterIndex, String[] parameters) {
         if (parameterIndex < 0 || parameterIndex > 2) {
             throw new IllegalArgumentException(
                     "\n" +

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/jms/JMSResponse.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/jms/JMSResponse.java
@@ -97,7 +97,7 @@ public class JMSResponse implements WsdlResponse {
     }
 
     public String[] getPropertyNames() {
-        List<String> propertyNames = new ArrayList<String>();
+        List<String> propertyNames = new ArrayList<>();
         Enumeration<?> temp;
         try {
             if (messageReceive != null) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/jms/util/HermesUtils.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/jms/util/HermesUtils.java
@@ -49,7 +49,7 @@ import java.util.Set;
 
 public class HermesUtils {
     private static ClassLoader hermesClassLoader;
-    private static Map<String, Context> contextMap = new HashMap<String, Context>();
+    private static Map<String, Context> contextMap = new HashMap<>();
     public static String HERMES_CONFIG_XML = "hermes-config.xml";
 
     private static HashSet<String> classesToBeLoadedByParentClassLoader = new HashSet<>();
@@ -138,7 +138,7 @@ public class HermesUtils {
         File[] children = dir.listFiles();
         if (children != null) {
             ClassLoader currentClassLoader = Hermes.class.getClassLoader();
-            List<URL> urls = new ArrayList<URL>();
+            List<URL> urls = new ArrayList<>();
             for (File file : children) {
                 // fix for users using version of hermesJMS which still has
                 // cglib-2.1.3.jar in lib directory

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/jms/util/HermesUtils.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/submit/transports/jms/util/HermesUtils.java
@@ -77,15 +77,15 @@ public class HermesUtils {
         return hermesClassLoader;
     }
 
-    public static Context hermesContext(WsdlProject project) throws NamingException, MalformedURLException,
-            IOException {
+    public static Context hermesContext(WsdlProject project) throws NamingException, 
+           IOException {
         String expandedHermesConfigPath = PropertyExpander.expandProperties(project, project.getHermesConfig());
         String key = project.getName() + expandedHermesConfigPath;
         return getHermes(key, expandedHermesConfigPath);
     }
 
     public static Context hermesContext(WsdlProject project, String hermesConfigPath) throws NamingException,
-            MalformedURLException, IOException {
+    IOException {
         String expandedHermesConfigPath = PropertyExpander.expandProperties(project, hermesConfigPath);
         String key = project.getName() + expandedHermesConfigPath;
         return getHermes(key, expandedHermesConfigPath);
@@ -93,8 +93,8 @@ public class HermesUtils {
 
     // private static URLClassLoader hermesClassLoader;
 
-    private static Context getHermes(String key, String hermesConfigPath) throws IOException, MalformedURLException,
-            NamingException {
+    private static Context getHermes(String key, String hermesConfigPath) throws IOException, 
+           NamingException {
         SoapUIClassLoaderState state = SoapUIExtensionClassLoader.ensure();
         if (hermesClassLoader == null) {
             addHermesJarsToClasspath();
@@ -120,7 +120,7 @@ public class HermesUtils {
         }
     }
 
-    private static void addHermesJarsToClasspath() throws IOException, MalformedURLException {
+    private static void addHermesJarsToClasspath() throws IOException {
         String hermesHome = SoapUI.getSettings().getString(ToolsSettings.HERMES_JMS, defaultHermesJMSPath());
 
         if (hermesHome == null || "".equals(hermesHome)) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/FileAttachment.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/FileAttachment.java
@@ -128,7 +128,7 @@ public abstract class FileAttachment<T extends AbstractWsdlModelItem<?>> impleme
         return modelItem;
     }
 
-    public void cacheFileLocally(File file) throws FileNotFoundException, IOException {
+    public void cacheFileLocally(File file) throws IOException {
         // write attachment-data to tempfile
         ByteArrayOutputStream data = new ByteArrayOutputStream();
         ZipOutputStream out = new ZipOutputStream(data);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/MapTestPropertyHolder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/MapTestPropertyHolder.java
@@ -41,9 +41,9 @@ import java.util.Properties;
 import java.util.Set;
 
 public class MapTestPropertyHolder implements MutableTestPropertyHolder {
-    private Map<String, TestProperty> propertyMap = new HashMap<String, TestProperty>();
-    private Set<TestPropertyListener> listeners = new HashSet<TestPropertyListener>();
-    private List<TestProperty> properties = new ArrayList<TestProperty>();
+    private Map<String, TestProperty> propertyMap = new HashMap<>();
+    private Set<TestPropertyListener> listeners = new HashSet<>();
+    private List<TestProperty> properties = new ArrayList<>();
     public ModelItem modelItem;
     private String propertiesLabel = "Test Properties";
 
@@ -245,7 +245,7 @@ public class MapTestPropertyHolder implements MutableTestPropertyHolder {
     }
 
     public Map<String, TestProperty> getProperties() {
-        Map<String, TestProperty> result = new HashMap<String, TestProperty>();
+        Map<String, TestProperty> result = new HashMap<>();
         for (String name : propertyMap.keySet()) {
             result.put(name, propertyMap.get(name));
         }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/MessageXmlObject.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/MessageXmlObject.java
@@ -42,7 +42,7 @@ import java.util.List;
 public class MessageXmlObject {
     private XmlObject messageObj;
     private WsdlContext wsdlContext;
-    private List<MessageXmlPart> messageParts = new ArrayList<MessageXmlPart>();
+    private List<MessageXmlPart> messageParts = new ArrayList<>();
 
     private final static Logger log = LogManager.getLogger(MessageXmlObject.class);
     private final String messageContent;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/XmlBeansPropertiesTestPropertyHolder.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/XmlBeansPropertiesTestPropertyHolder.java
@@ -48,9 +48,9 @@ import java.util.Set;
 
 public class XmlBeansPropertiesTestPropertyHolder implements MutableTestPropertyHolder, Map<String, TestProperty> {
     private PropertiesTypeConfig config;
-    private List<PropertiesStepProperty> properties = new ArrayList<PropertiesStepProperty>();
-    private Map<String, PropertiesStepProperty> propertyMap = new LinkedHashMap<String, PropertiesStepProperty>();
-    private Set<TestPropertyListener> listeners = new HashSet<TestPropertyListener>();
+    private List<PropertiesStepProperty> properties = new ArrayList<>();
+    private Map<String, PropertiesStepProperty> propertyMap = new LinkedHashMap<>();
+    private Set<TestPropertyListener> listeners = new HashSet<>();
     private ModelItem modelItem;
     private Properties overrideProperties;
     private String propertiesLabel = "Test Properties";
@@ -92,8 +92,8 @@ public class XmlBeansPropertiesTestPropertyHolder implements MutableTestProperty
      * placed after properties
      */
     private void sortVirtualLast() {
-        List<PropertiesStepProperty> virtualProperties = new ArrayList<PropertiesStepProperty>();
-        List<PropertiesStepProperty> nonVirtualProperties = new ArrayList<PropertiesStepProperty>();
+        List<PropertiesStepProperty> virtualProperties = new ArrayList<>();
+        List<PropertiesStepProperty> nonVirtualProperties = new ArrayList<>();
 
         for (PropertiesStepProperty psp : properties) {
             if (psp.isVirtualProperty()) {
@@ -167,7 +167,7 @@ public class XmlBeansPropertiesTestPropertyHolder implements MutableTestProperty
     }
 
     public List<TestProperty> getPropertyList() {
-        List<TestProperty> result = new ArrayList<TestProperty>();
+        List<TestProperty> result = new ArrayList<>();
 
         for (TestProperty property : properties) {
             result.add(property);
@@ -391,7 +391,7 @@ public class XmlBeansPropertiesTestPropertyHolder implements MutableTestProperty
     }
 
     public Map<String, TestProperty> getProperties() {
-        Map<String, TestProperty> result = new LinkedHashMap<String, TestProperty>();
+        Map<String, TestProperty> result = new LinkedHashMap<>();
         for (TestProperty property : propertyMap.values()) {
             result.put(property.getName(), property);
         }
@@ -449,7 +449,7 @@ public class XmlBeansPropertiesTestPropertyHolder implements MutableTestProperty
     }
 
     public PropertyExpansion[] getPropertyExpansions() {
-        List<PropertyExpansion> result = new ArrayList<PropertyExpansion>();
+        List<PropertyExpansion> result = new ArrayList<>();
 
         return result.toArray(new PropertyExpansion[result.size()]);
     }
@@ -506,7 +506,7 @@ public class XmlBeansPropertiesTestPropertyHolder implements MutableTestProperty
     }
 
     public Set<java.util.Map.Entry<String, TestProperty>> entrySet() {
-        HashSet<java.util.Map.Entry<String, TestProperty>> result = new HashSet<Entry<String, TestProperty>>();
+        HashSet<java.util.Map.Entry<String, TestProperty>> result = new HashSet<>();
 
         for (TestProperty p : propertyMap.values()) {
             // This does not compile on JDK 1.5:
@@ -549,7 +549,7 @@ public class XmlBeansPropertiesTestPropertyHolder implements MutableTestProperty
     }
 
     public Set<String> keySet() {
-        return new HashSet<String>(Arrays.asList(getPropertyNames()));
+        return new HashSet<>(Arrays.asList(getPropertyNames()));
     }
 
     public TestProperty put(String key, TestProperty value) {
@@ -573,7 +573,7 @@ public class XmlBeansPropertiesTestPropertyHolder implements MutableTestProperty
     }
 
     public Collection<TestProperty> values() {
-        ArrayList<TestProperty> result = new ArrayList<TestProperty>();
+        ArrayList<TestProperty> result = new ArrayList<>();
         result.addAll(propertyMap.values());
         return result;
     }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/assertions/AssertionsSupport.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/assertions/AssertionsSupport.java
@@ -44,8 +44,8 @@ import java.util.Map;
  */
 
 public class AssertionsSupport implements PropertyChangeListener {
-    private List<AssertionsListener> assertionsListeners = new ArrayList<AssertionsListener>();
-    private List<WsdlMessageAssertion> assertions = new ArrayList<WsdlMessageAssertion>();
+    private List<AssertionsListener> assertionsListeners = new ArrayList<>();
+    private List<WsdlMessageAssertion> assertions = new ArrayList<>();
     private final Assertable assertable;
     private AssertableConfig assertableConfig;
 
@@ -203,7 +203,7 @@ public class AssertionsSupport implements PropertyChangeListener {
     }
 
     public List<WsdlMessageAssertion> getAssertionsOfType(Class<? extends WsdlMessageAssertion> class1) {
-        List<WsdlMessageAssertion> result = new ArrayList<WsdlMessageAssertion>();
+        List<WsdlMessageAssertion> result = new ArrayList<>();
 
         for (WsdlMessageAssertion assertion : assertions) {
             if (assertion.getClass().equals(class1)) {
@@ -225,7 +225,7 @@ public class AssertionsSupport implements PropertyChangeListener {
     }
 
     public Map<String, TestAssertion> getAssertions() {
-        Map<String, TestAssertion> result = new HashMap<String, TestAssertion>();
+        Map<String, TestAssertion> result = new HashMap<>();
 
         for (TestAssertion assertion : assertions) {
             result.put(assertion.getName(), assertion);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/http/HttpClientSupport.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/http/HttpClientSupport.java
@@ -539,8 +539,8 @@ public class HttpClientSupport {
             return httpClient;
         }
 
-        public HttpResponse execute(ExtendedHttpMethod method, HttpContext httpContext) throws ClientProtocolException,
-                IOException {
+        public HttpResponse execute(ExtendedHttpMethod method, HttpContext httpContext) throws 
+               IOException {
             method.afterWriteRequest();
             if (method.getMetrics() != null) {
                 method.getMetrics().getConnectTimer().start();
@@ -551,7 +551,7 @@ public class HttpClientSupport {
             return httpResponse;
         }
 
-        public HttpResponse execute(ExtendedHttpMethod method) throws ClientProtocolException, IOException {
+        public HttpResponse execute(ExtendedHttpMethod method) throws IOException {
             method.afterWriteRequest();
             if (method.getMetrics() != null) {
                 method.getMetrics().getConnectTimer().start();
@@ -610,11 +610,11 @@ public class HttpClientSupport {
     }
 
     public static HttpResponse execute(ExtendedHttpMethod method, HttpContext httpContext)
-            throws ClientProtocolException, IOException {
+            throws IOException {
         return helper.execute(method, httpContext);
     }
 
-    public static HttpResponse execute(ExtendedHttpMethod method) throws ClientProtocolException, IOException {
+    public static HttpResponse execute(ExtendedHttpMethod method) throws IOException {
         return helper.execute(method);
     }
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/http/SoapUISSLSocketFactory.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/http/SoapUISSLSocketFactory.java
@@ -209,8 +209,8 @@ public class SoapUISSLSocketFactory extends SSLConnectionSocketFactory {
      * @since 4.1
      */
     @Override
-    public Socket connectSocket(int connectTimeout, Socket socket, HttpHost host, InetSocketAddress remoteAddress, InetSocketAddress localAddress, HttpContext context) throws IOException,
-            UnknownHostException, ConnectTimeoutException {
+    public Socket connectSocket(int connectTimeout, Socket socket, HttpHost host, InetSocketAddress remoteAddress, InetSocketAddress localAddress, HttpContext context) throws IOException
+    {
         if (remoteAddress == null) {
             throw new IllegalArgumentException("Remote address may not be null");
         }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/http/SoapUISSLSocketFactory.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/http/SoapUISSLSocketFactory.java
@@ -56,7 +56,7 @@ public class SoapUISSLSocketFactory extends SSLConnectionSocketFactory {
 
     private final static Logger log = LogManager.getLogger(SoapUISSLSocketFactory.class);
     // A cache of factories for custom certificates/Keystores at the project level - never cleared
-    private static final Map<String, SSLConnectionSocketFactory> factoryMap = new ConcurrentHashMap<String, SSLConnectionSocketFactory>();
+    private static final Map<String, SSLConnectionSocketFactory> factoryMap = new ConcurrentHashMap<>();
 
     private final SSLContext sslContext;
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/policy/PolicyUtils.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/policy/PolicyUtils.java
@@ -44,7 +44,7 @@ public class PolicyUtils {
 
     public static List<Policy> getPolicies(WsdlContext wsdlContext) {
 
-        List<Policy> policies = new ArrayList<Policy>();
+        List<Policy> policies = new ArrayList<>();
         try {
             List<InterfaceDefinitionPart> parts = wsdlContext.getDefinitionCache().getDefinitionParts();
             for (int i = 0; i < parts.size(); i++) {
@@ -103,7 +103,7 @@ public class PolicyUtils {
     }
 
     public static List<Policy> getAddressingPolicies(WsdlContext wsdlContext) {
-        List<Policy> addressingPolicies = new ArrayList<Policy>();
+        List<Policy> addressingPolicies = new ArrayList<>();
         List<Policy> policies = getPolicies(wsdlContext);
         for (Policy policy : policies) {
             if (isAddressing(policy)) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/soap/AbstractSoapVersion.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/soap/AbstractSoapVersion.java
@@ -41,7 +41,7 @@ public abstract class AbstractSoapVersion implements SoapVersion {
 
     @SuppressWarnings("unchecked")
     public void validateSoapEnvelope(String soapMessage, List<XmlError> errors) {
-        List<XmlError> errorList = new ArrayList<XmlError>();
+        List<XmlError> errorList = new ArrayList<>();
 
         try {
             XmlOptions xmlOptions = new XmlOptions();

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wsdl/CachedWsdlLoader.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wsdl/CachedWsdlLoader.java
@@ -129,7 +129,7 @@ public class CachedWsdlLoader extends WsdlLoader {
             throw new Exception("Failed to create directory [" + folderName + "]");
         }
 
-        Map<String, String> urlToFileMap = new HashMap<String, String>();
+        Map<String, String> urlToFileMap = new HashMap<>();
 
         setFilenameForUrl(config.getRootPart(), Constants.WSDL11_NS, urlToFileMap, null);
 
@@ -158,7 +158,7 @@ public class CachedWsdlLoader extends WsdlLoader {
 
     public StringToStringMap createFilesForExport(String urlPrefix) throws Exception {
         StringToStringMap result = new StringToStringMap();
-        Map<String, String> urlToFileMap = new HashMap<String, String>();
+        Map<String, String> urlToFileMap = new HashMap<>();
 
         if (urlPrefix == null) {
             urlPrefix = "";

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wsdl/UrlWsdlLoader.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wsdl/UrlWsdlLoader.java
@@ -67,7 +67,7 @@ public class UrlWsdlLoader extends WsdlLoader {
     private HttpContext state;
     protected HttpGet getMethod;
     private boolean aborted;
-    protected Map<String, byte[]> urlCache = new HashMap<String, byte[]>();
+    protected Map<String, byte[]> urlCache = new HashMap<>();
     protected boolean finished;
     private boolean useWorker;
     private ModelItem contextModelItem;
@@ -247,7 +247,7 @@ public class UrlWsdlLoader extends WsdlLoader {
      * @author ole.matzura
      */
 
-    private static Map<AuthScope, Credentials> cache = new HashMap<AuthScope, Credentials>();
+    private static Map<AuthScope, Credentials> cache = new HashMap<>();
 
     public final class WsdlCredentialsProvider implements CredentialsProvider {
         private XFormDialog basicDialog;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wsdl/WsdlImporter.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wsdl/WsdlImporter.java
@@ -52,7 +52,7 @@ import java.util.Map;
  */
 
 public class WsdlImporter {
-    private static List<BindingImporter> bindingImporters = new ArrayList<BindingImporter>();
+    private static List<BindingImporter> bindingImporters = new ArrayList<>();
     @SuppressWarnings("unused")
     private static WsdlImporter instance;
 
@@ -89,14 +89,14 @@ public class WsdlImporter {
         }
 
         Definition definition = wsdlContext.getDefinition();
-        List<WsdlInterface> result = new ArrayList<WsdlInterface>();
+        List<WsdlInterface> result = new ArrayList<>();
         if (bindingName != null) {
             WsdlInterface iface = importBinding(project, wsdlContext,
                     (Binding) definition.getAllBindings().get(bindingName));
             return iface == null ? new WsdlInterface[0] : new WsdlInterface[]{iface};
         }
 
-        Map<Binding, WsdlInterface> importedBindings = new HashMap<Binding, WsdlInterface>();
+        Map<Binding, WsdlInterface> importedBindings = new HashMap<>();
 
         Map<?, ?> serviceMap = definition.getAllServices();
         if (serviceMap.isEmpty()) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wsdl/WsdlUtils.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wsdl/WsdlUtils.java
@@ -119,7 +119,7 @@ public class WsdlUtils {
     }
 
     public static <T extends ExtensibilityElement> List<T> getExtensiblityElements(List list, Class<T> clazz) {
-        List<T> result = new ArrayList<T>();
+        List<T> result = new ArrayList<>();
 
         for (Iterator<T> i = list.iterator(); i.hasNext(); ) {
             T elm = i.next();
@@ -136,7 +136,7 @@ public class WsdlUtils {
             return new Element[0];
         }
 
-        List<Element> result = new ArrayList<Element>();
+        List<Element> result = new ArrayList<>();
 
         List<?> list = item.getExtensibilityElements();
         for (Iterator<?> i = list.iterator(); i.hasNext(); ) {
@@ -184,7 +184,7 @@ public class WsdlUtils {
     }
 
     public static String[] getEndpointsForBinding(Definition definition, Binding binding) {
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
         Map map = definition.getAllServices();
         for (Iterator i = map.values().iterator(); i.hasNext(); ) {
             Service service = (Service) i.next();
@@ -381,7 +381,7 @@ public class WsdlUtils {
      */
 
     public static Part[] getInputParts(BindingOperation operation) {
-        List<Part> result = new ArrayList<Part>();
+        List<Part> result = new ArrayList<>();
         Input input = operation.getOperation().getInput();
         if (input == null || operation.getBindingInput() == null) {
             return new Part[0];
@@ -458,7 +458,7 @@ public class WsdlUtils {
     }
 
     public static MIMEContent[] getContentParts(Part part, MIMEMultipartRelated multipart) {
-        List<MIMEContent> result = new ArrayList<MIMEContent>();
+        List<MIMEContent> result = new ArrayList<>();
 
         if (multipart != null) {
             List<MIMEPart> parts = multipart.getMIMEParts();
@@ -479,7 +479,7 @@ public class WsdlUtils {
     }
 
     public static Part[] getFaultParts(BindingOperation bindingOperation, String faultName) throws Exception {
-        List<Part> result = new ArrayList<Part>();
+        List<Part> result = new ArrayList<>();
 
         BindingFault bindingFault = bindingOperation.getBindingFault(faultName);
         SOAPFault soapFault = WsdlUtils.getExtensiblityElement(bindingFault.getExtensibilityElements(), SOAPFault.class);
@@ -567,7 +567,7 @@ public class WsdlUtils {
             return new Part[0];
         }
 
-        List<Part> result = new ArrayList<Part>();
+        List<Part> result = new ArrayList<>();
         Output output = operation.getOperation().getOutput();
         if (output == null) {
             return new Part[0];
@@ -842,7 +842,7 @@ public class WsdlUtils {
     }
 
     public static List<SoapHeader> getSoapHeaders(List list) {
-        List<SoapHeader> result = new ArrayList<SoapHeader>();
+        List<SoapHeader> result = new ArrayList<>();
 
         List<SOAPHeader> soapHeaders = WsdlUtils.getExtensiblityElements(list, SOAPHeader.class);
         if (soapHeaders != null && !soapHeaders.isEmpty()) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wsdl/WsdlValidator.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wsdl/WsdlValidator.java
@@ -68,7 +68,7 @@ public class WsdlValidator {
     }
 
     public AssertionError[] assertRequest(WsdlMessageExchange messageExchange, boolean envelopeOnly) {
-        List<XmlError> errors = new ArrayList<XmlError>();
+        List<XmlError> errors = new ArrayList<>();
         try {
             String requestContent = messageExchange.getRequestContent();
             wsdlContext.getSoapVersion().validateSoapEnvelope(requestContent, errors);
@@ -281,7 +281,7 @@ public class WsdlValidator {
             throw new Exception("Missing parts for operation [" + operationName + "]");
         }
 
-        List<XmlObject> result = new ArrayList<XmlObject>();
+        List<XmlObject> result = new ArrayList<>();
 
         if (WsdlUtils.isRpc(wsdlContext.getDefinition(), bindingOperation)) {
             // get root element
@@ -384,7 +384,7 @@ public class WsdlValidator {
 
     private AssertionError[] convertErrors(List<XmlError> errors) {
         if (errors.size() > 0) {
-            List<AssertionError> response = new ArrayList<AssertionError>();
+            List<AssertionError> response = new ArrayList<>();
             for (Iterator<XmlError> i = errors.iterator(); i.hasNext(); ) {
                 XmlError error = i.next();
 
@@ -498,7 +498,7 @@ public class WsdlValidator {
     }
 
     public AssertionError[] assertResponse(WsdlMessageExchange messageExchange, boolean envelopeOnly) {
-        List<XmlError> errors = new ArrayList<XmlError>();
+        List<XmlError> errors = new ArrayList<>();
         try {
             String response = messageExchange.getResponseContent();
 
@@ -610,7 +610,7 @@ public class WsdlValidator {
         xmlOptions.setLoadLineNumbers(XmlOptions.LOAD_LINE_NUMBERS_END_ELEMENT);
 
         XmlCursor cur = msg.newCursor();
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
 
         while (cur.hasNextToken()) {
             if (cur.toNextToken().isNamespace()) {
@@ -636,7 +636,7 @@ public class WsdlValidator {
         obj = obj.changeType(type);
 
         // create internal error list
-        ArrayList<Object> list = new ArrayList<Object>();
+        ArrayList<Object> list = new ArrayList<>();
 
         xmlOptions = new XmlOptions();
         xmlOptions.setErrorListener(list);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wsrm/WsrmTestRunListener.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wsrm/WsrmTestRunListener.java
@@ -62,7 +62,7 @@ public class WsrmTestRunListener implements TestRunListener {
         WsdlTestCase testCase = (WsdlTestCase) runContext.getTestCase();
         if (testStep instanceof WsdlTestRequestStep && testCase.getWsrmEnabled()) {
             if (wsrmMap == null) {
-                wsrmMap = new HashMap<String, WsrmSequence>();
+                wsrmMap = new HashMap<>();
             }
             WsdlTestRequestStep requestStep = (WsdlTestRequestStep) testStep;
             String endpoint = requestStep.getHttpRequest().getEndpoint();

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/DefaultWssContainer.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/DefaultWssContainer.java
@@ -38,11 +38,11 @@ import java.util.Set;
 
 public class DefaultWssContainer implements WssContainer {
     private final ModelItem modelItem;
-    private List<WssCrypto> cryptos = new ArrayList<WssCrypto>();
-    private List<IncomingWss> incomingWssConfigs = new ArrayList<IncomingWss>();
-    private List<OutgoingWss> outgoingWssConfigs = new ArrayList<OutgoingWss>();
+    private List<WssCrypto> cryptos = new ArrayList<>();
+    private List<IncomingWss> incomingWssConfigs = new ArrayList<>();
+    private List<OutgoingWss> outgoingWssConfigs = new ArrayList<>();
     private final WssContainerConfig config;
-    private Set<WssContainerListener> listeners = new HashSet<WssContainerListener>();
+    private Set<WssContainerListener> listeners = new HashSet<>();
 
     static {
         Security.addProvider(new BouncyCastleProvider());
@@ -80,7 +80,7 @@ public class DefaultWssContainer implements WssContainer {
     }
 
     public List<WssCrypto> getCryptoList() {
-        return new ArrayList<WssCrypto>(cryptos);
+        return new ArrayList<>(cryptos);
     }
 
     public WssCrypto addCrypto(String source, String password, CryptoType type) {
@@ -127,7 +127,7 @@ public class DefaultWssContainer implements WssContainer {
     }
 
     public List<IncomingWss> getIncomingWssList() {
-        return new ArrayList<IncomingWss>(incomingWssConfigs);
+        return new ArrayList<>(incomingWssConfigs);
     }
 
     public IncomingWss addIncomingWss(String label) {
@@ -167,7 +167,7 @@ public class DefaultWssContainer implements WssContainer {
     }
 
     public List<OutgoingWss> getOutgoingWssList() {
-        return new ArrayList<OutgoingWss>(outgoingWssConfigs);
+        return new ArrayList<>(outgoingWssConfigs);
     }
 
     public OutgoingWss addOutgoingWss(String label) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/IncomingWss.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/IncomingWss.java
@@ -113,7 +113,7 @@ public class IncomingWss {
             List<WSSecurityEngineResult> incomingResult = wssecurityEngine.processSecurityHeader(soapDocument,
                     (String) null, new WSSCallbackHandler(dec), sig, dec);
 
-            Vector<Object> wssResult = new Vector<Object>();
+            Vector<Object> wssResult = new Vector<>();
             wssResult.setSize(incomingResult.size());
             Collections.copy(wssResult, incomingResult);
             return wssResult;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/OutgoingWss.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/OutgoingWss.java
@@ -44,7 +44,7 @@ public class OutgoingWss implements PropertyExpansionContainer {
     private static final int MOVE_UP = -1;
 
     private OutgoingWssConfig config;
-    private List<WssEntry> entries = new ArrayList<WssEntry>();
+    private List<WssEntry> entries = new ArrayList<>();
     private final DefaultWssContainer container;
 
     public OutgoingWss(OutgoingWssConfig config, DefaultWssContainer container) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/crypto/KeyMaterialWssCrypto.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/crypto/KeyMaterialWssCrypto.java
@@ -204,7 +204,7 @@ public class KeyMaterialWssCrypto implements WssCrypto {
     @Deprecated
     private KeyStore fallbackLoad() throws IOException, CertificateException, KeyStoreException,
             NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, ProbablyBadPasswordException,
-            UnrecoverableKeyException, FileNotFoundException {
+            UnrecoverableKeyException {
         KeyStore fallbackKeystore = null;
         if (StringUtils.hasContent(getDefaultAlias()) && StringUtils.hasContent(getAliasPassword())) {
             fallbackKeystore = KeyStoreBuilder.build(

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/entries/AutomaticSAMLEntry.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/entries/AutomaticSAMLEntry.java
@@ -349,7 +349,7 @@ public class AutomaticSAMLEntry extends WssEntryBase {
 
     // Since we only use one column for the attribute values
     private List<String> extractValueColumnValues(List<StringToStringMap> table, PropertyExpansionContext context) {
-        List<String> firstColumnValues = new ArrayList<String>();
+        List<String> firstColumnValues = new ArrayList<>();
         for (StringToStringMap row : table) {
             String columnValue = row.get(ATTRIBUTE_VALUES_VALUE_COLUMN);
             // TODO Add property expansion to each value

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/entries/SignatureEntry.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/entries/SignatureEntry.java
@@ -71,7 +71,7 @@ public class SignatureEntry extends WssEntryBase {
     private String digestAlgorithm;
     private String customTokenValueType;
     private String customTokenId;
-    private List<StringToStringMap> parts = new ArrayList<StringToStringMap>();
+    private List<StringToStringMap> parts = new ArrayList<>();
     private com.eviware.soapui.impl.wsdl.support.wss.entries.WssEntryBase.KeyAliasComboBoxModel keyAliasComboBoxModel;
     private com.eviware.soapui.impl.wsdl.support.wss.entries.SignatureEntry.InternalWssContainerListener wssContainerListener;
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/entries/WssEntryBase.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/entries/WssEntryBase.java
@@ -175,7 +175,7 @@ public abstract class WssEntryBase implements WssEntry, PropertyExpansionContain
 
     // Used to save values from table GUI components
     protected List<StringToStringMap> readTableValues(XmlObjectConfigurationReader reader, String parameterName) {
-        List<StringToStringMap> result = new ArrayList<StringToStringMap>();
+        List<StringToStringMap> result = new ArrayList<>();
         String[] tableValues = reader.readStrings(parameterName);
         if (tableValues != null && tableValues.length > 0) {
             for (String tableValue : tableValues) {
@@ -195,7 +195,7 @@ public abstract class WssEntryBase implements WssEntry, PropertyExpansionContain
     }
 
     protected Vector<WSEncryptionPart> createWSParts(List<StringToStringMap> parts) {
-        Vector<WSEncryptionPart> result = new Vector<WSEncryptionPart>();
+        Vector<WSEncryptionPart> result = new Vector<>();
 
         for (StringToStringMap map : parts) {
             if (map.hasValue("id")) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/support/KeystoresComboBoxModel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/support/KeystoresComboBoxModel.java
@@ -30,7 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class KeystoresComboBoxModel extends AbstractListModel implements ComboBoxModel, WssContainerListener {
-    private List<WssCrypto> cryptos = new ArrayList<WssCrypto>();
+    private List<WssCrypto> cryptos = new ArrayList<>();
     private WssCrypto selectedCrypto;
     private final WssContainer container;
     private final boolean outgoingConfig;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/xsd/SampleXmlUtil.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/xsd/SampleXmlUtil.java
@@ -69,7 +69,7 @@ public class SampleXmlUtil {
     private boolean _soapEnc;
     private boolean _exampleContent = false;
     private boolean _typeComment = false;
-    private Set<QName> excludedTypes = new HashSet<QName>();
+    private Set<QName> excludedTypes = new HashSet<>();
     private Map<QName, String[]> multiValues = null;
     private boolean _skipComments;
 
@@ -1230,7 +1230,7 @@ public class SampleXmlUtil {
     public static final QName ENC_ARRAYTYPE = new QName("http://schemas.xmlsoap.org/soap/encoding/", "arrayType");
     private static final QName ENC_OFFSET = new QName("http://schemas.xmlsoap.org/soap/encoding/", "offset");
 
-    public static final Set<QName> SKIPPED_SOAP_ATTRS = new HashSet<QName>(Arrays.asList(new QName[]{HREF, ID,
+    public static final Set<QName> SKIPPED_SOAP_ATTRS = new HashSet<>(Arrays.asList(new QName[]{HREF, ID,
             ENC_OFFSET}));
 
     private void processAttributes(SchemaType stype, XmlCursor xmlc) {
@@ -1371,7 +1371,7 @@ public class SampleXmlUtil {
         return returnParticleType.toString();
     }
 
-    private ArrayList<SchemaType> _typeStack = new ArrayList<SchemaType>();
+    private ArrayList<SchemaType> _typeStack = new ArrayList<>();
 
     public boolean isIgnoreOptional() {
         return ignoreOptional;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/xsd/SchemaUtils.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/xsd/SchemaUtils.java
@@ -69,7 +69,7 @@ import java.util.Set;
 
 public class SchemaUtils {
     private final static Logger log = LogManager.getLogger(SchemaUtils.class);
-    private static Map<String, XmlObject> defaultSchemas = new HashMap<String, XmlObject>();
+    private static Map<String, XmlObject> defaultSchemas = new HashMap<>();
 
     static {
         initDefaultSchemas();
@@ -173,7 +173,7 @@ public class SchemaUtils {
 
         try {
             log.info("Loading schema types from [" + wsdlUrl + "]");
-            ArrayList<XmlObject> schemas = new ArrayList<XmlObject>(getSchemas(wsdlUrl, loader).values());
+            ArrayList<XmlObject> schemas = new ArrayList<>(getSchemas(wsdlUrl, loader).values());
 
             return buildSchemaTypes(schemas);
         } catch (Exception e) {
@@ -208,7 +208,7 @@ public class SchemaUtils {
 
         boolean strictSchemaTypes = SoapUI.getSettings().getBoolean(WsdlSettings.STRICT_SCHEMA_TYPES);
         if (!strictSchemaTypes) {
-            Set<String> mdefNamespaces = new HashSet<String>();
+            Set<String> mdefNamespaces = new HashSet<>();
 
             for (XmlObject xObj : schemas) {
                 mdefNamespaces.add(getTargetNamespace(xObj));
@@ -289,7 +289,7 @@ public class SchemaUtils {
     }
 
     public static Map<String, XmlObject> getSchemas(String wsdlUrl, SchemaLoader loader) throws SchemaException {
-        Map<String, XmlObject> result = new HashMap<String, XmlObject>();
+        Map<String, XmlObject> result = new HashMap<>();
         getSchemas(wsdlUrl, result, loader, null /* , false */);
         return result;
     }
@@ -313,7 +313,7 @@ public class SchemaUtils {
 
         ArrayList<?> errorList = new ArrayList<Object>();
 
-        Map<String, XmlObject> result = new HashMap<String, XmlObject>();
+        Map<String, XmlObject> result = new HashMap<>();
 
         boolean common = false;
 
@@ -472,7 +472,7 @@ public class SchemaUtils {
      */
 
     public static Map<String, XmlObject> getDefinitionParts(SchemaLoader loader) throws Exception {
-        Map<String, XmlObject> result = new LinkedHashMap<String, XmlObject>();
+        Map<String, XmlObject> result = new LinkedHashMap<>();
         getDefinitionParts(loader.getBaseURI(), result, loader);
         return result;
     }
@@ -525,7 +525,7 @@ public class SchemaUtils {
      */
 
     public static Collection<String> extractNamespaces(SchemaTypeSystem schemaTypes, boolean removeDefault) {
-        Set<String> namespaces = new HashSet<String>();
+        Set<String> namespaces = new HashSet<>();
         SchemaType[] globalTypes = schemaTypes.globalTypes();
         for (int c = 0; c < globalTypes.length; c++) {
             namespaces.add(globalTypes[c].getName().getNamespaceURI());

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/xsd/SchemaUtils.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/xsd/SchemaUtils.java
@@ -121,7 +121,7 @@ public class SchemaUtils {
         }
     }
 
-    private static void loadSchemaDirectory(String schemaDirectory) throws IOException, MalformedURLException {
+    private static void loadSchemaDirectory(String schemaDirectory) throws IOException {
         File dir = new File(schemaDirectory);
         if (dir.exists() && dir.isDirectory()) {
             String[] xsdFiles = dir.list();

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/xsd/SettingUtils.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/xsd/SettingUtils.java
@@ -30,7 +30,7 @@ import java.util.Map;
 
 public class SettingUtils {
     public static Collection<? extends QName> string2QNames(String string) {
-        List<QName> result = new ArrayList<QName>();
+        List<QName> result = new ArrayList<>();
         if (string != null && string.trim().length() > 0) {
             try {
                 StringList names = StringList.fromXml(string);
@@ -84,7 +84,7 @@ public class SettingUtils {
     }
 
     public static Map<QName, String[]> string2QNameValues(String string) {
-        LinkedHashMap<QName, String[]> result = new LinkedHashMap<QName, String[]>();
+        LinkedHashMap<QName, String[]> result = new LinkedHashMap<>();
         if (string != null && string.trim().length() > 0) {
             try {
                 StringList list = StringList.fromXml(string);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/testcase/TestCaseLogModel.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/testcase/TestCaseLogModel.java
@@ -60,7 +60,7 @@ public class TestCaseLogModel extends AbstractListModel {
         int size = items.size();
         items.add("Step " + stepCount + " [" + result.getTestStep().getName() + "] " + result.getStatus() + ": took "
                 + result.getTimeTaken() + " ms");
-        SoftReference<TestStepResult> ref = new SoftReference<TestStepResult>(result);
+        SoftReference<TestStepResult> ref = new SoftReference<>(result);
         results.add(ref);
         for (String msg : result.getMessages()) {
             items.add(" -> " + msg);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/testcase/WsdlProjectRunner.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/testcase/WsdlProjectRunner.java
@@ -39,8 +39,8 @@ import java.util.Set;
 
 public class WsdlProjectRunner extends AbstractTestRunner<WsdlProject, WsdlProjectRunContext> implements ProjectRunner {
     private ProjectRunListener[] listeners;
-    private Set<TestSuiteRunner> finishedRunners = new HashSet<TestSuiteRunner>();
-    private Set<TestSuiteRunner> activeRunners = new HashSet<TestSuiteRunner>();
+    private Set<TestSuiteRunner> finishedRunners = new HashSet<>();
+    private Set<TestSuiteRunner> activeRunners = new HashSet<>();
     private int currentTestSuiteIndex;
     private WsdlTestSuite currentTestSuite;
     private TestSuiteRunListener internalTestRunListener = new InternalTestSuiteRunListener();

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/testcase/WsdlTestCase.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/testcase/WsdlTestCase.java
@@ -89,10 +89,10 @@ public class WsdlTestCase extends AbstractTestPropertyHolderWsdlModelItem<TestCa
     public static final String ICON_NAME = "/testcase.png";
 
     private final WsdlTestSuite testSuite;
-    private final List<WsdlTestStep> testSteps = new ArrayList<WsdlTestStep>();
-    private final List<WsdlLoadTest> loadTests = new ArrayList<WsdlLoadTest>();
-    private final List<SecurityTest> securityTests = new ArrayList<SecurityTest>();
-    private final Set<TestRunListener> testRunListeners = new HashSet<TestRunListener>();
+    private final List<WsdlTestStep> testSteps = new ArrayList<>();
+    private final List<WsdlLoadTest> loadTests = new ArrayList<>();
+    private final List<SecurityTest> securityTests = new ArrayList<>();
+    private final Set<TestRunListener> testRunListeners = new HashSet<>();
     private DefaultActionList createActions;
     private final boolean forLoadTest;
     private SoapUIScriptEngine setupScriptEngine;
@@ -117,7 +117,7 @@ public class WsdlTestCase extends AbstractTestPropertyHolderWsdlModelItem<TestCa
         setPropertiesConfig(getConfig().getProperties());
 
         List<TestStepConfig> testStepConfigs = config.getTestStepList();
-        List<TestStepConfig> removed = new ArrayList<TestStepConfig>();
+        List<TestStepConfig> removed = new ArrayList<>();
         for (TestStepConfig tsc : testStepConfigs) {
             WsdlTestStep testStep = createTestStepFromConfig(tsc);
             if (testStep != null) {
@@ -616,7 +616,7 @@ public class WsdlTestCase extends AbstractTestPropertyHolderWsdlModelItem<TestCa
     }
 
     public Map<String, TestStep> getTestSteps() {
-        Map<String, TestStep> result = new HashMap<String, TestStep>();
+        Map<String, TestStep> result = new HashMap<>();
         for (TestStep testStep : testSteps) {
             result.put(testStep.getName(), testStep);
         }
@@ -625,7 +625,7 @@ public class WsdlTestCase extends AbstractTestPropertyHolderWsdlModelItem<TestCa
     }
 
     public Map<String, TestStep> getTestStepsOrdered() {
-        Map<String, TestStep> result = new TreeMap<String, TestStep>();
+        Map<String, TestStep> result = new TreeMap<>();
         for (TestStep testStep : testSteps) {
             result.put(testStep.getName(), testStep);
         }
@@ -634,7 +634,7 @@ public class WsdlTestCase extends AbstractTestPropertyHolderWsdlModelItem<TestCa
     }
 
     public Map<String, LoadTest> getLoadTests() {
-        Map<String, LoadTest> result = new HashMap<String, LoadTest>();
+        Map<String, LoadTest> result = new HashMap<>();
         for (LoadTest loadTest : loadTests) {
             result.put(loadTest.getName(), loadTest);
         }
@@ -747,7 +747,7 @@ public class WsdlTestCase extends AbstractTestPropertyHolderWsdlModelItem<TestCa
 
     @Override
     public List<TestStep> getTestStepList() {
-        List<TestStep> result = new ArrayList<TestStep>();
+        List<TestStep> result = new ArrayList<>();
         for (TestStep step : testSteps) {
             result.add(step);
         }
@@ -758,7 +758,7 @@ public class WsdlTestCase extends AbstractTestPropertyHolderWsdlModelItem<TestCa
     @Override
     @SuppressWarnings("unchecked")
     public <T extends TestStep> List<T> getTestStepsOfType(Class<T> stepType) {
-        List<T> result = new ArrayList<T>();
+        List<T> result = new ArrayList<>();
         for (TestStep step : testSteps) {
             if (step.getClass().isAssignableFrom(stepType)) {
                 result.add((T) step);
@@ -854,7 +854,7 @@ public class WsdlTestCase extends AbstractTestPropertyHolderWsdlModelItem<TestCa
 
     @Override
     public List<LoadTest> getLoadTestList() {
-        List<LoadTest> result = new ArrayList<LoadTest>();
+        List<LoadTest> result = new ArrayList<>();
         for (LoadTest loadTest : loadTests) {
             result.add(loadTest);
         }
@@ -900,7 +900,7 @@ public class WsdlTestCase extends AbstractTestPropertyHolderWsdlModelItem<TestCa
 
     @Override
     public List<? extends ModelItem> getChildren() {
-        List<ModelItem> result = new ArrayList<ModelItem>();
+        List<ModelItem> result = new ArrayList<>();
         result.addAll(getTestStepList());
         result.addAll(getLoadTestList());
         result.addAll(getSecurityTestList());
@@ -1104,7 +1104,7 @@ public class WsdlTestCase extends AbstractTestPropertyHolderWsdlModelItem<TestCa
     }
 
     public Map<String, SecurityTest> getSecurityTests() {
-        Map<String, SecurityTest> result = new HashMap<String, SecurityTest>();
+        Map<String, SecurityTest> result = new HashMap<>();
         for (SecurityTest securityTest : securityTests) {
             result.put(securityTest.getName(), securityTest);
         }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/testcase/WsdlTestSuiteRunner.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/testcase/WsdlTestSuiteRunner.java
@@ -46,8 +46,8 @@ import java.util.Set;
 public class WsdlTestSuiteRunner extends AbstractTestRunner<WsdlTestSuite, WsdlTestSuiteRunContext> implements
         TestSuiteRunner {
     private TestSuiteRunListener[] listeners;
-    private Set<TestCaseRunner> finishedRunners = new HashSet<TestCaseRunner>();
-    private Set<TestCaseRunner> activeRunners = new HashSet<TestCaseRunner>();
+    private Set<TestCaseRunner> finishedRunners = new HashSet<>();
+    private Set<TestCaseRunner> activeRunners = new HashSet<>();
     private int currentTestCaseIndex;
     private WsdlTestCase currentTestCase;
     private TestRunListener parallellTestRunListener = new ParallellTestRunListener();

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/AMFRequestTestStep.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/AMFRequestTestStep.java
@@ -384,7 +384,7 @@ public class AMFRequestTestStep extends WsdlTestStepWithProperties implements As
     }
 
     public List<TestAssertion> getAssertionList() {
-        return new ArrayList<TestAssertion>(assertionsSupport.getAssertionList());
+        return new ArrayList<>(assertionsSupport.getAssertionList());
     }
 
     public void propertyChange(PropertyChangeEvent arg0) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/AMFTestStepResult.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/AMFTestStepResult.java
@@ -46,7 +46,7 @@ public class AMFTestStepResult extends WsdlTestStepResult implements AssertedXPa
 
     public void setResponse(AMFResponse response, boolean useSoftReference) {
         if (useSoftReference) {
-            this.softResponse = new SoftReference<AMFResponse>(response);
+            this.softResponse = new SoftReference<>(response);
         } else {
             this.response = response;
         }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/GraphQLTestRequest.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/GraphQLTestRequest.java
@@ -687,7 +687,7 @@ public class GraphQLTestRequest extends AbstractHttpRequest<GraphQLTestRequestCo
 
     @Override
     public List<TestAssertion> getAssertionList() {
-        return new ArrayList<TestAssertion>(assertionsSupport.getAssertionList());
+        return new ArrayList<>(assertionsSupport.getAssertionList());
     }
 
     @Override

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/HttpResponseMessageExchange.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/HttpResponseMessageExchange.java
@@ -151,7 +151,7 @@ public class HttpResponseMessageExchange extends AbstractMessageExchange<HttpReq
     }
 
     public Attachment[] getResponseAttachmentsForPart(String name) {
-        List<Attachment> result = new ArrayList<Attachment>();
+        List<Attachment> result = new ArrayList<>();
 
         if (getResponseAttachments() != null) {
             for (Attachment attachment : getResponseAttachments()) {
@@ -165,7 +165,7 @@ public class HttpResponseMessageExchange extends AbstractMessageExchange<HttpReq
     }
 
     public Attachment[] getRequestAttachmentsForPart(String name) {
-        List<Attachment> result = new ArrayList<Attachment>();
+        List<Attachment> result = new ArrayList<>();
 
         for (Attachment attachment : getRequestAttachments()) {
             if (attachment.getPart().equals(name)) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/HttpTestRequest.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/HttpTestRequest.java
@@ -285,7 +285,7 @@ public class HttpTestRequest extends HttpRequest implements HttpTestRequestInter
     }
 
     public List<TestAssertion> getAssertionList() {
-        return new ArrayList<TestAssertion>(assertionsSupport.getAssertionList());
+        return new ArrayList<>(assertionsSupport.getAssertionList());
     }
 
     public WsdlMessageAssertion getAssertionByName(String name) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/JdbcRequestTestStep.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/JdbcRequestTestStep.java
@@ -419,7 +419,7 @@ public class JdbcRequestTestStep extends WsdlTestStepWithProperties implements A
     }
 
     public List<TestAssertion> getAssertionList() {
-        return new ArrayList<TestAssertion>(assertionsSupport.getAssertionList());
+        return new ArrayList<>(assertionsSupport.getAssertionList());
     }
 
     public void propertyChange(PropertyChangeEvent arg0) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/JdbcTestStepResult.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/JdbcTestStepResult.java
@@ -42,7 +42,7 @@ public class JdbcTestStepResult extends WsdlTestStepResult implements AssertedXP
 
     public void setResponse(JdbcResponse response, boolean useSoftReference) {
         if (useSoftReference) {
-            this.softResponse = new SoftReference<JdbcResponse>(response);
+            this.softResponse = new SoftReference<>(response);
         } else {
             this.response = response;
         }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/ManualTestStep.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/ManualTestStep.java
@@ -169,7 +169,7 @@ public class ManualTestStep extends WsdlTestStepWithProperties implements Proper
     }
 
     public PropertyExpansion[] getPropertyExpansions() {
-        List<PropertyExpansion> result = new ArrayList<PropertyExpansion>();
+        List<PropertyExpansion> result = new ArrayList<>();
         result.addAll(PropertyExpansionUtils.extractPropertyExpansions(this, this, "description"));
         result.addAll(PropertyExpansionUtils.extractPropertyExpansions(this, this, "expectedResult"));
         return result.toArray(new PropertyExpansion[result.size()]);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/PropertyTransfer.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/PropertyTransfer.java
@@ -420,7 +420,7 @@ public class PropertyTransfer implements PropertyChangeNotifier {
                 XmlCursor targetCursor = targetXml.newCursor();
 
                 try {
-                    List<String> result = new ArrayList<String>();
+                    List<String> result = new ArrayList<>();
 
                     targetCursor.selectPath(targetPath);
 
@@ -497,7 +497,7 @@ public class PropertyTransfer implements PropertyChangeNotifier {
         XmlCursor lastSource = null;
 
         try {
-            List<String> result = new ArrayList<String>();
+            List<String> result = new ArrayList<>();
 
             String tp = PropertyExpander.expandProperties(context, getTargetPath());
             targetXml.selectPath(tp);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/PropertyTransfersTestStep.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/PropertyTransfersTestStep.java
@@ -52,7 +52,7 @@ public class PropertyTransfersTestStep extends WsdlTestStepWithProperties implem
     public static final String TRANSFERS = PropertyTransfersTestStep.class.getName() + "@transfers";
     private PropertyTransfersStepConfig transferStepConfig;
     private boolean canceled;
-    private List<PropertyTransfer> transfers = new ArrayList<PropertyTransfer>();
+    private List<PropertyTransfer> transfers = new ArrayList<>();
     private ImageIcon failedIcon;
     private ImageIcon okIcon;
 
@@ -206,8 +206,8 @@ public class PropertyTransfersTestStep extends WsdlTestStepWithProperties implem
     }
 
     public class PropertyTransferResult extends WsdlTestStepResult {
-        private List<PropertyTransferConfig> transfers = new ArrayList<PropertyTransferConfig>();
-        private List<String[]> values = new ArrayList<String[]>();
+        private List<PropertyTransferConfig> transfers = new ArrayList<>();
+        private List<String[]> values = new ArrayList<>();
         private boolean addedAction;
 
         public PropertyTransferResult() {
@@ -286,7 +286,7 @@ public class PropertyTransfersTestStep extends WsdlTestStepWithProperties implem
     }
 
     public PropertyExpansion[] getPropertyExpansions() {
-        List<PropertyExpansion> result = new ArrayList<PropertyExpansion>();
+        List<PropertyExpansion> result = new ArrayList<>();
 
         for (PropertyTransfer transfer : transfers) {
             result.addAll(PropertyExpansionUtils.extractPropertyExpansions(this, transfer, "sourcePath"));
@@ -302,7 +302,7 @@ public class PropertyTransfersTestStep extends WsdlTestStepWithProperties implem
     }
 
     public XPathReference[] getXPathReferences() {
-        List<XPathReference> result = new ArrayList<XPathReference>();
+        List<XPathReference> result = new ArrayList<>();
 
         for (PropertyTransfer transfer : transfers) {
             if (StringUtils.hasContent(transfer.getSourcePath())) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/RestRequestStepResult.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/RestRequestStepResult.java
@@ -310,7 +310,7 @@ public class RestRequestStepResult extends WsdlTestStepResult implements Respons
     @Override
     public void addAssertedXPath(AssertedXPath assertedXPath) {
         if (assertedXPaths == null) {
-            assertedXPaths = new ArrayList<AssertedXPath>();
+            assertedXPaths = new ArrayList<>();
         }
 
         assertedXPaths.add(assertedXPath);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/RestTestRequest.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/RestTestRequest.java
@@ -345,7 +345,7 @@ public class RestTestRequest extends RestRequest implements RestTestRequestInter
     }
 
     public List<TestAssertion> getAssertionList() {
-        return new ArrayList<TestAssertion>(assertionsSupport.getAssertionList());
+        return new ArrayList<>(assertionsSupport.getAssertionList());
     }
 
     public WsdlMessageAssertion getAssertionByName(String name) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/RestTestRequestStep.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/RestTestRequestStep.java
@@ -98,7 +98,7 @@ public class RestTestRequestStep extends WsdlTestStepWithProperties implements R
     private final InternalInterfaceListener interfaceListener = new InternalInterfaceListener();
     private WsdlSubmit<RestRequest> submit;
     // private final Set<String> requestProperties = new HashSet<String>();
-    private final Map<String, RestTestStepProperty> requestProperties = new HashMap<String, RestTestStepProperty>();
+    private final Map<String, RestTestStepProperty> requestProperties = new HashMap<>();
 
     public RestTestRequestStep(WsdlTestCase testCase, TestStepConfig config, boolean forLoadTest)
             throws ItemDeletedException {
@@ -308,7 +308,7 @@ public class RestTestRequestStep extends WsdlTestStepWithProperties implements R
 
     @Override
     public Collection<Interface> getRequiredInterfaces() {
-        ArrayList<Interface> result = new ArrayList<Interface>();
+        ArrayList<Interface> result = new ArrayList<>();
         result.add(findRestResource().getInterface());
         return result;
     }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlDelayTestStep.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlDelayTestStep.java
@@ -108,7 +108,7 @@ public class WsdlDelayTestStep extends WsdlTestStepWithProperties implements Pro
     }
 
     public PropertyExpansion[] getPropertyExpansions() {
-        List<PropertyExpansion> result = new ArrayList<PropertyExpansion>();
+        List<PropertyExpansion> result = new ArrayList<>();
         result.addAll(PropertyExpansionUtils.extractPropertyExpansions(this, this, "delayString"));
         return result.toArray(new PropertyExpansion[result.size()]);
     }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlGotoTestStep.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlGotoTestStep.java
@@ -60,7 +60,7 @@ import java.util.List;
 public class WsdlGotoTestStep extends WsdlTestStepWithProperties implements XPathReferenceContainer,
         PropertyExpansionContainer {
     private GotoStepConfig gotoStepConfig;
-    private List<GotoCondition> conditions = new ArrayList<GotoCondition>();
+    private List<GotoCondition> conditions = new ArrayList<>();
     private boolean canceled;
 
     private final static Logger log = LogManager.getLogger(WsdlGotoTestStep.class);
@@ -310,7 +310,7 @@ public class WsdlGotoTestStep extends WsdlTestStepWithProperties implements XPat
     }
 
     public PropertyExpansion[] getPropertyExpansions() {
-        List<PropertyExpansion> result = new ArrayList<PropertyExpansion>();
+        List<PropertyExpansion> result = new ArrayList<>();
 
         for (GotoCondition condition : conditions) {
             result.addAll(PropertyExpansionUtils.extractPropertyExpansions(this, condition, "expression"));
@@ -320,7 +320,7 @@ public class WsdlGotoTestStep extends WsdlTestStepWithProperties implements XPat
     }
 
     public XPathReference[] getXPathReferences() {
-        List<XPathReference> result = new ArrayList<XPathReference>();
+        List<XPathReference> result = new ArrayList<>();
 
         for (GotoCondition condition : conditions) {
             if (StringUtils.hasContent(condition.getExpression())) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlMessageExchangeTestStepResult.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlMessageExchangeTestStepResult.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class WsdlMessageExchangeTestStepResult extends WsdlTestStepResult implements MessageExchangeTestStepResult {
-    private List<MessageExchange> exchanges = new ArrayList<MessageExchange>();
+    private List<MessageExchange> exchanges = new ArrayList<>();
 
     public WsdlMessageExchangeTestStepResult(WsdlTestStep testStep) {
         super(testStep);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlMockResponseTestStep.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlMockResponseTestStep.java
@@ -151,7 +151,7 @@ public class WsdlMockResponseTestStep extends WsdlTestStepWithProperties impleme
                 iface.addInterfaceListener(interfaceListener);
             }
 
-            iconAnimator = new IconAnimator<WsdlMockResponseTestStep>(this, "/mockResponseStep.gif",
+            iconAnimator = new IconAnimator<>(this, "/mockResponseStep.gif",
                     "/exec_mockResponse.gif", 4);
 
             initIcons();
@@ -973,7 +973,7 @@ public class WsdlMockResponseTestStep extends WsdlTestStepWithProperties impleme
 
     @Override
     public Collection<Interface> getRequiredInterfaces() {
-        ArrayList<Interface> result = new ArrayList<Interface>();
+        ArrayList<Interface> result = new ArrayList<>();
         result.add(getInterface());
         return result;
     }
@@ -1047,7 +1047,7 @@ public class WsdlMockResponseTestStep extends WsdlTestStepWithProperties impleme
     }
 
     public List<TestAssertion> getAssertionList() {
-        return new ArrayList<TestAssertion>(assertionsSupport.getAssertionList());
+        return new ArrayList<>(assertionsSupport.getAssertionList());
     }
 
     @Override
@@ -1056,7 +1056,7 @@ public class WsdlMockResponseTestStep extends WsdlTestStepWithProperties impleme
     }
 
     public PropertyExpansion[] getPropertyExpansions() {
-        List<PropertyExpansion> result = new ArrayList<PropertyExpansion>();
+        List<PropertyExpansion> result = new ArrayList<>();
 
         result.addAll(PropertyExpansionUtils.extractPropertyExpansions(this, mockResponse, "responseContent"));
 
@@ -1077,7 +1077,7 @@ public class WsdlMockResponseTestStep extends WsdlTestStepWithProperties impleme
     }
 
     public Map<String, TestAssertion> getAssertions() {
-        Map<String, TestAssertion> result = new HashMap<String, TestAssertion>();
+        Map<String, TestAssertion> result = new HashMap<>();
 
         for (TestAssertion assertion : getAssertionList()) {
             result.put(assertion.getName(), assertion);
@@ -1101,7 +1101,7 @@ public class WsdlMockResponseTestStep extends WsdlTestStepWithProperties impleme
 
         public void addAssertedXPath(AssertedXPath assertedXPath) {
             if (assertedXPaths == null) {
-                assertedXPaths = new ArrayList<AssertedXPath>();
+                assertedXPaths = new ArrayList<>();
             }
 
             assertedXPaths.add(assertedXPath);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlRunTestCaseTestStep.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlRunTestCaseTestStep.java
@@ -70,7 +70,7 @@ public class WsdlRunTestCaseTestStep extends WsdlTestStep {
     private InternalTestSuiteListener testSuiteListener = new InternalTestSuiteListener();
     private InternalTestRunListener testRunListener = new InternalTestRunListener();
     private InternalTestPropertyListener testPropertyListener = new InternalTestPropertyListener();
-    private Set<TestRunListener> testRunListeners = new HashSet<TestRunListener>();
+    private Set<TestRunListener> testRunListeners = new HashSet<>();
     private WsdlTestCase runningTestCase;
 
     public WsdlRunTestCaseTestStep(WsdlTestCase testCase, TestStepConfig config, boolean forLoadTest) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlTestRequest.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlTestRequest.java
@@ -407,7 +407,7 @@ public class WsdlTestRequest extends WsdlRequest implements Assertable, TestRequ
     }
 
     public List<TestAssertion> getAssertionList() {
-        return new ArrayList<TestAssertion>(assertionsSupport.getAssertionList());
+        return new ArrayList<>(assertionsSupport.getAssertionList());
     }
 
     public WsdlMessageAssertion getAssertionByName(String name) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlTestRequestStep.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlTestRequestStep.java
@@ -509,7 +509,7 @@ public class WsdlTestRequestStep extends WsdlTestStepWithProperties implements O
 
     @Override
     public Collection<Interface> getRequiredInterfaces() {
-        ArrayList<Interface> result = new ArrayList<Interface>();
+        ArrayList<Interface> result = new ArrayList<>();
         result.add(findWsdlOperation().getInterface());
         return result;
     }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlTestRequestStepResult.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlTestRequestStepResult.java
@@ -89,7 +89,7 @@ public class WsdlTestRequestStepResult extends WsdlTestStepResult implements Res
 
     public void setRequestContent(String requestContent, boolean useSoftReference) {
         if (useSoftReference) {
-            this.softRequestContent = new SoftReference<String>(requestContent);
+            this.softRequestContent = new SoftReference<>(requestContent);
         } else {
             this.requestContent = requestContent;
         }
@@ -111,7 +111,7 @@ public class WsdlTestRequestStepResult extends WsdlTestStepResult implements Res
 
     public void setResponse(WsdlResponse response, boolean useSoftReference) {
         if (useSoftReference) {
-            this.softResponse = new SoftReference<WsdlResponse>(response);
+            this.softResponse = new SoftReference<>(response);
         } else {
             this.response = response;
         }
@@ -277,7 +277,7 @@ public class WsdlTestRequestStepResult extends WsdlTestStepResult implements Res
 
     public void addAssertedXPath(AssertedXPath assertedXPath) {
         if (assertedXPaths == null) {
-            assertedXPaths = new ArrayList<AssertedXPath>();
+            assertedXPaths = new ArrayList<>();
         }
 
         assertedXPaths.add(assertedXPath);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlTestStep.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlTestStep.java
@@ -105,8 +105,8 @@ abstract public class WsdlTestStep extends AbstractWsdlModelItem<TestStepConfig>
         UISupport.setHourglassCursor();
 
         try {
-            List<MutablePropertyExpansion> result = new ArrayList<MutablePropertyExpansion>();
-            List<MutablePropertyExpansion> properties = new ArrayList<MutablePropertyExpansion>();
+            List<MutablePropertyExpansion> result = new ArrayList<>();
+            List<MutablePropertyExpansion> properties = new ArrayList<>();
 
             PropertyExpansion[] propertyExpansions = PropertyExpansionUtils.getPropertyExpansions(getTestCase(), true,
                     true);
@@ -170,7 +170,7 @@ abstract public class WsdlTestStep extends AbstractWsdlModelItem<TestStepConfig>
     }
 
     public Collection<Interface> getRequiredInterfaces() {
-        return new ArrayList<Interface>();
+        return new ArrayList<>();
     }
 
     public boolean isDisabled() {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlTestStepResult.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlTestStepResult.java
@@ -40,7 +40,7 @@ import java.util.List;
 public class WsdlTestStepResult implements TestStepResult {
     private static final String[] EMPTY_MESSAGES = new String[0];
     private final WsdlTestStep testStep;
-    private List<String> messages = new ArrayList<String>();
+    private List<String> messages = new ArrayList<>();
     private Throwable error;
     private TestStepStatus status = TestStepStatus.UNKNOWN;
     private long timeTaken;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlTestStepWithProperties.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/WsdlTestStepWithProperties.java
@@ -41,9 +41,9 @@ abstract public class WsdlTestStepWithProperties extends WsdlTestStep {
     public static String RAW_RESPONSE = "RawResponse";
 
     private Map<String, TestProperty> properties;
-    private List<TestProperty> propertyList = new ArrayList<TestProperty>();
-    private Map<String, Set<String>> normalizedPropertyNames = new HashMap<String, Set<String>>();
-    private Set<TestPropertyListener> listeners = new HashSet<TestPropertyListener>();
+    private List<TestProperty> propertyList = new ArrayList<>();
+    private Map<String, Set<String>> normalizedPropertyNames = new HashMap<>();
+    private Set<TestPropertyListener> listeners = new HashSet<>();
 
     protected WsdlTestStepWithProperties(WsdlTestCase testCase, TestStepConfig config, boolean hasEditor,
                                          boolean forLoadTest) {
@@ -98,7 +98,7 @@ abstract public class WsdlTestStepWithProperties extends WsdlTestStep {
 
     protected void addProperty(TestProperty property, boolean notify) {
         if (properties == null) {
-            properties = new HashMap<String, TestProperty>();
+            properties = new HashMap<>();
         }
 
         String name = property.getName();
@@ -230,7 +230,7 @@ abstract public class WsdlTestStepWithProperties extends WsdlTestStep {
 
     @Override
     public Map<String, TestProperty> getProperties() {
-        Map<String, TestProperty> result = new HashMap<String, TestProperty>();
+        Map<String, TestProperty> result = new HashMap<>();
 
         if (properties != null) {
             for (String name : properties.keySet()) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/actions/SetMockOperationAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/actions/SetMockOperationAction.java
@@ -56,7 +56,7 @@ public class SetMockOperationAction extends AbstractSoapUIAction<WsdlMockRespons
         }
 
         project = mockResponseTestStep.getTestCase().getTestSuite().getProject();
-        List<Interface> interfaces = new ArrayList<Interface>();
+        List<Interface> interfaces = new ArrayList<>();
         for (int c = 0; c < project.getInterfaceCount(); c++) {
             if (project.getInterfaceAt(c).getOperationCount() > 0) {
                 interfaces.add(project.getInterfaceAt(c));

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/actions/ShowMessageExchangeAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/actions/ShowMessageExchangeAction.java
@@ -131,7 +131,7 @@ public class ShowMessageExchangeAction extends AbstractAction {
     }
 
     private List<AssertedXPath> getAssertedXPaths() {
-        List<AssertedXPath> assertedXPaths = new ArrayList<AssertedXPath>();
+        List<AssertedXPath> assertedXPaths = new ArrayList<>();
 
         if (messageExchange instanceof RequestAssertedMessageExchange) {
             AssertedXPath[] xpaths = ((RequestAssertedMessageExchange) messageExchange).getAssertedXPathsForRequest();

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/actions/WsdlMessageAssertionSoapUIActionGroup.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/actions/WsdlMessageAssertionSoapUIActionGroup.java
@@ -36,10 +36,10 @@ public class WsdlMessageAssertionSoapUIActionGroup extends DefaultSoapUIActionGr
     @Override
     public SoapUIActionMappingList<WsdlMessageAssertion> getActionMappings(WsdlMessageAssertion modelItem) {
         SoapUIActionMappingList<WsdlMessageAssertion> actions = super.getActionMappings(modelItem);
-        SoapUIActionMappingList<WsdlMessageAssertion> result = new SoapUIActionMappingList<WsdlMessageAssertion>(actions);
+        SoapUIActionMappingList<WsdlMessageAssertion> result = new SoapUIActionMappingList<>(actions);
 
         if (modelItem.isConfigurable()) {
-            DefaultActionMapping<WsdlMessageAssertion> actionMapping = new DefaultActionMapping<WsdlMessageAssertion>(
+            DefaultActionMapping<WsdlMessageAssertion> actionMapping = new DefaultActionMapping<>(
                     ConfigureAssertionAction.SOAPUI_ACTION_ID, "ENTER", null, true, null);
 
             actionMapping.setName("Configure");
@@ -49,7 +49,7 @@ public class WsdlMessageAssertionSoapUIActionGroup extends DefaultSoapUIActionGr
         }
 
         if (modelItem.isClonable()) {
-            DefaultActionMapping<WsdlMessageAssertion> actionMapping = new DefaultActionMapping<WsdlMessageAssertion>(
+            DefaultActionMapping<WsdlMessageAssertion> actionMapping = new DefaultActionMapping<>(
                     CloneAssertionAction.SOAPUI_ACTION_ID, "F9", null, true, null);
 
             result.add(1, actionMapping);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/AbstractTestAssertionFactory.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/AbstractTestAssertionFactory.java
@@ -34,7 +34,7 @@ public abstract class AbstractTestAssertionFactory implements TestAssertionFacto
     private final String id;
     private final String label;
     private final Class<? extends TestAssertion> assertionClass;
-    private final List<Class<? extends ModelItem>> targetClasses = new ArrayList<Class<? extends ModelItem>>();
+    private final List<Class<? extends ModelItem>> targetClasses = new ArrayList<>();
 
     public AbstractTestAssertionFactory(String id, String label, Class<? extends TestAssertion> assertionClass) {
         this.id = id;

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/TestAssertionRegistry.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/TestAssertionRegistry.java
@@ -72,7 +72,7 @@ import java.util.TreeSet;
 
 public class TestAssertionRegistry implements SoapUIFactoryRegistryListener {
     private static TestAssertionRegistry instance;
-    private Map<String, TestAssertionFactory> availableAssertions = new HashMap<String, TestAssertionFactory>();
+    private Map<String, TestAssertionFactory> availableAssertions = new HashMap<>();
     private StringToStringMap assertionLabels = new StringToStringMap();
     private final static Logger log = LogManager.getLogger(TestAssertionRegistry.class);
 
@@ -245,7 +245,7 @@ public class TestAssertionRegistry implements SoapUIFactoryRegistryListener {
     public LinkedHashMap<String, SortedSet<AssertionListEntry>> addCategoriesAssertionsMap(Assertable assertable,
                                                                                            LinkedHashMap<String, SortedSet<AssertionListEntry>> categoryAssertionsMap) {
         for (String category : AssertionCategoryMapping.getAssertionCategories()) {
-            SortedSet<AssertionListEntry> assertionCategorySet = new TreeSet<AssertionListEntry>();
+            SortedSet<AssertionListEntry> assertionCategorySet = new TreeSet<>();
             categoryAssertionsMap.put(category, assertionCategorySet);
         }
 
@@ -277,7 +277,7 @@ public class TestAssertionRegistry implements SoapUIFactoryRegistryListener {
     public LinkedHashMap<String, SortedSet<AssertionListEntry>> addAllCategoriesMap(
             LinkedHashMap<String, SortedSet<AssertionListEntry>> categoryAssertionsMap) {
         for (String category : AssertionCategoryMapping.getAssertionCategories()) {
-            SortedSet<AssertionListEntry> assertionCategorySet = new TreeSet<AssertionListEntry>();
+            SortedSet<AssertionListEntry> assertionCategorySet = new TreeSet<>();
             categoryAssertionsMap.put(category, assertionCategorySet);
         }
 
@@ -305,7 +305,7 @@ public class TestAssertionRegistry implements SoapUIFactoryRegistryListener {
     }
 
     public String[] getAvailableAssertionNames(Assertable assertable) {
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
 
         for (TestAssertionFactory assertion : availableAssertions.values()) {
             if (assertion.canAssert(assertable)) {

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/basic/AbstractXmlContainsAssertion.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/basic/AbstractXmlContainsAssertion.java
@@ -207,7 +207,7 @@ XPathReferenceContainer{
 	    
 	    @Override
 	    public PropertyExpansion[] getPropertyExpansions() {
-	        List<PropertyExpansion> result = new ArrayList<PropertyExpansion>();
+	        List<PropertyExpansion> result = new ArrayList<>();
 
 	        result.addAll(PropertyExpansionUtils.extractPropertyExpansions(getAssertable().getModelItem(), this,
 	                "expectedContent"));
@@ -263,7 +263,7 @@ XPathReferenceContainer{
 	    protected abstract String getQueryType();
 	    
 	    public XPathReference[] getXPathReferences() {
-	        List<XPathReference> result = new ArrayList<XPathReference>();
+	        List<XPathReference> result = new ArrayList<>();
 
 	        if (StringUtils.hasContent(getPath())) {
 	            TestModelItem testStep = getAssertable().getTestStep();

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/basic/SchemaComplianceAssertion.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/basic/SchemaComplianceAssertion.java
@@ -70,7 +70,7 @@ public class SchemaComplianceAssertion extends WsdlMessageAssertion implements R
     private String definition;
     private DefinitionContext<?> definitionContext;
     private String wsdlContextDef;
-    private static Map<String, WsdlContext> wsdlContextMap = new HashMap<String, WsdlContext>();
+    private static Map<String, WsdlContext> wsdlContextMap = new HashMap<>();
     private static final String SCHEMA_COMPLIANCE_HAS_CLEARED_CACHE_FLAG = SchemaComplianceAssertion.class.getName()
             + "@SchemaComplianceHasClearedCacheFlag";
     public static final String DESCRIPTION = "Validates that the last received message is compliant with the associated WSDL or WADL schema definition. Applicable to SOAP and REST TestSteps.";

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/basic/SimpleContainsAssertion.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/basic/SimpleContainsAssertion.java
@@ -222,7 +222,7 @@ public class SimpleContainsAssertion extends WsdlMessageAssertion implements Req
     }
 
     public PropertyExpansion[] getPropertyExpansions() {
-        List<PropertyExpansion> result = new ArrayList<PropertyExpansion>();
+        List<PropertyExpansion> result = new ArrayList<>();
 
         result.addAll(PropertyExpansionUtils.extractPropertyExpansions(getAssertable().getModelItem(), this, "token"));
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/basic/SimpleNotContainsAssertion.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/basic/SimpleNotContainsAssertion.java
@@ -220,7 +220,7 @@ public class SimpleNotContainsAssertion extends WsdlMessageAssertion implements 
     }
 
     public PropertyExpansion[] getPropertyExpansions() {
-        List<PropertyExpansion> result = new ArrayList<PropertyExpansion>();
+        List<PropertyExpansion> result = new ArrayList<>();
 
         result.addAll(PropertyExpansionUtils.extractPropertyExpansions(getAssertable().getModelItem(), this, "token"));
 

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/recent/BoundedQueue.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/assertions/recent/BoundedQueue.java
@@ -28,7 +28,7 @@ public class BoundedQueue {
     private LinkedList<String> queue;
 
     public BoundedQueue() {
-        this.queue = new LinkedList<String>();
+        this.queue = new LinkedList<>();
     }
 
     public void remove(String e) {
@@ -48,12 +48,12 @@ public class BoundedQueue {
     }
 
     public List<String> getByAlphabeticalOrder() {
-        List<String> list = new ArrayList<String>(this.queue);
+        List<String> list = new ArrayList<>(this.queue);
         Collections.sort(list);
         return list;
     }
 
     public List<String> getByInsertionOrder() {
-        return new LinkedList<String>(this.queue);
+        return new LinkedList<>(this.queue);
     }
 }

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/registry/HttpRequestStepFactory.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/registry/HttpRequestStepFactory.java
@@ -208,7 +208,7 @@ public class HttpRequestStepFactory extends WsdlTestStepFactory {
         // set parameters
         RestParametersConfig parametersConfig = testRequestConfig.addNewParameters();
         Map<String, String> parametersMap = me.getHttpRequestParameters();
-        List<RestParameterConfig> parameterConfigList = new ArrayList<RestParameterConfig>();
+        List<RestParameterConfig> parameterConfigList = new ArrayList<>();
         for (String name : parametersMap.keySet()) {
             RestParameterConfig parameterConf = RestParameterConfig.Factory.newInstance();
             parameterConf.setName(name);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/registry/RestRequestStepFactory.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/registry/RestRequestStepFactory.java
@@ -89,8 +89,8 @@ public class RestRequestStepFactory extends WsdlTestStepFactory {
     public TestStepConfig createNewTestStep(WsdlTestCase testCase, String name) {
         // build list of available interfaces / restResources
         Project project = testCase.getTestSuite().getProject();
-        List<String> options = new ArrayList<String>();
-        TupleList<RestMethod, RestRequest> restMethods = new TupleList<RestMethod, RestRequest>();
+        List<String> options = new ArrayList<>();
+        TupleList<RestMethod, RestRequest> restMethods = new TupleList<>();
 
         for (int c = 0; c < project.getInterfaceCount(); c++) {
             Interface iface = project.getInterfaceAt(c);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/registry/WsdlMockResponseStepFactory.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/registry/WsdlMockResponseStepFactory.java
@@ -92,7 +92,7 @@ public class WsdlMockResponseStepFactory extends WsdlTestStepFactory {
         WsdlMockResponseStepFactory.project = project;
 
         try {
-            List<Interface> interfaces = new ArrayList<Interface>();
+            List<Interface> interfaces = new ArrayList<>();
             for (Interface iface : project.getInterfaces(WsdlInterfaceFactory.WSDL_TYPE)) {
                 if (iface.getOperationCount() > 0) {
                     interfaces.add(iface);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/registry/WsdlTestRequestStepFactory.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/registry/WsdlTestRequestStepFactory.java
@@ -150,8 +150,8 @@ public class WsdlTestRequestStepFactory extends WsdlTestStepFactory {
     public TestStepConfig createNewTestStep(WsdlTestCase testCase, String name) {
         // build list of available interfaces / operations
         Project project = testCase.getTestSuite().getProject();
-        List<String> options = new ArrayList<String>();
-        List<Operation> operations = new ArrayList<Operation>();
+        List<String> options = new ArrayList<>();
+        List<Operation> operations = new ArrayList<>();
 
         for (int c = 0; c < project.getInterfaceCount(); c++) {
             Interface iface = project.getInterfaceAt(c);

--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/registry/WsdlTestStepRegistry.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/teststeps/registry/WsdlTestStepRegistry.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 public class WsdlTestStepRegistry implements SoapUIFactoryRegistryListener {
     private static WsdlTestStepRegistry instance;
-    private List<WsdlTestStepFactory> factories = new ArrayList<WsdlTestStepFactory>();
+    private List<WsdlTestStepFactory> factories = new ArrayList<>();
 
     public WsdlTestStepRegistry() {
         addFactory(new WsdlTestRequestStepFactory());

--- a/soapui/src/main/java/com/eviware/soapui/integration/exporter/ProjectExporter.java
+++ b/soapui/src/main/java/com/eviware/soapui/integration/exporter/ProjectExporter.java
@@ -165,7 +165,7 @@ public class ProjectExporter {
     }
 
     public static List<String> getZipContents(String archive) {
-        List<String> contents = new ArrayList<String>();
+        List<String> contents = new ArrayList<>();
 
         try {
             ZipFile zipFile = new ZipFile(archive);

--- a/soapui/src/main/java/com/eviware/soapui/mockaswar/MockAsWarServlet.java
+++ b/soapui/src/main/java/com/eviware/soapui/mockaswar/MockAsWarServlet.java
@@ -221,7 +221,7 @@ public class MockAsWarServlet extends HttpServlet {
 
     class MockServletSoapUICore extends DefaultSoapUICore implements MockEngine, MockAsWarCoreInterface {
         private final ServletContext servletContext;
-        private List<MockRunner> mockRunners = new ArrayList<MockRunner>();
+        private List<MockRunner> mockRunners = new ArrayList<>();
 
         public MockServletSoapUICore(ServletContext servletContext, String soapUISettings) {
             super(servletContext.getRealPath("/"), servletContext.getRealPath(soapUISettings));

--- a/soapui/src/main/java/com/eviware/soapui/model/project/ProjectFactoryRegistry.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/project/ProjectFactoryRegistry.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ProjectFactoryRegistry {
-    private static Map<String, ProjectFactory<?>> factories = new HashMap<String, ProjectFactory<?>>();
+    private static Map<String, ProjectFactory<?>> factories = new HashMap<>();
 
     static {
         factories.put(WsdlProjectFactory.WSDL_TYPE, new WsdlProjectFactory());

--- a/soapui/src/main/java/com/eviware/soapui/model/propertyexpansion/PropertyExpander.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/propertyexpansion/PropertyExpander.java
@@ -51,8 +51,8 @@ import java.util.Map;
  */
 
 public class PropertyExpander implements SoapUIFactoryRegistryListener {
-    private List<PropertyResolver> propertyResolvers = new ArrayList<PropertyResolver>();
-    private static List<PropertyResolver> defaultResolvers = new ArrayList<PropertyResolver>();
+    private List<PropertyResolver> propertyResolvers = new ArrayList<>();
+    private static List<PropertyResolver> defaultResolvers = new ArrayList<>();
     private static PropertyExpander defaultExpander;
     private static boolean debuggingMode;
     private static Map<String, StringToStringMap> debuggingExpandedProperties;
@@ -78,7 +78,7 @@ public class PropertyExpander implements SoapUIFactoryRegistryListener {
 
         // WORKAROUND: eliminates a potential problem with a circular dependency between HttpClientSupport and this class
         ProxyUtils.setGlobalProxy(SoapUI.getSettings());
-        debuggingExpandedProperties = new HashMap<String, StringToStringMap>();
+        debuggingExpandedProperties = new HashMap<>();
     }
 
     public PropertyExpander(boolean addDefaultResolvers) {
@@ -111,7 +111,7 @@ public class PropertyExpander implements SoapUIFactoryRegistryListener {
         resolverFactories.put( factory, resolver );
     }
 
-    private Map<PropertyResolverFactory,PropertyResolver> resolverFactories = new HashMap<PropertyResolverFactory, PropertyResolver>();
+    private Map<PropertyResolverFactory,PropertyResolver> resolverFactories = new HashMap<>();
 
     public void removeResolverFactory( PropertyResolverFactory factory )
     {

--- a/soapui/src/main/java/com/eviware/soapui/model/propertyexpansion/PropertyExpansionUtils.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/propertyexpansion/PropertyExpansionUtils.java
@@ -221,8 +221,8 @@ public class PropertyExpansionUtils {
         UISupport.setHourglassCursor();
 
         try {
-            List<MutablePropertyExpansion> result = new ArrayList<MutablePropertyExpansion>();
-            List<MutablePropertyExpansion> properties = new ArrayList<MutablePropertyExpansion>();
+            List<MutablePropertyExpansion> result = new ArrayList<>();
+            List<MutablePropertyExpansion> properties = new ArrayList<>();
 
             PropertyExpansion[] propertyExpansions = getPropertyExpansions(root, true, true);
             for (PropertyExpansion pe : propertyExpansions) {
@@ -251,7 +251,7 @@ public class PropertyExpansionUtils {
     }
 
     public static PropertyExpansion[] getPropertyExpansions(ModelItem modelItem, boolean mutableOnly, boolean deep) {
-        List<PropertyExpansion> result = new ArrayList<PropertyExpansion>();
+        List<PropertyExpansion> result = new ArrayList<>();
 
         if (modelItem instanceof PropertyExpansionContainer) {
             PropertyExpansion[] pes = ((PropertyExpansionContainer) modelItem).getPropertyExpansions();
@@ -280,8 +280,8 @@ public class PropertyExpansionUtils {
 
     public static Collection<? extends PropertyExpansion> extractPropertyExpansions(ModelItem modelItem, Object target,
                                                                                     String propertyName) {
-        List<PropertyExpansion> result = new ArrayList<PropertyExpansion>();
-        Set<String> expansions = new HashSet<String>();
+        List<PropertyExpansion> result = new ArrayList<>();
+        Set<String> expansions = new HashSet<>();
 
         try {
             Object property = PropertyUtils.getProperty(target, propertyName);

--- a/soapui/src/main/java/com/eviware/soapui/model/propertyexpansion/resolvers/DynamicPropertyResolver.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/propertyexpansion/resolvers/DynamicPropertyResolver.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class DynamicPropertyResolver implements PropertyResolver, SoapUIFactoryRegistryListener {
-    private static Map<String, ValueProvider> providers = new HashMap<String, ValueProvider>();
+    private static Map<String, ValueProvider> providers = new HashMap<>();
 
     static {
         addProvider("projectDir", new ProjectDirProvider());

--- a/soapui/src/main/java/com/eviware/soapui/model/propertyexpansion/resolvers/EvalPropertyResolver.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/propertyexpansion/resolvers/EvalPropertyResolver.java
@@ -48,7 +48,7 @@ import java.util.Map;
 
 public class EvalPropertyResolver implements PropertyResolver {
     private Logger log = LogManager.getLogger(EvalPropertyResolver.class);
-    private Map<String, ScriptEnginePool> scriptEnginePools = new HashMap<String, ScriptEnginePool>();
+    private Map<String, ScriptEnginePool> scriptEnginePools = new HashMap<>();
 
     public String resolveProperty(PropertyExpansionContext context, String name, boolean globalOverride) {
         if (name.length() == 0 || name.charAt(0) != '=') {

--- a/soapui/src/main/java/com/eviware/soapui/model/propertyexpansion/resolvers/GlobalPropertyResolver.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/propertyexpansion/resolvers/GlobalPropertyResolver.java
@@ -47,7 +47,7 @@ public class GlobalPropertyResolver implements PropertyResolver {
 
         public Map<String, TestProperty> getProperties() {
             Map<String, String> properties = System.getenv();
-            Map<String, TestProperty> result = new HashMap<String, TestProperty>();
+            Map<String, TestProperty> result = new HashMap<>();
 
             for (Object key : properties.keySet()) {
                 result.put(key.toString(), new SystemEnviromentTestProperty(key));
@@ -57,7 +57,7 @@ public class GlobalPropertyResolver implements PropertyResolver {
         }
 
         public List<TestProperty> getPropertyList() {
-            List<TestProperty> result = new ArrayList<TestProperty>();
+            List<TestProperty> result = new ArrayList<>();
 
             for (TestProperty property : getProperties().values()) {
                 result.add(property);
@@ -168,7 +168,7 @@ public class GlobalPropertyResolver implements PropertyResolver {
 
         public Map<String, TestProperty> getProperties() {
             Properties properties = System.getProperties();
-            Map<String, TestProperty> result = new HashMap<String, TestProperty>();
+            Map<String, TestProperty> result = new HashMap<>();
 
             for (Object key : properties.keySet()) {
                 result.put(key.toString(), new SystemTestProperty(key));
@@ -195,7 +195,7 @@ public class GlobalPropertyResolver implements PropertyResolver {
         }
 
         public List<TestProperty> getPropertyList() {
-            List<TestProperty> result = new ArrayList<TestProperty>();
+            List<TestProperty> result = new ArrayList<>();
 
             for (TestProperty property : getProperties().values()) {
                 result.add(property);

--- a/soapui/src/main/java/com/eviware/soapui/model/security/SensitiveInformationTableModel.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/security/SensitiveInformationTableModel.java
@@ -98,7 +98,7 @@ public class SensitiveInformationTableModel extends DefaultTableModel {
     }
 
     public void removeRows(int[] selectedRows) {
-        ArrayList<String> toRemove = new ArrayList<String>();
+        ArrayList<String> toRemove = new ArrayList<>();
 
         for (int index : selectedRows) {
             String name = (String) getValueAt(index, 0);

--- a/soapui/src/main/java/com/eviware/soapui/model/support/ModelSupport.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/support/ModelSupport.java
@@ -48,7 +48,7 @@ public class ModelSupport {
 
     @SuppressWarnings("unchecked")
     public static <T extends ModelItem> List<T> getChildren(ModelItem modelItem, Class<T> childType) {
-        List<T> result = new ArrayList<T>();
+        List<T> result = new ArrayList<>();
         for (ModelItem child : modelItem.getChildren()) {
             if (child.getClass().equals(childType)) {
                 result.add((T) child);

--- a/soapui/src/main/java/com/eviware/soapui/model/tree/AbstractModelItemTreeNode.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/tree/AbstractModelItemTreeNode.java
@@ -210,7 +210,7 @@ public abstract class AbstractModelItemTreeNode<T extends ModelItem> implements 
     }
 
     public Enumeration<? extends TreeNode> children() {
-        Vector<TreeNode> children = new Vector<TreeNode>();
+        Vector<TreeNode> children = new Vector<>();
         for (int c = 0; c < getChildCount(); c++) {
             children.add(getChildAt(c));
         }

--- a/soapui/src/main/java/com/eviware/soapui/model/tree/AbstractTreeNode.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/tree/AbstractTreeNode.java
@@ -67,7 +67,7 @@ public abstract class AbstractTreeNode<T extends ModelItem> implements SoapUITre
     }
 
     public Enumeration children() {
-        Vector<TreeNode> children = new Vector<TreeNode>();
+        Vector<TreeNode> children = new Vector<>();
         for (int c = 0; c < getChildCount(); c++) {
             children.add(getChildAt(c));
         }

--- a/soapui/src/main/java/com/eviware/soapui/model/tree/SoapUITreeModel.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/tree/SoapUITreeModel.java
@@ -43,10 +43,10 @@ import java.util.Set;
  */
 
 public class SoapUITreeModel implements TreeModel {
-    private Set<TreeModelListener> listeners = new HashSet<TreeModelListener>();
+    private Set<TreeModelListener> listeners = new HashSet<>();
     private SoapUITreeNode workspaceNode;
     private final static Logger logger = LogManager.getLogger(SoapUITreeModel.class);
-    private Map<ModelItem, SoapUITreeNode> modelItemMap = new HashMap<ModelItem, SoapUITreeNode>();
+    private Map<ModelItem, SoapUITreeNode> modelItemMap = new HashMap<>();
     private boolean showProperties = false;
 
     public SoapUITreeModel(Workspace workspace) {
@@ -145,7 +145,7 @@ public class SoapUITreeModel implements TreeModel {
         // throw new RuntimeException( "Missing mapping for modelItem " +
         // modelItem.getName() );
 
-        List<Object> nodes = new ArrayList<Object>();
+        List<Object> nodes = new ArrayList<>();
         if (treeNode != null) {
             nodes.add(treeNode);
 

--- a/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/InterfaceTreeNode.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/InterfaceTreeNode.java
@@ -38,7 +38,7 @@ import java.util.List;
 
 public class InterfaceTreeNode extends AbstractModelItemTreeNode<Interface> {
     private InternalInterfaceListener interfaceListener;
-    private List<SoapUITreeNode> operationNodes = new ArrayList<SoapUITreeNode>();
+    private List<SoapUITreeNode> operationNodes = new ArrayList<>();
 
     public InterfaceTreeNode(Interface iface, SoapUITreeModel treeModel) {
         super(iface, iface.getProject(), treeModel);

--- a/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/MockOperationTreeNode.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/MockOperationTreeNode.java
@@ -32,7 +32,7 @@ import java.util.List;
  */
 
 public class MockOperationTreeNode extends AbstractModelItemTreeNode<MockOperation> {
-    private List<MockResponseTreeNode> mockResponseNodes = new ArrayList<MockResponseTreeNode>();
+    private List<MockResponseTreeNode> mockResponseNodes = new ArrayList<>();
 
     public MockOperationTreeNode(MockOperation mockOperation, SoapUITreeModel treeModel) {
         super(mockOperation, mockOperation.getMockService(), treeModel);

--- a/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/MockServiceTreeNode.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/MockServiceTreeNode.java
@@ -35,7 +35,7 @@ import java.util.List;
 
 public class MockServiceTreeNode extends AbstractModelItemTreeNode<MockService> {
     private ReorderPropertyChangeListener propertyChangeListener = new ReorderPropertyChangeListener();
-    private List<MockOperationTreeNode> mockOperationNodes = new ArrayList<MockOperationTreeNode>();
+    private List<MockOperationTreeNode> mockOperationNodes = new ArrayList<>();
     private InternalMockServiceListener mockServiceListener;
     private PropertiesTreeNode<?> propertiesTreeNode;
 

--- a/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/OperationTreeNode.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/OperationTreeNode.java
@@ -33,7 +33,7 @@ import java.util.List;
  */
 
 public class OperationTreeNode extends AbstractModelItemTreeNode<Operation> {
-    private List<RequestTreeNode> requestNodes = new ArrayList<RequestTreeNode>();
+    private List<RequestTreeNode> requestNodes = new ArrayList<>();
     private ReorderPropertyChangeListener propertyChangeListener = new ReorderPropertyChangeListener();
 
     public OperationTreeNode(Operation operation, SoapUITreeModel treeModel) {

--- a/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/ProjectTreeNode.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/ProjectTreeNode.java
@@ -36,9 +36,9 @@ import java.util.List;
 
 public class ProjectTreeNode extends AbstractModelItemTreeNode<Project> {
     private InternalProjectListener internalProjectListener;
-    private List<InterfaceTreeNode> interfaceNodes = new ArrayList<InterfaceTreeNode>();
-    private List<TestSuiteTreeNode> testSuiteNodes = new ArrayList<TestSuiteTreeNode>();
-    private List<MockServiceTreeNode> mockServiceNodes = new ArrayList<MockServiceTreeNode>();
+    private List<InterfaceTreeNode> interfaceNodes = new ArrayList<>();
+    private List<TestSuiteTreeNode> testSuiteNodes = new ArrayList<>();
+    private List<MockServiceTreeNode> mockServiceNodes = new ArrayList<>();
     private PropertiesTreeNode<?> propertiesTreeNode;
 
     public ProjectTreeNode(Project project, WorkspaceTreeNode workspaceNode) {

--- a/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/PropertiesTreeNode.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/PropertiesTreeNode.java
@@ -38,8 +38,8 @@ import java.util.List;
 import java.util.Map;
 
 public class PropertiesTreeNode<T extends ModelItem> extends AbstractModelItemTreeNode<T> {
-    private List<PropertyTreeNode> propertyNodes = new ArrayList<PropertyTreeNode>();
-    private Map<String, PropertyTreeNode> propertyMap = new HashMap<String, PropertyTreeNode>();
+    private List<PropertyTreeNode> propertyNodes = new ArrayList<>();
+    private Map<String, PropertyTreeNode> propertyMap = new HashMap<>();
     private InternalTestPropertyListener testPropertyListener;
     private final TestPropertyHolder holder;
 

--- a/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/RestMethodTreeNode.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/RestMethodTreeNode.java
@@ -35,7 +35,7 @@ import java.util.List;
  */
 
 public class RestMethodTreeNode extends AbstractModelItemTreeNode<RestMethod> {
-    private List<RequestTreeNode> requestNodes = new ArrayList<RequestTreeNode>();
+    private List<RequestTreeNode> requestNodes = new ArrayList<>();
     private ReorderPropertyChangeListener propertyChangeListener = new ReorderPropertyChangeListener();
 
     public RestMethodTreeNode(RestMethod method, SoapUITreeModel treeModel) {

--- a/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/RestResourceTreeNode.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/RestResourceTreeNode.java
@@ -37,8 +37,8 @@ import java.util.List;
  */
 
 public class RestResourceTreeNode extends AbstractModelItemTreeNode<RestResource> implements PropertyChangeListener {
-    private List<RestResourceTreeNode> resourceNodes = new ArrayList<RestResourceTreeNode>();
-    private List<RestMethodTreeNode> methodNodes = new ArrayList<RestMethodTreeNode>();
+    private List<RestResourceTreeNode> resourceNodes = new ArrayList<>();
+    private List<RestMethodTreeNode> methodNodes = new ArrayList<>();
     private final RestResource restResource;
 
     private ReorderPropertyChangeListener propertyChangeListener = new ReorderPropertyChangeListener();

--- a/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/TestCaseTreeNode.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/TestCaseTreeNode.java
@@ -44,7 +44,7 @@ public class TestCaseTreeNode extends AbstractModelItemTreeNode<TestCase> {
     private LoadTestsTreeNode loadTestsNode;
     private SecurityTestsTreeNode securityTestsNode;
     private PropertiesTreeNode<?> propertiesTreeNode;
-    private List<SoapUITreeNode> childNodes = new ArrayList<SoapUITreeNode>();
+    private List<SoapUITreeNode> childNodes = new ArrayList<>();
 
     public TestCaseTreeNode(TestCase testCase, SoapUITreeModel treeModel) {
         super(testCase, testCase.getTestSuite(), treeModel);
@@ -114,7 +114,7 @@ public class TestCaseTreeNode extends AbstractModelItemTreeNode<TestCase> {
     }
 
     public class TestStepsTreeNode extends AbstractTreeNode<WsdlTestStepsModelItem> {
-        private List<TestStepTreeNode> testStepNodes = new ArrayList<TestStepTreeNode>();
+        private List<TestStepTreeNode> testStepNodes = new ArrayList<>();
 
         protected TestStepsTreeNode() {
             super(new WsdlTestStepsModelItem(getTestCase()));
@@ -183,7 +183,7 @@ public class TestCaseTreeNode extends AbstractModelItemTreeNode<TestCase> {
     }
 
     public class LoadTestsTreeNode extends AbstractTreeNode<WsdlLoadTestsModelItem> {
-        private List<LoadTestTreeNode> loadTestNodes = new ArrayList<LoadTestTreeNode>();
+        private List<LoadTestTreeNode> loadTestNodes = new ArrayList<>();
 
         protected LoadTestsTreeNode() {
             super(new WsdlLoadTestsModelItem(getTestCase()));
@@ -241,7 +241,7 @@ public class TestCaseTreeNode extends AbstractModelItemTreeNode<TestCase> {
     }
 
     public class SecurityTestsTreeNode extends AbstractTreeNode<SecurityTestsModelItem> {
-        private List<SecurityTestTreeNode> securityTestNodes = new ArrayList<SecurityTestTreeNode>();
+        private List<SecurityTestTreeNode> securityTestNodes = new ArrayList<>();
 
         protected SecurityTestsTreeNode() {
             super(new SecurityTestsModelItem(getTestCase()));

--- a/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/TestSuiteTreeNode.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/TestSuiteTreeNode.java
@@ -39,7 +39,7 @@ public class TestSuiteTreeNode extends AbstractModelItemTreeNode<TestSuite> {
     private InternalTestSuiteListener internalTestSuiteListener = new InternalTestSuiteListener();
     ;
     private ReorderPropertyChangeListener propertyChangeListener = new ReorderPropertyChangeListener();
-    private List<TestCaseTreeNode> testCaseNodes = new ArrayList<TestCaseTreeNode>();
+    private List<TestCaseTreeNode> testCaseNodes = new ArrayList<>();
     private PropertiesTreeNode<?> propertiesTreeNode;
 
     public TestSuiteTreeNode(TestSuite testSuite, SoapUITreeModel treeModel) {

--- a/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/WorkspaceTreeNode.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/tree/nodes/WorkspaceTreeNode.java
@@ -36,7 +36,7 @@ import java.util.List;
 
 public class WorkspaceTreeNode extends AbstractModelItemTreeNode<Workspace> {
     private InternalWorkspaceListener workspaceListener = new InternalWorkspaceListener();
-    private List<ProjectTreeNode> projectNodes = new ArrayList<ProjectTreeNode>();
+    private List<ProjectTreeNode> projectNodes = new ArrayList<>();
     private ReorderPropertyChangeListener propertyChangeListener = new ReorderPropertyChangeListener();
 
     public WorkspaceTreeNode(Workspace workspace, SoapUITreeModel treeModel) {

--- a/soapui/src/main/java/com/eviware/soapui/model/util/ModelItemIconFactory.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/util/ModelItemIconFactory.java
@@ -48,7 +48,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ModelItemIconFactory {
-    private static Map<Class<? extends ModelItem>, String> modelItemIcons = new HashMap<Class<? extends ModelItem>, String>();
+    private static Map<Class<? extends ModelItem>, String> modelItemIcons = new HashMap<>();
 
     static {
         // the "class" keys here are only used for lookup - but must be implementations of ModelItem

--- a/soapui/src/main/java/com/eviware/soapui/model/util/ModelItemNames.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/util/ModelItemNames.java
@@ -32,12 +32,12 @@ public class ModelItemNames<T extends ModelItem> {
     private List<T> elements;
 
     public ModelItemNames(List<T> elements) {
-        this.elements = new ArrayList<T>(elements);
+        this.elements = new ArrayList<>(elements);
     }
 
     public ModelItemNames(T[] elements) {
         // Create an ArrayList to make sure that elements is modifyable.
-        this.elements = new ArrayList<T>(Arrays.asList(elements));
+        this.elements = new ArrayList<>(Arrays.asList(elements));
     }
 
     public String[] getNames() {
@@ -46,7 +46,7 @@ public class ModelItemNames<T extends ModelItem> {
     }
 
     private ArrayList<String> getElementNameList() {
-        ArrayList<String> elementNames = new ArrayList<String>();
+        ArrayList<String> elementNames = new ArrayList<>();
         for (T element : elements) {
             elementNames.add(element.getName());
         }

--- a/soapui/src/main/java/com/eviware/soapui/model/util/PanelBuilderRegistry.java
+++ b/soapui/src/main/java/com/eviware/soapui/model/util/PanelBuilderRegistry.java
@@ -98,7 +98,7 @@ import java.util.Map;
  */
 
 public class PanelBuilderRegistry {
-    private static Map<Class<? extends ModelItem>, PanelBuilder<? extends ModelItem>> builders = new HashMap<Class<? extends ModelItem>, PanelBuilder<? extends ModelItem>>();
+    private static Map<Class<? extends ModelItem>, PanelBuilder<? extends ModelItem>> builders = new HashMap<>();
 
     @SuppressWarnings("unchecked")
     public static <T extends ModelItem> PanelBuilder<T> getPanelBuilder(T modelItem) {

--- a/soapui/src/main/java/com/eviware/soapui/monitor/JettyMockEngine.java
+++ b/soapui/src/main/java/com/eviware/soapui/monitor/JettyMockEngine.java
@@ -78,9 +78,9 @@ public class JettyMockEngine implements MockEngine {
     public final static Logger log = LogManager.getLogger(JettyMockEngine.class);
 
     private Server server;
-    private Map<Integer, Map<String, List<MockRunner>>> runners = new HashMap<Integer, Map<String, List<MockRunner>>>();
-    private Map<Integer, SoapUIConnector> connectors = new HashMap<Integer, SoapUIConnector>();
-    private List<MockRunner> mockRunners = new CopyOnWriteArrayList<MockRunner>();
+    private Map<Integer, Map<String, List<MockRunner>>> runners = new HashMap<>();
+    private Map<Integer, SoapUIConnector> connectors = new HashMap<>();
+    private List<MockRunner> mockRunners = new CopyOnWriteArrayList<>();
 
     private SslSocketConnector sslConnector;
 
@@ -256,7 +256,7 @@ public class JettyMockEngine implements MockEngine {
     }
 
     private class SoapUIConnector extends SelectChannelConnector {
-        private Set<HttpConnection> connections = new HashSet<HttpConnection>();
+        private Set<HttpConnection> connections = new HashSet<>();
 
         @Override
         protected void connectionClosed(HttpConnection arg0) {

--- a/soapui/src/main/java/com/eviware/soapui/monitor/TestMonitor.java
+++ b/soapui/src/main/java/com/eviware/soapui/monitor/TestMonitor.java
@@ -54,7 +54,7 @@ import java.util.Set;
  */
 
 public class TestMonitor {
-    private Set<TestMonitorListener> listeners = new HashSet<TestMonitorListener>();
+    private Set<TestMonitorListener> listeners = new HashSet<>();
     private InternalWorkspaceListener workspaceListener = new InternalWorkspaceListener();
     private InternalProjectListener projectListener = new InternalProjectListener();
     private InternalTestSuiteListener testSuiteListener = new InternalTestSuiteListener();
@@ -62,10 +62,10 @@ public class TestMonitor {
     private InternalMockRunListener mockRunListener = new InternalMockRunListener();
     private InternalLoadTestRunListener loadTestRunListener = new InternalLoadTestRunListener();
     private InternalSecurityTestRunListener securityTestRunListener = new InternalSecurityTestRunListener();
-    private Set<TestCaseRunner> runningTestCases = new HashSet<TestCaseRunner>();
-    private Set<LoadTestRunner> runningLoadTests = new HashSet<LoadTestRunner>();
-    private Set<SecurityTestRunner> runningSecurityTests = new HashSet<SecurityTestRunner>();
-    private Set<MockRunner> runningMockServices = new HashSet<MockRunner>();
+    private Set<TestCaseRunner> runningTestCases = new HashSet<>();
+    private Set<LoadTestRunner> runningLoadTests = new HashSet<>();
+    private Set<SecurityTestRunner> runningSecurityTests = new HashSet<>();
+    private Set<MockRunner> runningMockServices = new HashSet<>();
     private Map<String, TestCaseRunner.Status> runStatusHistory = new HashMap<String, TestCaseRunner.Status>();
 
     public TestMonitor() {

--- a/soapui/src/main/java/com/eviware/soapui/plugins/LoaderBase.java
+++ b/soapui/src/main/java/com/eviware/soapui/plugins/LoaderBase.java
@@ -66,7 +66,7 @@ public class LoaderBase {
 
     protected Collection<? extends SoapUIFactory> loadFactories(Reflections jarFileScanner)
             throws IllegalAccessException, InstantiationException {
-        Collection<SoapUIFactory> factories = new HashSet<SoapUIFactory>();
+        Collection<SoapUIFactory> factories = new HashSet<>();
 
         Set<Class<?>> factoryClasses = jarFileScanner.getTypesAnnotatedWith(FactoryConfiguration.class);
         for (Class<?> factoryClass : factoryClasses) {
@@ -122,7 +122,7 @@ public class LoaderBase {
     protected Collection<SoapUIFactory> findAutoFactoryObjects(Reflections jarFileScanner, Class<? extends Annotation> annotationType,
                                                                Class<? extends SoapUIFactory> factoryClass) {
 
-        Collection<SoapUIFactory> factories = new HashSet<SoapUIFactory>();
+        Collection<SoapUIFactory> factories = new HashSet<>();
         Set<Class<?>> objectClasses = jarFileScanner.getTypesAnnotatedWith(annotationType);
 
         for (Class<?> clazz : objectClasses) {
@@ -162,7 +162,7 @@ public class LoaderBase {
     }
 
     protected List<Class<? extends SoapUIListener>> loadListeners(Reflections jarFileScanner) throws IllegalAccessException, InstantiationException {
-        List<Class<? extends SoapUIListener>> listeners = new ArrayList<Class<? extends SoapUIListener>>();
+        List<Class<? extends SoapUIListener>> listeners = new ArrayList<>();
 
         Set<Class<?>> listenerClasses = jarFileScanner.getTypesAnnotatedWith(ListenerConfiguration.class);
         for (Class<?> listenerClass : listenerClasses) {
@@ -213,7 +213,7 @@ public class LoaderBase {
     }
 
     protected List<? extends SoapUIActionGroup> loadActionGroups(Reflections jarFileScanner) throws InstantiationException, IllegalAccessException {
-        List<SoapUIActionGroup> actionGroups = new ArrayList<SoapUIActionGroup>();
+        List<SoapUIActionGroup> actionGroups = new ArrayList<>();
         Set<Class<?>> actionGroupClasses = jarFileScanner.getTypesAnnotatedWith(ActionGroup.class);
         for (Class<?> actionGroupClass : actionGroupClasses) {
             if (!SoapUIActionGroup.class.isAssignableFrom(actionGroupClass)) {
@@ -280,7 +280,7 @@ public class LoaderBase {
     }
 
     protected List<? extends SoapUIAction> loadActions(Reflections jarFileScanner) throws InstantiationException, IllegalAccessException {
-        List<SoapUIAction> actions = new ArrayList<SoapUIAction>();
+        List<SoapUIAction> actions = new ArrayList<>();
         Set<Class<?>> actionClasses = jarFileScanner.getTypesAnnotatedWith(ActionConfiguration.class);
         for (Class<?> actionClass : actionClasses) {
             if (!SoapUIAction.class.isAssignableFrom(actionClass)) {

--- a/soapui/src/main/java/com/eviware/soapui/plugins/PluginDependencyResolver.java
+++ b/soapui/src/main/java/com/eviware/soapui/plugins/PluginDependencyResolver.java
@@ -32,16 +32,16 @@ public class PluginDependencyResolver {
     private final Map<PluginInfo,File> infoToFileMap;
 
     public PluginDependencyResolver(PluginLoader pluginLoader, Iterable<File> pluginFiles) throws IOException {
-        infoToFileMap = new HashMap<PluginInfo,File>();
+        infoToFileMap = new HashMap<>();
         for (File pluginFile : pluginFiles) {
             infoToFileMap.put(pluginLoader.loadPluginInfoFrom(pluginFile, Collections.<JarClassLoader>emptySet()), pluginFile);
         }
     }
 
     public List<File> determineLoadOrder() throws IOException {
-        List<PluginInfo> infoList = new ArrayList<PluginInfo>(infoToFileMap.keySet());
+        List<PluginInfo> infoList = new ArrayList<>(infoToFileMap.keySet());
         Collections.sort(infoList, new PluginDependencyComparator());
-        List<File> resultList = new ArrayList<File>();
+        List<File> resultList = new ArrayList<>();
         for (PluginInfo pluginInfo : infoList) {
             resultList.add(infoToFileMap.get(pluginInfo));
         }
@@ -49,7 +49,7 @@ public class PluginDependencyResolver {
     }
 
     public Collection<PluginInfo> findAllDependencies(PluginInfo plugin) {
-        Set<PluginInfo> allDependencies = new HashSet<PluginInfo>();
+        Set<PluginInfo> allDependencies = new HashSet<>();
         for (PluginInfo dependency : plugin.getDependencies()) {
             PluginInfo realDependency = findDependency(dependency.getId());
             if (realDependency != null) {
@@ -87,7 +87,7 @@ public class PluginDependencyResolver {
     }
 
     public List<PluginInfo> getPluginInfoListFromFiles(List<File> files) {
-        List<PluginInfo> result = new ArrayList<PluginInfo>();
+        List<PluginInfo> result = new ArrayList<>();
         for (File file : files) {
             for (Map.Entry<PluginInfo, File> entry : infoToFileMap.entrySet()) {
                 if (entry.getValue().equals(file)) {

--- a/soapui/src/main/java/com/eviware/soapui/plugins/PluginInfo.java
+++ b/soapui/src/main/java/com/eviware/soapui/plugins/PluginInfo.java
@@ -26,7 +26,7 @@ public class PluginInfo {
     private final Version version;
     private final String description;
     private final String infoUrl;
-    private List<PluginInfo> dependencies = new ArrayList<PluginInfo>();
+    private List<PluginInfo> dependencies = new ArrayList<>();
 
     public PluginInfo(PluginId id, Version version, String description, String infoUrl) {
         this.id = id;

--- a/soapui/src/main/java/com/eviware/soapui/plugins/PluginLoader.java
+++ b/soapui/src/main/java/com/eviware/soapui/plugins/PluginLoader.java
@@ -134,7 +134,7 @@ public class PluginLoader extends LoaderBase {
 
     private Collection<SoapUIFactory> loadPluginFactories(Plugin plugin, boolean autoDetect, Reflections jarFileScanner)
             throws IllegalAccessException, InstantiationException {
-        Collection<SoapUIFactory> factories = new HashSet<SoapUIFactory>(plugin.getFactories());
+        Collection<SoapUIFactory> factories = new HashSet<>(plugin.getFactories());
         if (!factories.isEmpty())
             registerFactories(factories);
 
@@ -147,7 +147,7 @@ public class PluginLoader extends LoaderBase {
 
 
     private List<Class<? extends SoapUIListener>> loadPluginListeners(Plugin plugin, boolean autoDetect, Reflections jarFileScanner) throws IllegalAccessException, InstantiationException {
-        List<Class<? extends SoapUIListener>> listeners = new ArrayList<Class<? extends SoapUIListener>>(plugin.getListeners());
+        List<Class<? extends SoapUIListener>> listeners = new ArrayList<>(plugin.getListeners());
         if (!listeners.isEmpty())
             registerListeners(listeners);
 
@@ -160,7 +160,7 @@ public class PluginLoader extends LoaderBase {
 
     private List<SoapUIAction> loadPluginActions(Plugin plugin, boolean autoDetect, Reflections jarFileScanner)
             throws InstantiationException, IllegalAccessException {
-        List<SoapUIAction> actions = new ArrayList<SoapUIAction>(plugin.getActions());
+        List<SoapUIAction> actions = new ArrayList<>(plugin.getActions());
         if (!actions.isEmpty())
             registerActions(actions);
 

--- a/soapui/src/main/java/com/eviware/soapui/plugins/PluginManager.java
+++ b/soapui/src/main/java/com/eviware/soapui/plugins/PluginManager.java
@@ -46,9 +46,9 @@ public class PluginManager {
     PluginLoader pluginLoader;
 
     private static Logger log = LogManager.getLogger(PluginManager.class);
-    private Map<File, InstalledPluginRecord> installedPlugins = new HashMap<File, InstalledPluginRecord>();
+    private Map<File, InstalledPluginRecord> installedPlugins = new HashMap<>();
     private File pluginDirectory;
-    private List<PluginListener> listeners = new ArrayList<PluginListener>();
+    private List<PluginListener> listeners = new ArrayList<>();
     private final File pluginDeleteListFile;
     private PluginDependencyResolver resolver;
     private List<String> ignorePluginNameList;
@@ -138,7 +138,7 @@ public class PluginManager {
             return Collections.emptySet();
         }
         Collection<PluginInfo> allDependencies = resolver.findAllDependencies(pluginFile);
-        Set<JarClassLoader> classLoaders = new HashSet<JarClassLoader>();
+        Set<JarClassLoader> classLoaders = new HashSet<>();
         for (PluginInfo dependency : allDependencies) {
             for (InstalledPluginRecord installedPluginRecord : installedPlugins.values()) {
                 if (installedPluginRecord.plugin.getInfo().isCompatibleWith(dependency)) {
@@ -266,7 +266,7 @@ public class PluginManager {
     }
 
     public Collection<Plugin> getInstalledPlugins() {
-        Set<Plugin> plugins = new HashSet<Plugin>();
+        Set<Plugin> plugins = new HashSet<>();
         for (InstalledPluginRecord installedPluginRecord : installedPlugins.values()) {
             plugins.add(installedPluginRecord.plugin);
         }
@@ -308,7 +308,7 @@ public class PluginManager {
 
 
     private List<PluginInfo> findUnsatisfiedDependencies(PluginInfo pluginInfo) {
-        List<PluginInfo> unsatisfiedDependencies = new ArrayList<PluginInfo>();
+        List<PluginInfo> unsatisfiedDependencies = new ArrayList<>();
         for (PluginInfo dependency : pluginInfo.getDependencies()) {
             if (!dependencyInstalled(dependency)) {
                 unsatisfiedDependencies.add(dependency);
@@ -336,7 +336,7 @@ public class PluginManager {
     }
 
     public Collection<Plugin> getDependentPlugins(Plugin selectedPlugin) {
-        Set<Plugin> dependentPlugins = new HashSet<Plugin>();
+        Set<Plugin> dependentPlugins = new HashSet<>();
         for (InstalledPluginRecord installedPluginRecord : installedPlugins.values()) {
             Collection<PluginInfo> allDependencies = resolver.findAllDependencies(installedPluginRecord.plugin.getInfo());
             for (PluginInfo dependency : allDependencies) {
@@ -383,7 +383,7 @@ public class PluginManager {
         private List<File> files;
 
         private LoadPluginsTask(Collection<File> files) {
-            this.files = new ArrayList<File>(files);
+            this.files = new ArrayList<>(files);
         }
 
         @Override
@@ -397,7 +397,7 @@ public class PluginManager {
                 LoadPluginsTask rightTask = new LoadPluginsTask(files.subList(splitPoint, files.size()));
                 List<Plugin> rightTaskResult = rightTask.compute();
                 List<Plugin> leftTaskResult = leftTask.join();
-                List<Plugin> result = new ArrayList<Plugin>();
+                List<Plugin> result = new ArrayList<>();
                 result.addAll(leftTaskResult);
                 result.addAll(rightTaskResult);
                 return result;
@@ -428,7 +428,7 @@ public class PluginManager {
 
 
         private List<Plugin> computeSequentially() {
-            List<Plugin> result = new ArrayList<Plugin>();
+            List<Plugin> result = new ArrayList<>();
             for (File pluginFile : files) {
                 try {
                     log.info("Adding plugin from [" + pluginFile.getAbsolutePath() + "]");

--- a/soapui/src/main/java/com/eviware/soapui/plugins/PluginProxies.java
+++ b/soapui/src/main/java/com/eviware/soapui/plugins/PluginProxies.java
@@ -74,7 +74,7 @@ public class PluginProxies {
     }
 
     public static <T> Collection<T> proxyInstancesWhereApplicable(Collection<T> instancesToProxy) {
-        Collection<T> proxiedInstances = new HashSet<T>();
+        Collection<T> proxiedInstances = new HashSet<>();
         for (T instance : instancesToProxy) {
             proxiedInstances.add(proxyIfApplicable(instance));
         }

--- a/soapui/src/main/java/com/eviware/soapui/report/JUnitReportCollector.java
+++ b/soapui/src/main/java/com/eviware/soapui/report/JUnitReportCollector.java
@@ -67,9 +67,9 @@ public class JUnitReportCollector implements TestRunListener, TestSuiteRunListen
 
     public JUnitReportCollector(int maxErrors) {
         this.maxErrors = maxErrors;
-        reports = new HashMap<String, JUnitReport>();
-        errorCount = new HashMap<TestCase, Integer>();
-        failures = new HashMap<TestCase, String>();
+        reports = new HashMap<>();
+        errorCount = new HashMap<>();
+        failures = new HashMap<>();
     }
 
     public List<String> saveReports(String path) throws Exception {
@@ -79,7 +79,7 @@ public class JUnitReportCollector implements TestRunListener, TestSuiteRunListen
             file.mkdirs();
         }
 
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
 
         Iterator<String> keyset = reports.keySet().iterator();
         while (keyset.hasNext()) {

--- a/soapui/src/main/java/com/eviware/soapui/security/SecurityTest.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/SecurityTest.java
@@ -66,11 +66,11 @@ public class SecurityTest extends AbstractTestPropertyHolderWsdlModelItem<Securi
     private WsdlTestCase testCase;
     private Set<SecurityTestRunListener> securityTestRunListeners = Collections
             .synchronizedSet(new HashSet<SecurityTestRunListener>());
-    private Map<TestStep, Set<SecurityTestRunListener>> securityTestStepRunListeners = new HashMap<TestStep, Set<SecurityTestRunListener>>();
+    private Map<TestStep, Set<SecurityTestRunListener>> securityTestStepRunListeners = new HashMap<>();
     private Map<TestStep, SecurityTestStepResult> securityTestStepResultMap;
 
-    private HashMap<String, List<SecurityScan>> securityScansMap = new HashMap<String, List<SecurityScan>>();
-    private ArrayList<SecurityTestListener> securityTestListeners = new ArrayList<SecurityTestListener>();
+    private HashMap<String, List<SecurityScan>> securityScansMap = new HashMap<>();
+    private ArrayList<SecurityTestListener> securityTestListeners = new ArrayList<>();
 
     private SecurityTestRunnerImpl runner;
     private SoapUIScriptEngine startupScriptEngine;
@@ -85,7 +85,7 @@ public class SecurityTest extends AbstractTestPropertyHolderWsdlModelItem<Securi
 
         setPropertiesConfig(getConfig().getProperties());
 
-        securityTestStepResultMap = new LinkedHashMap<TestStep, SecurityTestStepResult>();
+        securityTestStepResultMap = new LinkedHashMap<>();
 
         for (SecurityTestRunListener listener : SoapUI.getListenerRegistry().getListeners(SecurityTestRunListener.class)) {
             addSecurityTestRunListener(listener);
@@ -181,7 +181,7 @@ public class SecurityTest extends AbstractTestPropertyHolderWsdlModelItem<Securi
                 securityScansMap.get(testStepId).add(newSecScan);
             }
         } else {
-            List<SecurityScan> list = new ArrayList<SecurityScan>();
+            List<SecurityScan> list = new ArrayList<>();
             list.add(newSecScan);
             securityScansMap.put(testStepId, list);
         }
@@ -310,7 +310,7 @@ public class SecurityTest extends AbstractTestPropertyHolderWsdlModelItem<Securi
         if (getConfig() != null) {
             if (!getConfig().getTestStepSecurityTestList().isEmpty()) {
                 for (TestStepSecurityTestConfig testStepSecurityTestListConfig : getConfig().getTestStepSecurityTestList()) {
-                    List<SecurityScan> scanList = new ArrayList<SecurityScan>();
+                    List<SecurityScan> scanList = new ArrayList<>();
                     if (testStepSecurityTestListConfig != null) {
                         if (!testStepSecurityTestListConfig.getTestStepSecurityScanList().isEmpty()) {
                             for (SecurityScanConfig secScanConfig : testStepSecurityTestListConfig
@@ -499,7 +499,7 @@ public class SecurityTest extends AbstractTestPropertyHolderWsdlModelItem<Securi
 
     @SuppressWarnings("unchecked")
     public <T extends SecurityScan> List<T> getTestStepSecurityScanByType(String testStepId, Class<T> securityScanType) {
-        List<T> result = new ArrayList<T>();
+        List<T> result = new ArrayList<>();
         for (SecurityScan scan : getTestStepSecurityScans(testStepId)) {
             if (securityScanType.isAssignableFrom(scan.getClass())) {
                 result.add((T) scan);
@@ -644,7 +644,7 @@ public class SecurityTest extends AbstractTestPropertyHolderWsdlModelItem<Securi
         if (securityTestStepRunListeners.containsKey(testStep)) {
             securityTestStepRunListeners.get(testStep).add(listener);
         } else {
-            Set<SecurityTestRunListener> listeners = new HashSet<SecurityTestRunListener>();
+            Set<SecurityTestRunListener> listeners = new HashSet<>();
             listeners.add(listener);
             securityTestStepRunListeners.put(testStep, listeners);
         }
@@ -665,7 +665,7 @@ public class SecurityTest extends AbstractTestPropertyHolderWsdlModelItem<Securi
 
     @Override
     public List<? extends ModelItem> getChildren() {
-        List<ModelItem> result = new ArrayList<ModelItem>();
+        List<ModelItem> result = new ArrayList<>();
         Set<String> testStepIds = getSecurityScansMap().keySet();
         for (String testStepId : testStepIds) {
             List<SecurityScan> t = getSecurityScansMap().get(testStepId);
@@ -725,7 +725,7 @@ public class SecurityTest extends AbstractTestPropertyHolderWsdlModelItem<Securi
      * @return boolean
      */
     public String[] getAvailableSecurityScanNames(TestStep testStep, String[] securityScanNames) {
-        List<String> availableNames = new ArrayList<String>();
+        List<String> availableNames = new ArrayList<>();
 
         for (int i = 0; i < securityScanNames.length; i++) {
             String name = securityScanNames[i];

--- a/soapui/src/main/java/com/eviware/soapui/security/SensitiveInformationPropertyHolder.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/SensitiveInformationPropertyHolder.java
@@ -30,7 +30,7 @@ import java.util.Map;
 
 public class SensitiveInformationPropertyHolder implements MutableTestPropertyHolder {
 
-    private Map<String, TestProperty> properties = new HashMap<String, TestProperty>();
+    private Map<String, TestProperty> properties = new HashMap<>();
 
     @Override
     public void addTestPropertyListener(TestPropertyListener listener) {
@@ -74,7 +74,7 @@ public class SensitiveInformationPropertyHolder implements MutableTestPropertyHo
 
     @Override
     public List<TestProperty> getPropertyList() {
-        return new ArrayList<TestProperty>(properties.values());
+        return new ArrayList<>(properties.values());
     }
 
     @Override

--- a/soapui/src/main/java/com/eviware/soapui/security/actions/CloneParametersAction.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/actions/CloneParametersAction.java
@@ -105,7 +105,7 @@ public class CloneParametersAction extends AbstractAction {
 
     private String[] getSecurableTestStepsNames(TestCase testCase) {
         List<TestStep> testStepList = testCase.getTestStepList();
-        List<String> namesList = new ArrayList<String>();
+        List<String> namesList = new ArrayList<>();
         for (TestStep testStep : testStepList) {
             if (AbstractSecurityScan.isSecurable(testStep)) {
                 namesList.add(testStep.getName());
@@ -119,7 +119,7 @@ public class CloneParametersAction extends AbstractAction {
     }
 
     public List<ModelItem> performClone(boolean showErrorMessage) {
-        List<ModelItem> items = new ArrayList<ModelItem>();
+        List<ModelItem> items = new ArrayList<>();
         String targetTestSuiteName = dialog.getValue(CloneParameterDialog.TARGET_TESTSUITE);
         String targetTestCaseName = dialog.getValue(CloneParameterDialog.TARGET_TESTCASE);
         String targetSecurityTestName = dialog.getValue(CloneParameterDialog.TARGET_SECURITYTEST);

--- a/soapui/src/main/java/com/eviware/soapui/security/assertion/CrossSiteScriptAssertion.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/assertion/CrossSiteScriptAssertion.java
@@ -118,7 +118,7 @@ public class CrossSiteScriptAssertion extends WsdlMessageAssertion implements Re
         CrossSiteScriptingScanConfig parameterExposureCheckConfig = (CrossSiteScriptingScanConfig) context
                 .getProperty(CrossSiteScriptingScan.PARAMETER_EXPOSURE_SCAN_CONFIG);
 
-        List<AssertionError> assertionErrorList = new ArrayList<AssertionError>();
+        List<AssertionError> assertionErrorList = new ArrayList<>();
         boolean throwExceptionCheckResponse = false;
 
         if (checkResponse) {
@@ -184,7 +184,7 @@ public class CrossSiteScriptAssertion extends WsdlMessageAssertion implements Re
     }
 
     private List<String> submitScript(MessageExchange messageExchange, SubmitContext context) {
-        List<String> urls = new ArrayList<String>();
+        List<String> urls = new ArrayList<>();
         scriptEngine.setScript(script);
         scriptEngine.setVariable("urls", urls);
         scriptEngine.setVariable("messageExchange", messageExchange);
@@ -289,7 +289,7 @@ public class CrossSiteScriptAssertion extends WsdlMessageAssertion implements Re
             return new AbstractAction() {
                 public void actionPerformed(ActionEvent e) {
                     Object result = null;
-                    List<String> urls = new ArrayList<String>();
+                    List<String> urls = new ArrayList<>();
                     scriptEngine.setScript(script);
                     scriptEngine.setVariable("urls", urls);
                     scriptEngine.setVariable("messageExchange", messageExchange);

--- a/soapui/src/main/java/com/eviware/soapui/security/assertion/InvalidHttpStatusCodesAssertion.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/assertion/InvalidHttpStatusCodesAssertion.java
@@ -113,7 +113,7 @@ public class InvalidHttpStatusCodesAssertion extends WsdlMessageAssertion implem
 
     private List<String> extractCodes(SubmitContext context) {
         String expandedCodes = context.expand(codes);
-        List<String> codeList = new ArrayList<String>();
+        List<String> codeList = new ArrayList<>();
         for (String str : expandedCodes.split(",")) {
             codeList.add(str.trim());
         }

--- a/soapui/src/main/java/com/eviware/soapui/security/assertion/SensitiveInfoExposureAssertion.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/assertion/SensitiveInfoExposureAssertion.java
@@ -116,9 +116,9 @@ public class SensitiveInfoExposureAssertion extends WsdlMessageAssertion impleme
     protected String internalAssertResponse(MessageExchange messageExchange, SubmitContext context)
             throws AssertionException {
         Map<String, String> checkMap = createCheckMap(context);
-        List<AssertionError> assertionErrorList = new ArrayList<AssertionError>();
+        List<AssertionError> assertionErrorList = new ArrayList<>();
         String response = messageExchange.getResponseContent();
-        Set<String> messages = new HashSet<String>();
+        Set<String> messages = new HashSet<>();
 
         try {
             for (Map.Entry<String, String> tokenEntry : checkMap.entrySet()) {
@@ -154,9 +154,9 @@ public class SensitiveInfoExposureAssertion extends WsdlMessageAssertion impleme
                                             MessageExchange messageExchange, SubmitContext context) throws AssertionException {
 
         Map<String, String> checkMap = createCheckMap(context);
-        List<AssertionError> assertionErrorList = new ArrayList<AssertionError>();
+        List<AssertionError> assertionErrorList = new ArrayList<>();
         String propertyValue = source.getPropertyValue(propertyName);
-        Set<String> messages = new HashSet<String>();
+        Set<String> messages = new HashSet<>();
 
         try {
             for (Map.Entry<String, String> tokenEntry : checkMap.entrySet()) {
@@ -189,7 +189,7 @@ public class SensitiveInfoExposureAssertion extends WsdlMessageAssertion impleme
     }
 
     private Map<String, String> createCheckMap(SubmitContext context) {
-        Map<String, String> checkMap = new HashMap<String, String>();
+        Map<String, String> checkMap = new HashMap<>();
         checkMap.putAll(createMapFromTable());
         if (includeProjectSpecific) {
             checkMap.putAll(SecurityScanUtil.projectEntriesList(this));
@@ -203,7 +203,7 @@ public class SensitiveInfoExposureAssertion extends WsdlMessageAssertion impleme
     }
 
     private Map<String, String> propertyExpansionSupport(Map<String, String> checkMap, SubmitContext context) {
-        Map<String, String> expanded = new HashMap<String, String>();
+        Map<String, String> expanded = new HashMap<>();
         for (Map.Entry<String, String> entry : checkMap.entrySet()) {
             expanded.put(context.expand(entry.getKey()), context.expand(entry.getValue()));
         }
@@ -268,7 +268,7 @@ public class SensitiveInfoExposureAssertion extends WsdlMessageAssertion impleme
     }
 
     private List<String> createListFromTable() {
-        List<String> temp = new ArrayList<String>();
+        List<String> temp = new ArrayList<>();
         for (TestProperty tp : sensitiveInformationTableModel.getHolder().getPropertyList()) {
             String tokenPlusDescription = tp.getName() + "###" + tp.getValue();
             temp.add(tokenPlusDescription);
@@ -277,7 +277,7 @@ public class SensitiveInfoExposureAssertion extends WsdlMessageAssertion impleme
     }
 
     private Map<String, String> createMapFromTable() {
-        Map<String, String> temp = new HashMap<String, String>();
+        Map<String, String> temp = new HashMap<>();
         for (TestProperty tp : sensitiveInformationTableModel.getHolder().getPropertyList()) {
             temp.put(tp.getName(), tp.getValue());
         }

--- a/soapui/src/main/java/com/eviware/soapui/security/assertion/ValidHttpStatusCodesAssertion.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/assertion/ValidHttpStatusCodesAssertion.java
@@ -113,7 +113,7 @@ public class ValidHttpStatusCodesAssertion extends WsdlMessageAssertion implemen
 
     private List<String> extractCodes(SubmitContext context) {
         String expandedCodes = context.expand(codes);
-        List<String> codeList = new ArrayList<String>();
+        List<String> codeList = new ArrayList<>();
         for (String str : expandedCodes.split(",")) {
             codeList.add(str.trim());
         }

--- a/soapui/src/main/java/com/eviware/soapui/security/boundary/BoundaryRestrictionUtill.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/boundary/BoundaryRestrictionUtill.java
@@ -67,7 +67,7 @@ public class BoundaryRestrictionUtill {
     }
 
     public static List<String> extractEnums(XmlTreeNode node) {
-        List<String> restrictionsList = new ArrayList<String>();
+        List<String> restrictionsList = new ArrayList<>();
         for (XmlAnySimpleType s : node.getSchemaType().getEnumerationValues()) {
             if (restrictionsList.isEmpty()) {
                 restrictionsList.add("For type enumeration values are: ");

--- a/soapui/src/main/java/com/eviware/soapui/security/boundary/EnumerationValuesExtractor.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/boundary/EnumerationValuesExtractor.java
@@ -35,7 +35,7 @@ import java.util.List;
 public class EnumerationValuesExtractor {
     private WsdlRequest request;
     // private List<String> enumerationParameters = new ArrayList<String>();
-    private List<String> selectedEnumerationParameters = new ArrayList<String>();
+    private List<String> selectedEnumerationParameters = new ArrayList<>();
 
     private XmlObjectTreeModel model;
 
@@ -132,7 +132,7 @@ public class EnumerationValuesExtractor {
 
     class EnumerationValues {
         private String type;
-        private List<String> valuesList = new ArrayList<String>();
+        private List<String> valuesList = new ArrayList<>();
 
         public EnumerationValues(String type) {
             this.type = type;

--- a/soapui/src/main/java/com/eviware/soapui/security/boundary/EnumerationValuesExtractor.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/boundary/EnumerationValuesExtractor.java
@@ -55,7 +55,7 @@ public class EnumerationValuesExtractor {
         // extractEnumerationParameters( model.getRootNode() );
     }
 
-    public String extract() throws XmlException, Exception {
+    public String extract() throws Exception {
 
         getNextChild(model.getRootNode());
 

--- a/soapui/src/main/java/com/eviware/soapui/security/boundary/SchemeTypeExtractor.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/boundary/SchemeTypeExtractor.java
@@ -57,7 +57,7 @@ public class SchemeTypeExtractor {
         return nodes;
     }
 
-    public TreeMap<String, NodeInfo> extract() throws XmlException, Exception {
+    public TreeMap<String, NodeInfo> extract() throws Exception {
         // XmlObjectTreeModel model = new XmlObjectTreeModel(
         // request.getOperation().getInterface().getDefinitionContext()
         // .getSchemaTypeSystem(), XmlObject.Factory.parse(

--- a/soapui/src/main/java/com/eviware/soapui/security/boundary/SchemeTypeExtractor.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/boundary/SchemeTypeExtractor.java
@@ -94,7 +94,7 @@ public class SchemeTypeExtractor {
      * actualy carry values.
      */
     TreeMap<String, NodeInfo> getElements(XmlTreeNode rootXmlTreeNode) {
-        TreeMap<String, NodeInfo> result = new TreeMap<String, NodeInfo>();
+        TreeMap<String, NodeInfo> result = new TreeMap<>();
         for (int cnt = 0; cnt < rootXmlTreeNode.getChildCount(); cnt++) {
             XmlTreeNode xmlTreeNodeChild = (XmlTreeNode) rootXmlTreeNode.getChild(cnt);
 

--- a/soapui/src/main/java/com/eviware/soapui/security/boundary/enumeration/EnumerationValues.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/boundary/enumeration/EnumerationValues.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 public class EnumerationValues {
     private String type;
-    private List<String> valuesList = new ArrayList<String>();
+    private List<String> valuesList = new ArrayList<>();
 
     public EnumerationValues(String type) {
         this.type = type;

--- a/soapui/src/main/java/com/eviware/soapui/security/log/FunctionalTestLogModel.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/log/FunctionalTestLogModel.java
@@ -69,7 +69,7 @@ public class FunctionalTestLogModel extends AbstractListModel {
     public synchronized void addSecurityTestFunctionalStepResult(TestStepResult result) {
         stepCount++;
         int size = items.size();
-        SoftReference<TestStepResult> stepResultRef = new SoftReference<TestStepResult>(result);
+        SoftReference<TestStepResult> stepResultRef = new SoftReference<>(result);
 
         items.add("Step " + stepCount + " [" + result.getTestStep().getName() + "] " + result.getStatus() + ": took "
                 + result.getTimeTaken() + " ms");

--- a/soapui/src/main/java/com/eviware/soapui/security/log/JFunctionalTestRunLog.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/log/JFunctionalTestRunLog.java
@@ -60,7 +60,7 @@ import java.util.Set;
 public class JFunctionalTestRunLog extends JPanel {
     private FunctionalTestLogModel logListModel;
     private JList testLogList;
-    private Set<String> boldTexts = new HashSet<String>();
+    private Set<String> boldTexts = new HashSet<>();
     protected int selectedIndex;
     private Logger log = LogManager.getLogger(JSecurityTestRunLog.class);
     // TODO see how to get this from security log options to apply here

--- a/soapui/src/main/java/com/eviware/soapui/security/log/JSecurityTestRunLog.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/log/JSecurityTestRunLog.java
@@ -73,7 +73,7 @@ public class JSecurityTestRunLog extends JPanel {
     private JList testLogList;
     private boolean errorsOnly = false;
     private final Settings settings;
-    private Set<String> boldTexts = new HashSet<String>();
+    private Set<String> boldTexts = new HashSet<>();
     private boolean follow = true;
     protected int selectedIndex;
     private XFormDialog optionsDialog;

--- a/soapui/src/main/java/com/eviware/soapui/security/log/SecurityTestLogModel.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/log/SecurityTestLogModel.java
@@ -91,7 +91,7 @@ public class SecurityTestLogModel extends AbstractListModel {
         int size = items.size();
         if (AbstractSecurityScan.isSecurable(testStep)) {
             SecurityTestStepResult result = new SecurityTestStepResult(testStep, null);
-            SoftReference<SecurityResult> stepResultRef = new SoftReference<SecurityResult>(result);
+            SoftReference<SecurityResult> stepResultRef = new SoftReference<>(result);
             items.add("Step " + stepCount + " [" + result.getTestStep().getName() + "] ");
             results.add(stepResultRef);
 
@@ -135,7 +135,7 @@ public class SecurityTestLogModel extends AbstractListModel {
                     String statusToDisplay = getStatusToDisplay(result.getExecutionProgressStatus());
                     items.set(startStepIndex, "Step " + stepCount + " [" + result.getTestStep().getName() + "] "
                             + statusToDisplay + ": took " + result.getTimeTaken() + " ms");
-                    SoftReference<SecurityResult> stepResultRef = new SoftReference<SecurityResult>(result);
+                    SoftReference<SecurityResult> stepResultRef = new SoftReference<>(result);
                     results.set(startStepIndex, stepResultRef);
                     fireContentsChanged(this, startStepIndex, startStepIndex);
                 }
@@ -175,7 +175,7 @@ public class SecurityTestLogModel extends AbstractListModel {
         requestCount = 0;
 
         SecurityScanResult securityCheckResult = securityCheck.getSecurityScanResult();
-        SoftReference<SecurityResult> checkResultRef = new SoftReference<SecurityResult>(securityCheckResult);
+        SoftReference<SecurityResult> checkResultRef = new SoftReference<>(securityCheckResult);
 
         items.add("SecurityScan " + checkCount + " [" + securityCheck.getName() + "] ");
         results.add(checkResultRef);
@@ -222,7 +222,7 @@ public class SecurityTestLogModel extends AbstractListModel {
             try {
                 if (startCheckIndex > 0 && startCheckIndex < maxSize) {
                     items.set(startCheckIndex, outStr.toString());
-                    SoftReference<SecurityResult> checkResultRef = new SoftReference<SecurityResult>(securityCheckResult);
+                    SoftReference<SecurityResult> checkResultRef = new SoftReference<>(securityCheckResult);
                     results.set(startCheckIndex, checkResultRef);
                     currentCheckEntriesCount = 0;
                     fireContentsChanged(this, startCheckIndex, startCheckIndex);
@@ -239,7 +239,7 @@ public class SecurityTestLogModel extends AbstractListModel {
         int size = items.size();
         requestCount++;
 
-        SoftReference<SecurityResult> checkReqResultRef = new SoftReference<SecurityResult>(securityCheckRequestResult);
+        SoftReference<SecurityResult> checkReqResultRef = new SoftReference<>(securityCheckRequestResult);
 
         items.add(securityCheckRequestResult.getChangedParamsInfo(requestCount));
         results.add(checkReqResultRef);

--- a/soapui/src/main/java/com/eviware/soapui/security/panels/ProjectSensitiveInformationPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/panels/ProjectSensitiveInformationPanel.java
@@ -103,7 +103,7 @@ public class ProjectSensitiveInformationPanel {
     }
 
     private List<String> createListFromTable() {
-        List<String> temp = new ArrayList<String>();
+        List<String> temp = new ArrayList<>();
         for (TestProperty tp : sensitiveInformationTableModel.getHolder().getPropertyList()) {
             String tokenPlusDescription = tp.getName() + "###" + tp.getValue();
             temp.add(tokenPlusDescription);

--- a/soapui/src/main/java/com/eviware/soapui/security/panels/SecurityTestPanelBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/panels/SecurityTestPanelBuilder.java
@@ -42,7 +42,7 @@ public class SecurityTestPanelBuilder<T extends SecurityTest> extends EmptyPanel
     }
 
     public Component buildOverviewPanel(T modelItem) {
-        JPropertiesTable<SecurityTest> table = new JPropertiesTable<SecurityTest>("SecurityTest Properties", modelItem);
+        JPropertiesTable<SecurityTest> table = new JPropertiesTable<>("SecurityTest Properties", modelItem);
 
         table.addProperty("Name", "name", true);
 

--- a/soapui/src/main/java/com/eviware/soapui/security/panels/SecurityTreeCellRender.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/panels/SecurityTreeCellRender.java
@@ -49,7 +49,7 @@ import java.util.Map;
 @SuppressWarnings("serial")
 public class SecurityTreeCellRender implements TreeCellRenderer {
 
-    Map<DefaultMutableTreeNode, Component> componentTree = new HashMap<DefaultMutableTreeNode, Component>();
+    Map<DefaultMutableTreeNode, Component> componentTree = new HashMap<>();
     private JTree tree;
     Color selected = new Color(205, 205, 205);
     Color unselected = new Color(228, 228, 228);

--- a/soapui/src/main/java/com/eviware/soapui/security/registry/SecurityScanRegistry.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/registry/SecurityScanRegistry.java
@@ -36,7 +36,7 @@ import java.util.Map;
 
 public class SecurityScanRegistry {
     protected static SecurityScanRegistry instance;
-    private Map<String, SecurityScanFactory> availableSecurityChecks = new HashMap<String, SecurityScanFactory>();
+    private Map<String, SecurityScanFactory> availableSecurityChecks = new HashMap<>();
     private StringToStringMap securityCheckNames = new StringToStringMap();
 
     public SecurityScanRegistry() {
@@ -146,7 +146,7 @@ public class SecurityScanRegistry {
      * @return A String Array containing the names of all the scans
      */
     public String[] getAvailableSecurityScansNames() {
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
 
         for (SecurityScanFactory securityCheck : availableSecurityChecks.values()) {
             result.add(securityCheck.getSecurityScanName());
@@ -160,7 +160,7 @@ public class SecurityScanRegistry {
 
     // TODO drso: test and implement properly
     public String[] getAvailableSecurityScansNames(TestStep testStep) {
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
 
         for (SecurityScanFactory securityCheck : availableSecurityChecks.values()) {
             if (securityCheck.canCreate(testStep)) {

--- a/soapui/src/main/java/com/eviware/soapui/security/result/SecurityScanRequestResult.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/result/SecurityScanRequestResult.java
@@ -41,7 +41,7 @@ public class SecurityScanRequestResult implements SecurityResult {
     public final static String TYPE = "SecurityScanRequestResult";
     private ResultStatus status = ResultStatus.UNKNOWN;
     private SecurityScan securityCheck;
-    private List<String> messages = new ArrayList<String>();
+    private List<String> messages = new ArrayList<>();
     private long timeTaken;
     private long startTime;
     private long timeStamp;

--- a/soapui/src/main/java/com/eviware/soapui/security/result/SecurityScanResult.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/result/SecurityScanResult.java
@@ -68,7 +68,7 @@ public class SecurityScanResult implements SecurityResult {
         status = ResultStatus.INITIALIZED;
         executionProgressStatus = ResultStatus.INITIALIZED;
         logIconStatus = ResultStatus.UNKNOWN;
-        securityRequestResultList = new ArrayList<SecurityScanRequestResult>();
+        securityRequestResultList = new ArrayList<>();
         timeStamp = System.currentTimeMillis();
         requestCount = 0;
     }

--- a/soapui/src/main/java/com/eviware/soapui/security/result/SecurityTestStepResult.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/result/SecurityTestStepResult.java
@@ -58,7 +58,7 @@ public class SecurityTestStepResult implements SecurityResult {
     public SecurityTestStepResult(TestStep testStep, TestStepResult originalResult) {
         this.testStep = testStep;
         executionProgressStatus = ResultStatus.INITIALIZED;
-        securityScanResultList = new ArrayList<SecurityScanResult>();
+        securityScanResultList = new ArrayList<>();
         timeStamp = System.currentTimeMillis();
         this.originalTestStepResult = originalResult;
     }

--- a/soapui/src/main/java/com/eviware/soapui/security/scan/AbstractSecurityScan.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/scan/AbstractSecurityScan.java
@@ -524,7 +524,7 @@ public abstract class AbstractSecurityScan extends AbstractWsdlModelItem<Securit
 
     @Override
     public List<TestAssertion> getAssertionList() {
-        return new ArrayList<TestAssertion>(assertionsSupport.getAssertionList());
+        return new ArrayList<>(assertionsSupport.getAssertionList());
     }
 
     @Override

--- a/soapui/src/main/java/com/eviware/soapui/security/scan/AbstractSecurityScanWithProperties.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/scan/AbstractSecurityScanWithProperties.java
@@ -71,7 +71,7 @@ public abstract class AbstractSecurityScanWithProperties extends AbstractSecurit
     }
 
     public XPathReference[] getXPathReferences() {
-        List<XPathReference> result = new ArrayList<XPathReference>();
+        List<XPathReference> result = new ArrayList<>();
 
         for (SecurityCheckedParameter param : getParameterHolder().getParameterList()) {
             TestStep t = getTestStep();

--- a/soapui/src/main/java/com/eviware/soapui/security/scan/BoundarySecurityScan.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/scan/BoundarySecurityScan.java
@@ -90,7 +90,7 @@ public class BoundarySecurityScan extends AbstractSecurityScanWithProperties {
         return requestMutationsStack.empty() ? null : requestMutationsStack.pop();
     }
 
-    private void extractMutations(TestStep testStep, SecurityTestRunContext context) throws XmlException, Exception {
+    private void extractMutations(TestStep testStep, SecurityTestRunContext context) throws Exception {
         strategy = getExecutionStrategy().getStrategy();
 
         XmlObjectTreeModel model = null;// getXmlObjectTreeModel( testStep );
@@ -168,7 +168,7 @@ public class BoundarySecurityScan extends AbstractSecurityScanWithProperties {
 
     public String extractRestrictions(XmlObjectTreeModel model2, SecurityTestRunContext context,
                                       XmlTreeNode nodeToUpdate, XmlObjectTreeModel model, SecurityCheckedParameter scp, StringToStringMap stsmap)
-            throws XmlException, Exception {
+            throws Exception {
         getNextChild(model2.getRootNode(), context, nodeToUpdate, model, scp, stsmap);
 
         return nodeToUpdate.getXmlObject().toString();

--- a/soapui/src/main/java/com/eviware/soapui/security/scan/BoundarySecurityScan.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/scan/BoundarySecurityScan.java
@@ -234,7 +234,7 @@ public class BoundarySecurityScan extends AbstractSecurityScanWithProperties {
     @SuppressWarnings("unchecked")
     protected boolean hasNext(TestStep testStep, SecurityTestRunContext context) {
         if (!context.hasProperty(REQUEST_MUTATIONS_STACK)) {
-            Stack<PropertyMutation> requestMutationsList = new Stack<PropertyMutation>();
+            Stack<PropertyMutation> requestMutationsList = new Stack<>();
             context.put(REQUEST_MUTATIONS_STACK, requestMutationsList);
             try {
                 extractMutations(testStep, context);

--- a/soapui/src/main/java/com/eviware/soapui/security/scan/CrossSiteScriptingScan.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/scan/CrossSiteScriptingScan.java
@@ -76,7 +76,7 @@ public class CrossSiteScriptingScan extends AbstractSecurityScanWithProperties {
     private CrossSiteScriptingScanConfig cssConfig;
     StrategyTypeConfig.Enum strategy = StrategyTypeConfig.ONE_BY_ONE;
 
-    List<String> defaultParameterExposureStrings = new ArrayList<String>();
+    List<String> defaultParameterExposureStrings = new ArrayList<>();
     private JFormDialog dialog;
 
     public CrossSiteScriptingScan(TestStep testStep, SecurityScanConfig config, ModelItem parent, String icon) {
@@ -179,7 +179,7 @@ public class CrossSiteScriptingScan extends AbstractSecurityScanWithProperties {
     @Override
     protected boolean hasNext(TestStep testStep, SecurityTestRunContext context) {
         if (!context.hasProperty(PropertyMutation.REQUEST_MUTATIONS_STACK)) {
-            Stack<PropertyMutation> requestMutationsList = new Stack<PropertyMutation>();
+            Stack<PropertyMutation> requestMutationsList = new Stack<>();
             context.put(PropertyMutation.REQUEST_MUTATIONS_STACK, requestMutationsList);
             context.put(PARAMETER_EXPOSURE_SCAN_CONFIG, cssConfig);
             try {

--- a/soapui/src/main/java/com/eviware/soapui/security/scan/InvalidTypesSecurityScan.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/scan/InvalidTypesSecurityScan.java
@@ -150,7 +150,7 @@ public class InvalidTypesSecurityScan extends AbstractSecurityScanWithProperties
      * Set new value for request
      */
     private StringToStringMap updateRequestContent(TestStep testStep, SecurityTestRunContext context)
-            throws XmlException, Exception {
+            throws Exception {
 
         StringToStringMap params = new StringToStringMap();
 
@@ -257,7 +257,7 @@ public class InvalidTypesSecurityScan extends AbstractSecurityScanWithProperties
      * @throws XmlException
      * @throws XmlException
      */
-    private void mutateParameters(TestStep testStep, SecurityTestRunContext context) throws XmlException, Exception {
+    private void mutateParameters(TestStep testStep, SecurityTestRunContext context) throws Exception {
 
         mutation = true;
         // for each parameter

--- a/soapui/src/main/java/com/eviware/soapui/security/scan/InvalidTypesSecurityScan.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/scan/InvalidTypesSecurityScan.java
@@ -58,7 +58,7 @@ public class InvalidTypesSecurityScan extends AbstractSecurityScanWithProperties
     private TypeLabel typeLabel = new TypeLabel();
     private InvalidSecurityScanConfig invalidTypeConfig;
 
-    private Map<SecurityCheckedParameter, ArrayList<String>> parameterMutations = new HashMap<SecurityCheckedParameter, ArrayList<String>>();
+    private Map<SecurityCheckedParameter, ArrayList<String>> parameterMutations = new HashMap<>();
 
     private boolean mutation;
 
@@ -347,7 +347,7 @@ public class InvalidTypesSecurityScan extends AbstractSecurityScanWithProperties
      */
     private class InvalidTypesForSOAP {
 
-        private HashMap<Integer, String> typeMap = new HashMap<Integer, String>();
+        private HashMap<Integer, String> typeMap = new HashMap<>();
 
         public InvalidTypesForSOAP() {
             generateInvalidTypes();

--- a/soapui/src/main/java/com/eviware/soapui/security/scan/MalformedXmlSecurityScan.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/scan/MalformedXmlSecurityScan.java
@@ -49,7 +49,7 @@ public class MalformedXmlSecurityScan extends AbstractSecurityScanWithProperties
 
     public static final String TYPE = "MalformedXmlSecurityScan";
     public static final String NAME = "Malformed XML";
-    private Map<SecurityCheckedParameter, ArrayList<String>> parameterMutations = new HashMap<SecurityCheckedParameter, ArrayList<String>>();
+    private Map<SecurityCheckedParameter, ArrayList<String>> parameterMutations = new HashMap<>();
     private boolean mutation;
     private MalformedXmlConfig malformedXmlConfig;
     private MalformedXmlAttributeConfig malformedAttributeConfig;
@@ -289,7 +289,7 @@ public class MalformedXmlSecurityScan extends AbstractSecurityScanWithProperties
 
     protected Collection<? extends String> mutateNode(XmlTreeNode node, String xml) throws IOException {
 
-        ArrayList<String> result = new ArrayList<String>();
+        ArrayList<String> result = new ArrayList<>();
         String nodeXml = getXmlForNode(node);
         // insert new element
         if (malformedXmlConfig.getInsertNewElement()) {

--- a/soapui/src/main/java/com/eviware/soapui/security/scan/MalformedXmlSecurityScan.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/scan/MalformedXmlSecurityScan.java
@@ -105,8 +105,8 @@ public class MalformedXmlSecurityScan extends AbstractSecurityScanWithProperties
         }
     }
 
-    protected StringToStringMap update(TestStep testStep, SecurityTestRunContext context) throws XmlException,
-            Exception {
+    protected StringToStringMap update(TestStep testStep, SecurityTestRunContext context) throws 
+           Exception {
         StringToStringMap params = new StringToStringMap();
 
         if (parameterMutations.size() == 0) {

--- a/soapui/src/main/java/com/eviware/soapui/security/scan/MaliciousAttachmentSecurityScan.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/scan/MaliciousAttachmentSecurityScan.java
@@ -244,7 +244,7 @@ public class MaliciousAttachmentSecurityScan extends AbstractSecurityScan implem
     }
 
     private void removeAttachments(TestStep testStep, String key, boolean equals) {
-        List<Attachment> toRemove = new ArrayList<Attachment>();
+        List<Attachment> toRemove = new ArrayList<>();
         AbstractHttpRequest<?> request = (AbstractHttpRequest<?>) getRequest(testStep);
 
         for (Attachment attachment : request.getAttachments()) {

--- a/soapui/src/main/java/com/eviware/soapui/security/scan/SQLInjectionScan.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/scan/SQLInjectionScan.java
@@ -127,7 +127,7 @@ public class SQLInjectionScan extends AbstractSecurityScanWithProperties {
         }
     }
 
-    private StringToStringMap update(TestStep testStep, SecurityTestRunContext context) throws XmlException, Exception {
+    private StringToStringMap update(TestStep testStep, SecurityTestRunContext context) throws Exception {
         StringToStringMap params = new StringToStringMap();
 
         if (parameterMutations.size() == 0) {
@@ -221,7 +221,7 @@ public class SQLInjectionScan extends AbstractSecurityScanWithProperties {
         return params;
     }
 
-    private void mutateParameters(TestStep testStep, SecurityTestRunContext context) throws XmlException, Exception {
+    private void mutateParameters(TestStep testStep, SecurityTestRunContext context) throws Exception {
         mutation = true;
         // for each parameter
         for (SecurityCheckedParameter parameter : getParameterHolder().getParameterList()) {

--- a/soapui/src/main/java/com/eviware/soapui/security/scan/SQLInjectionScan.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/scan/SQLInjectionScan.java
@@ -65,7 +65,7 @@ public class SQLInjectionScan extends AbstractSecurityScanWithProperties {
 
     private SQLInjectionScanConfig sqlInjectionConfig;
 
-    private Map<SecurityCheckedParameter, ArrayList<String>> parameterMutations = new HashMap<SecurityCheckedParameter, ArrayList<String>>();
+    private Map<SecurityCheckedParameter, ArrayList<String>> parameterMutations = new HashMap<>();
 
     String[] defaultSqlInjectionStrings = {"' or '1'='1", "'--", "1'", "admin'--", "/*!10000%201/0%20*/",
             "/*!10000 1/0 */", "1/0", "'%20o/**/r%201/0%20--", "' o/**/r 1/0 --", ";", "'%20and%201=2%20--",

--- a/soapui/src/main/java/com/eviware/soapui/security/scan/XPathInjectionSecurityScan.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/scan/XPathInjectionSecurityScan.java
@@ -58,7 +58,7 @@ public class XPathInjectionSecurityScan extends AbstractSecurityScanWithProperti
 
     private XPathInjectionConfig xpathList;
 
-    private Map<SecurityCheckedParameter, ArrayList<String>> parameterMutations = new HashMap<SecurityCheckedParameter, ArrayList<String>>();
+    private Map<SecurityCheckedParameter, ArrayList<String>> parameterMutations = new HashMap<>();
 
     String[] defaultXPathInjectionStrings = {" or name(//users/LoginID[1]) = 'LoginID' or 'a'='b", "' or '1'='1",
             "1/0", "'%20o/**/r%201/0%20--", "' o/**/r 1/0 --", ";", "'%20and%201=2%20--", "' and 1=2 --",

--- a/soapui/src/main/java/com/eviware/soapui/security/scan/XPathInjectionSecurityScan.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/scan/XPathInjectionSecurityScan.java
@@ -115,7 +115,7 @@ public class XPathInjectionSecurityScan extends AbstractSecurityScanWithProperti
         }
     }
 
-    private StringToStringMap update(TestStep testStep, SecurityTestRunContext context) throws XmlException, Exception {
+    private StringToStringMap update(TestStep testStep, SecurityTestRunContext context) throws Exception {
         StringToStringMap params = new StringToStringMap();
 
         if (parameterMutations.size() == 0) {
@@ -212,7 +212,7 @@ public class XPathInjectionSecurityScan extends AbstractSecurityScanWithProperti
         return params;
     }
 
-    private void mutateParameters(TestStep testStep, SecurityTestRunContext context) throws XmlException, Exception {
+    private void mutateParameters(TestStep testStep, SecurityTestRunContext context) throws Exception {
         mutation = true;
         // for each parameter
         for (SecurityCheckedParameter parameter : getParameterHolder().getParameterList()) {

--- a/soapui/src/main/java/com/eviware/soapui/security/scan/XmlBombSecurityScan.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/scan/XmlBombSecurityScan.java
@@ -54,7 +54,7 @@ public class XmlBombSecurityScan extends AbstractSecurityScanWithProperties {
 
     private int currentIndex = 0;
     private XmlBombSecurityScanConfig xmlBombConfig;
-    private Map<SecurityCheckedParameter, ArrayList<String>> parameterMutations = new HashMap<SecurityCheckedParameter, ArrayList<String>>();
+    private Map<SecurityCheckedParameter, ArrayList<String>> parameterMutations = new HashMap<>();
     private boolean mutation;
 
     public XmlBombSecurityScan(TestStep testStep, SecurityScanConfig config, ModelItem parent, String icon) {

--- a/soapui/src/main/java/com/eviware/soapui/security/scan/XmlBombSecurityScan.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/scan/XmlBombSecurityScan.java
@@ -148,7 +148,7 @@ public class XmlBombSecurityScan extends AbstractSecurityScanWithProperties {
         }
     }
 
-    private StringToStringMap update(TestStep testStep, SecurityTestRunContext context) throws XmlException, Exception {
+    private StringToStringMap update(TestStep testStep, SecurityTestRunContext context) throws Exception {
         StringToStringMap params = new StringToStringMap();
 
         if (parameterMutations.size() == 0) {
@@ -171,7 +171,7 @@ public class XmlBombSecurityScan extends AbstractSecurityScanWithProperties {
         return params;
     }
 
-    private void mutateParameters(TestStep testStep, SecurityTestRunContext context) throws XmlException, Exception {
+    private void mutateParameters(TestStep testStep, SecurityTestRunContext context) throws Exception {
         mutation = true;
 
         // for each parameter

--- a/soapui/src/main/java/com/eviware/soapui/security/support/MaliciousAttachmentListToTableHolder.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/support/MaliciousAttachmentListToTableHolder.java
@@ -33,9 +33,9 @@ public class MaliciousAttachmentListToTableHolder {
     MaliciousAttachmentTableModel replaceTableModel;
     JFormDialog tablesDialog;
 
-    Map<String, List<MaliciousAttachmentConfig>> generateMap = new HashMap<String, List<MaliciousAttachmentConfig>>();
-    Map<String, List<MaliciousAttachmentConfig>> replaceMap = new HashMap<String, List<MaliciousAttachmentConfig>>();
-    Map<String, Boolean> removeMap = new HashMap<String, Boolean>();
+    Map<String, List<MaliciousAttachmentConfig>> generateMap = new HashMap<>();
+    Map<String, List<MaliciousAttachmentConfig>> replaceMap = new HashMap<>();
+    Map<String, Boolean> removeMap = new HashMap<>();
 
     public JFormDialog getTablesDialog() {
         return tablesDialog;
@@ -100,8 +100,8 @@ public class MaliciousAttachmentListToTableHolder {
     }
 
     private void save(AttachmentElement item) {
-        List<MaliciousAttachmentConfig> generateList = new ArrayList<MaliciousAttachmentConfig>();
-        List<MaliciousAttachmentConfig> replaceList = new ArrayList<MaliciousAttachmentConfig>();
+        List<MaliciousAttachmentConfig> generateList = new ArrayList<>();
+        List<MaliciousAttachmentConfig> replaceList = new ArrayList<>();
 
         for (int i = 0; i < generateTableModel.getRowCount(); i++) {
             generateList.add(generateTableModel.getRowValue(i));

--- a/soapui/src/main/java/com/eviware/soapui/security/support/SecurityCheckedParameterHolder.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/support/SecurityCheckedParameterHolder.java
@@ -42,10 +42,10 @@ public class SecurityCheckedParameterHolder extends SecurityScanParameterListene
     private SecurityScan securityCheck;
     private CheckedParametersListConfig paramsConfig;
 
-    private List<SecurityCheckedParameter> params = new ArrayList<SecurityCheckedParameter>();
-    private Map<String, SecurityCheckedParameter> paramsMap = new HashMap<String, SecurityCheckedParameter>();
+    private List<SecurityCheckedParameter> params = new ArrayList<>();
+    private Map<String, SecurityCheckedParameter> paramsMap = new HashMap<>();
 
-    private Set<SecurityScanParameterHolderListener> listeners = new HashSet<SecurityScanParameterHolderListener>();
+    private Set<SecurityScanParameterHolderListener> listeners = new HashSet<>();
 
     public SecurityCheckedParameterHolder(SecurityScan securityCheck, CheckedParametersListConfig checkedPameters) {
         this.securityCheck = securityCheck;
@@ -182,7 +182,7 @@ public class SecurityCheckedParameterHolder extends SecurityScanParameterListene
      * @return parameter
      */
     public List<SecurityCheckedParameter> getParametarsByName(String paramName) {
-        List<SecurityCheckedParameter> paramsList = new ArrayList<SecurityCheckedParameter>();
+        List<SecurityCheckedParameter> paramsList = new ArrayList<>();
         for (SecurityCheckedParameter param : params) {
             if (param.getName().equals(paramName)) {
                 paramsList.add(param);
@@ -192,7 +192,7 @@ public class SecurityCheckedParameterHolder extends SecurityScanParameterListene
     }
 
     public void removeParameters(int[] selected) {
-        ArrayList<SecurityCheckedParameter> paramsToRemove = new ArrayList<SecurityCheckedParameter>();
+        ArrayList<SecurityCheckedParameter> paramsToRemove = new ArrayList<>();
         for (int index : selected) {
             paramsToRemove.add(params.get(index));
         }
@@ -216,7 +216,7 @@ public class SecurityCheckedParameterHolder extends SecurityScanParameterListene
 
     @Override
     public void propertyRemoved(String name) {
-        ArrayList<SecurityCheckedParameter> parameterToRemove = new ArrayList<SecurityCheckedParameter>();
+        ArrayList<SecurityCheckedParameter> parameterToRemove = new ArrayList<>();
         for (SecurityCheckedParameter param : params) {
             if (param.getName().equals(name)) {
                 parameterToRemove.add(param);
@@ -229,7 +229,7 @@ public class SecurityCheckedParameterHolder extends SecurityScanParameterListene
 
     @Override
     public void propertyRenamed(String oldName, String newName) {
-        ArrayList<SecurityCheckedParameter> parameterToRemove = new ArrayList<SecurityCheckedParameter>();
+        ArrayList<SecurityCheckedParameter> parameterToRemove = new ArrayList<>();
         for (SecurityCheckedParameter param : params) {
             if (param.getName().equals(oldName)) {
                 parameterToRemove.add(param);

--- a/soapui/src/main/java/com/eviware/soapui/security/tools/AttachmentHolder.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/tools/AttachmentHolder.java
@@ -27,7 +27,7 @@ public class AttachmentHolder {
 
     public void addElement(MaliciousAttachmentConfig config) {
         if (list == null) {
-            list = new ArrayList<MaliciousAttachmentConfig>();
+            list = new ArrayList<>();
         }
 
         list.add(config);

--- a/soapui/src/main/java/com/eviware/soapui/security/ui/InvalidTypesTable.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/ui/InvalidTypesTable.java
@@ -107,7 +107,7 @@ public class InvalidTypesTable extends JPanel {
 
         add(toolbar, BorderLayout.NORTH);
         table = JTableFactory.getInstance().makeJXTable(model);
-        TableRowSorter<InvalidTypeTableModel> sorter = new TableRowSorter<InvalidTypeTableModel>(model);
+        TableRowSorter<InvalidTypeTableModel> sorter = new TableRowSorter<>(model);
         table.setRowSorter(sorter);
         table.toggleSortOrder(0);
         add(new JScrollPane(table), BorderLayout.CENTER);

--- a/soapui/src/main/java/com/eviware/soapui/security/ui/SecurityCheckedParametersTablePanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/security/ui/SecurityCheckedParametersTablePanel.java
@@ -85,7 +85,7 @@ public class SecurityCheckedParametersTablePanel extends JPanel implements ListS
     }
 
     private void initRequestPartProperties(Map<String, TestProperty> properties) {
-        this.properties = new HashMap<String, TestProperty>();
+        this.properties = new HashMap<>();
         for (Map.Entry<String, TestProperty> entry : properties.entrySet()) {
             if (properties.get(entry.getKey()).isRequestPart()) {
                 this.properties.put(entry.getKey(), entry.getValue());
@@ -195,7 +195,7 @@ public class SecurityCheckedParametersTablePanel extends JPanel implements ListS
 
             }
         });
-        ArrayList<String> options = new ArrayList<String>();
+        ArrayList<String> options = new ArrayList<>();
         options.add(CHOOSE_TEST_PROPERTY);
         options.addAll(properties.keySet());
         nameField.setOptions(options.toArray(new String[0]));

--- a/soapui/src/main/java/com/eviware/soapui/support/AbstractEditorModel.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/AbstractEditorModel.java
@@ -20,7 +20,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 public abstract class AbstractEditorModel implements EditorModel {
-    private Set<EditorModelListener> listeners = new HashSet<EditorModelListener>();
+    private Set<EditorModelListener> listeners = new HashSet<>();
 
     public void addEditorModelListener(EditorModelListener editorModelListener) {
         listeners.add(editorModelListener);

--- a/soapui/src/main/java/com/eviware/soapui/support/ClassUtils.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/ClassUtils.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 public class ClassUtils {
     public static List<Class<?>> getImplementedAndExtendedClasses(Object obj) {
-        ArrayList<Class<?>> result = new ArrayList<Class<?>>();
+        ArrayList<Class<?>> result = new ArrayList<>();
         addImplementedInterfacesFromSuperClass(obj.getClass(), result);
         return result;
     }

--- a/soapui/src/main/java/com/eviware/soapui/support/GroovyUtils.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/GroovyUtils.java
@@ -90,7 +90,7 @@ public class GroovyUtils {
         return XmlUtils.createXmlObject(node).xmlText();
     }
 
-    private static final ConcurrentHashMap<String, Boolean> registeredDrivers = new ConcurrentHashMap<String, Boolean>();
+    private static final ConcurrentHashMap<String, Boolean> registeredDrivers = new ConcurrentHashMap<>();
     private static final Object[] mutex = new Object[0];
 
     public static void registerJdbcDriver(String name) {

--- a/soapui/src/main/java/com/eviware/soapui/support/MessageSupport.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/MessageSupport.java
@@ -23,7 +23,7 @@ import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
 public final class MessageSupport {
-    private static final Map<String, ResourceBundle> bundles = new HashMap<String, ResourceBundle>();
+    private static final Map<String, ResourceBundle> bundles = new HashMap<>();
     private final Class<? extends Object> clazz;
 
     public MessageSupport(Class<? extends Object> clazz) {

--- a/soapui/src/main/java/com/eviware/soapui/support/PlainJavaJsonProvider.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/PlainJavaJsonProvider.java
@@ -101,7 +101,7 @@ public class PlainJavaJsonProvider extends AbstractJsonProvider {
 
     private Object convertToPlainJavaImplementation(JSON jsonRoot) {
         if (jsonRoot.isArray()) {
-            List<Object> returnedList = new ArrayList<Object>();
+            List<Object> returnedList = new ArrayList<>();
             JSONArray array = (JSONArray) jsonRoot;
             for (Object originalValue : array) {
                 if (originalValue instanceof JSON) {
@@ -112,7 +112,7 @@ public class PlainJavaJsonProvider extends AbstractJsonProvider {
             }
             return returnedList;
         } else if (jsonRoot instanceof JSONObject) {
-            Map<Object, Object> returnedMap = new HashMap<Object, Object>();
+            Map<Object, Object> returnedMap = new HashMap<>();
             JSONObject jsonObject = (JSONObject) jsonRoot;
             for (Object o : jsonObject.keySet()) {
                 Object value = jsonObject.get(o);

--- a/soapui/src/main/java/com/eviware/soapui/support/PlainJavaJsonProvider.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/PlainJavaJsonProvider.java
@@ -40,16 +40,16 @@ public class PlainJavaJsonProvider extends AbstractJsonProvider {
     private JsonSlurper jsonSlurper = new JsonSlurper();
 
     @Override
-    public Object parse(String json) throws InvalidJsonException {
+    public Object parse(String json) {
         return parse(new StringReader(json));
     }
 
     @Override
-    public Object parse(InputStream inputStream, String s) throws InvalidJsonException {
+    public Object parse(InputStream inputStream, String s) {
         return parse(new InputStreamReader(inputStream, Charset.forName(s)));
     }
 
-    private Object parse(Reader jsonReader) throws InvalidJsonException {
+    private Object parse(Reader jsonReader) {
         try {
             JSON jsonRoot = jsonSlurper.parse(jsonReader);
             Object converted = convertToPlainJavaImplementation(jsonRoot);

--- a/soapui/src/main/java/com/eviware/soapui/support/SecurityScanUtil.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/SecurityScanUtil.java
@@ -141,7 +141,7 @@ public class SecurityScanUtil {
                 .getSensitiveInformation());
         String[] strngArray = reader.readStrings(ProjectSensitiveInformationPanel.PROJECT_SPECIFIC_EXPOSURE_LIST);
         if (strngArray != null) {
-            Map<String, String> map = new HashMap<String, String>();
+            Map<String, String> map = new HashMap<>();
 
             for (String str : strngArray) {
                 String[] tokens = str.split("###");
@@ -153,7 +153,7 @@ public class SecurityScanUtil {
             }
             return map;
         } else {
-            return new HashMap<String, String>();
+            return new HashMap<>();
         }
     }
 
@@ -230,7 +230,7 @@ public class SecurityScanUtil {
      */
     public static List<String> getAllSecurityScanNames(boolean excludeCustomScript) {
         if (excludeCustomScript) {
-            List<String> newList = new ArrayList<String>();
+            List<String> newList = new ArrayList<>();
             for (String name : SoapUI.getSoapUICore().getSecurityScanRegistry().getAvailableSecurityScansNames()) {
                 if (name.equals(GroovySecurityScan.NAME)) {
                     continue;

--- a/soapui/src/main/java/com/eviware/soapui/support/StringUtils.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/StringUtils.java
@@ -64,7 +64,7 @@ public class StringUtils {
 
     public static List<String> splitLines(String string) {
         try {
-            ArrayList<String> list = new ArrayList<String>();
+            ArrayList<String> list = new ArrayList<>();
 
             LineNumberReader reader = new LineNumberReader(new StringReader(string));
             String s;

--- a/soapui/src/main/java/com/eviware/soapui/support/Tools.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/Tools.java
@@ -65,7 +65,7 @@ public class Tools {
         }
 
         List<String> l = Arrays.asList(args.split(" "));
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
 
         for (int c = 0; c < l.size(); c++) {
             String s = l.get(c);

--- a/soapui/src/main/java/com/eviware/soapui/support/UISupport.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/UISupport.java
@@ -110,10 +110,10 @@ public class UISupport {
     public static final int EXTENDED_ERROR_MESSAGE_THRESHOLD = 120;
 
     // This is needed in Eclipse that has strict class loader constraints.
-    private static List<ClassLoader> secondaryResourceLoaders = new ArrayList<ClassLoader>();
+    private static List<ClassLoader> secondaryResourceLoaders = new ArrayList<>();
 
     private static Component frame;
-    private static Map<String, ImageIcon> iconCache = new HashMap<String, ImageIcon>();
+    private static Map<String, ImageIcon> iconCache = new HashMap<>();
     public static Dimension TOOLBAR_BUTTON_DIMENSION;
     private static boolean isWindows = System.getProperty("os.name").contains("Windows");
     private static boolean isMac = System.getProperty("os.name").contains("Mac");

--- a/soapui/src/main/java/com/eviware/soapui/support/action/SoapUIActionRegistry.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/action/SoapUIActionRegistry.java
@@ -45,8 +45,8 @@ import java.util.Map;
 
 @SuppressWarnings("unchecked")
 public class SoapUIActionRegistry {
-    private Map<String, SoapUIAction> actions = new HashMap<String, SoapUIAction>();
-    private Map<String, SoapUIActionGroup> actionGroups = new HashMap<String, SoapUIActionGroup>();
+    private Map<String, SoapUIAction> actions = new HashMap<>();
+    private Map<String, SoapUIActionGroup> actionGroups = new HashMap<>();
 
     public void addAction(String soapuiActionID, SoapUIAction action) {
         actions.put(soapuiActionID, action);

--- a/soapui/src/main/java/com/eviware/soapui/support/action/support/DefaultSoapUIActionGroup.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/action/support/DefaultSoapUIActionGroup.java
@@ -27,7 +27,7 @@ import com.eviware.soapui.support.types.StringList;
  */
 
 public class DefaultSoapUIActionGroup<T extends ModelItem> extends AbstractSoapUIActionGroup<T> {
-    private SoapUIActionMappingList<T> mappings = new SoapUIActionMappingList<T>();
+    private SoapUIActionMappingList<T> mappings = new SoapUIActionMappingList<>();
     private StringList ids = new StringList();
 
     public DefaultSoapUIActionGroup(String id, String name) {

--- a/soapui/src/main/java/com/eviware/soapui/support/action/swing/ActionComponentRegistry.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/action/swing/ActionComponentRegistry.java
@@ -32,7 +32,7 @@ public class ActionComponentRegistry {
         return null;
     }
 
-    private static Map<String, ActionComponentFactory> factories = new HashMap<String, ActionComponentFactory>();
+    private static Map<String, ActionComponentFactory> factories = new HashMap<>();
 
     static {
     }

--- a/soapui/src/main/java/com/eviware/soapui/support/action/swing/ActionListBuilder.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/action/swing/ActionListBuilder.java
@@ -112,7 +112,7 @@ public class ActionListBuilder {
                 actionListAction.setEnabled(mapping.isEnabled());
                 prevWasSeparator = false;
             } else if (action != null) {
-                SwingActionDelegate<T> actionDelegate = new SwingActionDelegate<T>(actionMapping, modelItem);
+                SwingActionDelegate<T> actionDelegate = new SwingActionDelegate<>(actionMapping, modelItem);
                 actions.addAction(actionDelegate);
                 if (mapping.isDefault()) {
                     actions.setDefaultAction(actionDelegate);
@@ -166,7 +166,7 @@ public class ActionListBuilder {
                 actionListAction.setEnabled(mapping.isEnabled());
                 prevWasSeparator = false;
             } else if (action instanceof SoapUIMultiAction) {
-                List<ModelItem> targets = new ArrayList<ModelItem>();
+                List<ModelItem> targets = new ArrayList<>();
                 for (ModelItem target : modelItems) {
                     if (action.applies(target)) {
                         targets.add(target);

--- a/soapui/src/main/java/com/eviware/soapui/support/action/swing/DefaultActionList.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/action/swing/DefaultActionList.java
@@ -32,7 +32,7 @@ import java.util.List;
  */
 
 public class DefaultActionList implements ActionList {
-    private List<Action> actions = new ArrayList<Action>();
+    private List<Action> actions = new ArrayList<>();
     private Action defaultAction;
     private final String label;
 

--- a/soapui/src/main/java/com/eviware/soapui/support/action/swing/JXSoapUIActionListToolBar.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/action/swing/JXSoapUIActionListToolBar.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class JXSoapUIActionListToolBar extends JXToolBar {
-    private Map<String, Action> actionMap = new HashMap<String, Action>();
+    private Map<String, Action> actionMap = new HashMap<>();
 
     @SuppressWarnings("unchecked")
     public JXSoapUIActionListToolBar(ActionList actions, ModelItem modelItem) {

--- a/soapui/src/main/java/com/eviware/soapui/support/action/swing/SwingActionDelegate.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/action/swing/SwingActionDelegate.java
@@ -122,20 +122,20 @@ public class SwingActionDelegate<T extends ModelItem> extends AbstractAction imp
 
     public static <T extends ModelItem> SwingActionDelegate<T> createDelegate(SoapUIAction<T> action, T target,
                                                                               String keyStroke, String iconPath) {
-        return new SwingActionDelegate<T>(new StandaloneActionMapping<T>(action, keyStroke, iconPath), target);
+        return new SwingActionDelegate<>(new StandaloneActionMapping<T>(action, keyStroke, iconPath), target);
     }
 
     public static <T extends ModelItem> SwingActionDelegate<T> createDelegate(SoapUIAction<T> action, T target,
                                                                               String keyStroke) {
-        return new SwingActionDelegate<T>(new StandaloneActionMapping<T>(action, keyStroke), target);
+        return new SwingActionDelegate<>(new StandaloneActionMapping<T>(action, keyStroke), target);
     }
 
     public static <T extends ModelItem> SwingActionDelegate<T> createDelegate(SoapUIAction<T> action, T target) {
-        return new SwingActionDelegate<T>(new StandaloneActionMapping<T>(action), target);
+        return new SwingActionDelegate<>(new StandaloneActionMapping<T>(action), target);
     }
 
     public static <T extends ModelItem> SwingActionDelegate<T> createDelegate(SoapUIAction<T> action) {
-        return new SwingActionDelegate<T>(new StandaloneActionMapping<T>(action), null);
+        return new SwingActionDelegate<>(new StandaloneActionMapping<T>(action), null);
     }
 
     public static SwingActionDelegate<?> createDelegate(String soapUIActionId) {

--- a/soapui/src/main/java/com/eviware/soapui/support/components/EnabledWebViewBasedBrowserComponent.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/components/EnabledWebViewBasedBrowserComponent.java
@@ -363,7 +363,7 @@ class EnabledWebViewBasedBrowserComponent implements WebViewBasedBrowserComponen
 
         private final EnabledWebViewBasedBrowserComponent browser;
 
-        private BrowserWindow(PopupFeatures popupFeatures) throws HeadlessException {
+        private BrowserWindow(PopupFeatures popupFeatures) {
             super("Browser");
             setIconImages(SoapUI.getFrameIcons());
             browser = new EnabledWebViewBasedBrowserComponent(popupFeatures.hasToolbar(), popupStrategy);

--- a/soapui/src/main/java/com/eviware/soapui/support/components/EnabledWebViewBasedBrowserComponent.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/components/EnabledWebViewBasedBrowserComponent.java
@@ -79,12 +79,12 @@ class EnabledWebViewBasedBrowserComponent implements WebViewBasedBrowserComponen
     public String url;
     private PropertyChangeSupport pcs = new PropertyChangeSupport(this);
 
-    private java.util.List<BrowserListener> listeners = new ArrayList<BrowserListener>();
+    private java.util.List<BrowserListener> listeners = new ArrayList<>();
 
     public WebView webView;
     private WebViewNavigationBar navigationBar;
     private String lastLocation;
-    private Set<BrowserWindow> browserWindows = new HashSet<BrowserWindow>();
+    private Set<BrowserWindow> browserWindows = new HashSet<>();
 
     private JFXPanel browserPanel;
     private PopupStrategy popupStrategy;

--- a/soapui/src/main/java/com/eviware/soapui/support/components/JDebugPropertiesTable.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/components/JDebugPropertiesTable.java
@@ -54,7 +54,7 @@ public class JDebugPropertiesTable<T> {
 
     public JDebugPropertiesTable(T propertyObject) {
 
-        tableModel = new PropertiesTableModel<T>(propertyObject);
+        tableModel = new PropertiesTableModel<>(propertyObject);
         table = new PTable(tableModel);
 
         table.getColumnModel().getColumn(0).setHeaderValue("Property");
@@ -96,7 +96,7 @@ public class JDebugPropertiesTable<T> {
     }
 
     public static final class PropertiesTableModel<T> extends AbstractTableModel implements PropertyChangeListener {
-        private List<PropertyDescriptor> properties = new ArrayList<PropertyDescriptor>();
+        private List<PropertyDescriptor> properties = new ArrayList<>();
         private T propertyObject;
         private boolean attached;
 

--- a/soapui/src/main/java/com/eviware/soapui/support/components/JInspectorPanelImpl.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/components/JInspectorPanelImpl.java
@@ -50,8 +50,8 @@ public class JInspectorPanelImpl extends JPanel implements PropertyChangeListene
     private JPanel inspectorPanel;
     private int lastDividerLocation = 0;
     private JXToolBar inspectToolbar;
-    private List<Inspector> inspectors = new ArrayList<Inspector>();
-    private Map<Inspector, JToggleButton> inspectorButtons = new HashMap<Inspector, JToggleButton>();
+    private List<Inspector> inspectors = new ArrayList<>();
+    private Map<Inspector, JToggleButton> inspectorButtons = new HashMap<>();
     public Inspector currentInspector;
 
     private final int orientation;

--- a/soapui/src/main/java/com/eviware/soapui/support/components/JPropertiesTable.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/components/JPropertiesTable.java
@@ -83,7 +83,7 @@ public class JPropertiesTable<T> extends JPanel {
         super(new BorderLayout());
         this.title = title;
         setBackground(Color.WHITE);
-        tableModel = new PropertiesTableModel<T>(propertyObject);
+        tableModel = new PropertiesTableModel<>(propertyObject);
         table = new PTable(tableModel);
         table.setBackground(Color.WHITE);
         table.getColumnModel().getColumn(0).setHeaderValue("Property");
@@ -171,7 +171,7 @@ public class JPropertiesTable<T> extends JPanel {
     }
 
     public static final class PropertiesTableModel<T> extends AbstractTableModel implements PropertyChangeListener {
-        private List<PropertyDescriptor> properties = new ArrayList<PropertyDescriptor>();
+        private List<PropertyDescriptor> properties = new ArrayList<>();
         private T propertyObject;
         private boolean attached;
 

--- a/soapui/src/main/java/com/eviware/soapui/support/components/MetricsPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/components/MetricsPanel.java
@@ -39,8 +39,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class MetricsPanel extends JPanel {
-    private Map<String, Metric> metrics = new HashMap<String, Metric>();
-    private Map<String, MetricsSection> sections = new HashMap<String, MetricsSection>();
+    private Map<String, Metric> metrics = new HashMap<>();
+    private Map<String, MetricsSection> sections = new HashMap<>();
 
     public MetricsPanel() {
         super(new VerticalLayout());

--- a/soapui/src/main/java/com/eviware/soapui/support/components/ModelItemListDesktopPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/components/ModelItemListDesktopPanel.java
@@ -55,7 +55,7 @@ public class ModelItemListDesktopPanel extends DefaultDesktopPanel {
     private JList list;
     private ItemsListModel listModel;
     private InternalTreeModelListener treeModelListener;
-    private Map<ModelItem, StringList> detailInfo = new HashMap<ModelItem, StringList>();
+    private Map<ModelItem, StringList> detailInfo = new HashMap<>();
     private JList detailList;
     private DetailsListModel detailListModel;
 

--- a/soapui/src/main/java/com/eviware/soapui/support/components/ProgressDialog.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/components/ProgressDialog.java
@@ -47,7 +47,7 @@ public class ProgressDialog extends JDialog implements XProgressDialog, XProgres
     private Worker worker;
 
     public ProgressDialog(String title, String label, int length, String initialValue, boolean allowCancel)
-            throws HeadlessException {
+    {
         super(UISupport.getMainFrame(), title, true);
 
         setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);

--- a/soapui/src/main/java/com/eviware/soapui/support/components/SimpleForm.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/components/SimpleForm.java
@@ -82,8 +82,8 @@ public class SimpleForm {
     private FormLayout layout;
     private RowSpec rowSpec;
     private int rowSpacing = 5;
-    private Map<String, JComponent> components = new HashMap<String, JComponent>();
-    private Map<JComboBox, Object[]> comboBoxMaps = new HashMap<JComboBox, Object[]>();
+    private Map<String, JComponent> components = new HashMap<>();
+    private Map<JComboBox, Object[]> comboBoxMaps = new HashMap<>();
     private String rowAlignment = "top";
     private Map<String, String> hiddenValues;
     private boolean appended;
@@ -470,7 +470,7 @@ public class SimpleForm {
 
     public void addHiddenValue(String name, String value) {
         if (hiddenValues == null) {
-            hiddenValues = new HashMap<String, String>();
+            hiddenValues = new HashMap<>();
         }
 
         hiddenValues.put(name, value);

--- a/soapui/src/main/java/com/eviware/soapui/support/components/StringListFormComponent.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/components/StringListFormComponent.java
@@ -46,7 +46,7 @@ public class StringListFormComponent extends JPanel implements JFormComponent, A
     private JList list;
     private JButton editButton;
     private Box buttonBox;
-    private List<JButton> buttons = new ArrayList<JButton>();
+    private List<JButton> buttons = new ArrayList<>();
 
     public StringListFormComponent(String tooltip) {
         this(tooltip, false, null);

--- a/soapui/src/main/java/com/eviware/soapui/support/components/SwingConfigurationDialogImpl.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/components/SwingConfigurationDialogImpl.java
@@ -49,7 +49,7 @@ public class SwingConfigurationDialogImpl implements ConfigurationDialog {
     private SimpleForm form;
     private boolean result;
     private Map<String, String> values;
-    private Map<String, FieldType> fieldTypes = new HashMap<String, FieldType>();
+    private Map<String, FieldType> fieldTypes = new HashMap<>();
     private final String title;
     private Dimension size;
     private JComponent content;

--- a/soapui/src/main/java/com/eviware/soapui/support/components/TestStepPropertyComboBoxModel.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/components/TestStepPropertyComboBoxModel.java
@@ -34,7 +34,7 @@ public class TestStepPropertyComboBoxModel extends AbstractListModel implements 
     public TestStepPropertyComboBoxModel(WsdlTestStep testStep) {
         this.testStep = testStep;
 
-        names = new ArrayList<String>();
+        names = new ArrayList<>();
 
         if (testStep != null) {
             names.addAll(Arrays.asList(testStep.getPropertyNames()));

--- a/soapui/src/main/java/com/eviware/soapui/support/dnd/SoapUIDragAndDropHandler.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/dnd/SoapUIDragAndDropHandler.java
@@ -82,7 +82,7 @@ public class SoapUIDragAndDropHandler implements DragGestureListener, DragSource
     private Point _ptLast = new Point();
 
     static {
-        handlers = new ArrayList<ModelItemDropHandler<ModelItem>>();
+        handlers = new ArrayList<>();
         SoapUIDragAndDropHandler.addDropHandler(new TestStepToTestCaseDropHandler());
         SoapUIDragAndDropHandler.addDropHandler(new TestStepToTestStepsDropHandler());
         SoapUIDragAndDropHandler.addDropHandler(new TestStepToTestStepDropHandler());

--- a/soapui/src/main/java/com/eviware/soapui/support/dnd/handlers/DragAndDropSupport.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/dnd/handlers/DragAndDropSupport.java
@@ -55,7 +55,7 @@ public class DragAndDropSupport {
 
     public static boolean importRequiredInterfaces(Project project, Set<Interface> requiredInterfaces, String title) {
         if (requiredInterfaces.size() > 0 && project.getInterfaceCount() > 0) {
-            Map<String, Interface> bindings = new HashMap<String, Interface>();
+            Map<String, Interface> bindings = new HashMap<>();
             for (Interface iface : requiredInterfaces) {
                 bindings.put(iface.getTechnicalId(), iface);
             }

--- a/soapui/src/main/java/com/eviware/soapui/support/dnd/handlers/TestCaseToProjectDropHandler.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/dnd/handlers/TestCaseToProjectDropHandler.java
@@ -78,7 +78,7 @@ public class TestCaseToProjectDropHandler extends AbstractAfterModelItemDropHand
             testSuite = target.addNewTestSuite(name);
         }
 
-        Set<Interface> requiredInterfaces = new HashSet<Interface>();
+        Set<Interface> requiredInterfaces = new HashSet<>();
 
         for (int i = 0; i < testSuite.getTestCaseCount(); i++) {
             WsdlTestCase testCase = testSuite.getTestCaseAt(i);

--- a/soapui/src/main/java/com/eviware/soapui/support/dnd/handlers/TestCaseToTestSuiteDropHandler.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/dnd/handlers/TestCaseToTestSuiteDropHandler.java
@@ -62,7 +62,7 @@ public class TestCaseToTestSuiteDropHandler extends AbstractAfterModelItemDropHa
         } else if (testCase.getTestSuite().getProject() == target.getProject()) {
             return target.importTestCase(testCase, name, position, true, true, true);
         } else {
-            Set<Interface> requiredInterfaces = new HashSet<Interface>();
+            Set<Interface> requiredInterfaces = new HashSet<>();
 
             // get required interfaces
             for (int y = 0; y < testCase.getTestStepCount(); y++) {
@@ -113,7 +113,7 @@ public class TestCaseToTestSuiteDropHandler extends AbstractAfterModelItemDropHa
             }
         } else if (UISupport.confirm("Move TestCase [" + testCase.getName() + "] to TestSuite [" + target.getName() + "]",
                 "Move TestCase")) {
-            Set<Interface> requiredInterfaces = new HashSet<Interface>();
+            Set<Interface> requiredInterfaces = new HashSet<>();
 
             // get required interfaces
             for (int y = 0; y < testCase.getTestStepCount(); y++) {

--- a/soapui/src/main/java/com/eviware/soapui/support/dnd/handlers/TestSuiteToTestSuiteDropHandler.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/dnd/handlers/TestSuiteToTestSuiteDropHandler.java
@@ -136,7 +136,7 @@ public class TestSuiteToTestSuiteDropHandler extends
             }
         } else if (UISupport.confirm("Move TestSuite [" + testSuite.getName() + "] to Project [" + target.getName() + "]",
                 "Move TestSuite")) {
-            Set<Interface> requiredInterfaces = new HashSet<Interface>();
+            Set<Interface> requiredInterfaces = new HashSet<>();
 
             // get required interfaces
             for (TestCase testCase : testSuite.getTestCaseList()) {
@@ -169,7 +169,7 @@ public class TestSuiteToTestSuiteDropHandler extends
         if (testSuite.getProject() == target) {
             return target.importTestSuite(testSuite, name, position, true, null);
         } else {
-            Set<Interface> requiredInterfaces = new HashSet<Interface>();
+            Set<Interface> requiredInterfaces = new HashSet<>();
 
             // get required interfaces
             for (TestCase testCase : testSuite.getTestCaseList()) {

--- a/soapui/src/main/java/com/eviware/soapui/support/editor/Editor.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/Editor.java
@@ -47,7 +47,7 @@ public class Editor<T extends EditorDocument> extends JPanel implements Property
         EditorLocationListener<T> {
     public final static String OUTLINE_TABLE_PROPERTY = Editor.class.getSimpleName() + "@outlineTable";
     private JTabbedPane inputTabs;
-    private List<EditorView<T>> views = new ArrayList<EditorView<T>>();
+    private List<EditorView<T>> views = new ArrayList<>();
     private EditorView<T> currentView;
     private T document;
     private JInspectorPanel inspectorPanel;

--- a/soapui/src/main/java/com/eviware/soapui/support/editor/inspectors/attachments/AttachmentsInspectorFactory.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/inspectors/attachments/AttachmentsInspectorFactory.java
@@ -114,7 +114,7 @@ public class AttachmentsInspectorFactory implements RequestInspectorFactory, Res
 
             MessagePart[] responseParts = request.getMessageExchange().getOperation().getDefaultRequestParts();
 
-            List<HttpAttachmentPart> result = new ArrayList<HttpAttachmentPart>();
+            List<HttpAttachmentPart> result = new ArrayList<>();
 
             for (MessagePart part : responseParts) {
                 if (part instanceof HttpAttachmentPart) {
@@ -179,7 +179,7 @@ public class AttachmentsInspectorFactory implements RequestInspectorFactory, Res
 
             MessagePart[] responseParts = response.getMessageExchange().getOperation().getDefaultResponseParts();
 
-            List<HttpAttachmentPart> result = new ArrayList<HttpAttachmentPart>();
+            List<HttpAttachmentPart> result = new ArrayList<>();
 
             for (MessagePart part : responseParts) {
                 if (part instanceof HttpAttachmentPart) {
@@ -237,7 +237,7 @@ public class AttachmentsInspectorFactory implements RequestInspectorFactory, Res
         public HttpAttachmentPart[] getDefinedAttachmentParts() {
             MessagePart[] responseParts = request.getResponseParts();
 
-            List<HttpAttachmentPart> result = new ArrayList<HttpAttachmentPart>();
+            List<HttpAttachmentPart> result = new ArrayList<>();
 
             for (MessagePart part : responseParts) {
                 if (part instanceof HttpAttachmentPart) {
@@ -298,7 +298,7 @@ public class AttachmentsInspectorFactory implements RequestInspectorFactory, Res
         public HttpAttachmentPart[] getDefinedAttachmentParts() {
             MessagePart[] responseParts = mockResponse.getRequestParts();
 
-            List<HttpAttachmentPart> result = new ArrayList<HttpAttachmentPart>();
+            List<HttpAttachmentPart> result = new ArrayList<>();
 
             for (MessagePart part : responseParts) {
                 if (part instanceof HttpAttachmentPart) {

--- a/soapui/src/main/java/com/eviware/soapui/support/editor/inspectors/attachments/AttachmentsPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/inspectors/attachments/AttachmentsPanel.java
@@ -269,7 +269,7 @@ public class AttachmentsPanel extends javax.swing.JPanel {
     }
 
     private void exportAttachment(File file, Attachment attachment, boolean showOpenQuery)
-            throws FileNotFoundException, IOException, Exception, MalformedURLException {
+            throws Exception {
         FileOutputStream out = new FileOutputStream(file);
 
         long total = Tools.writeAll(out, attachment.getInputStream());

--- a/soapui/src/main/java/com/eviware/soapui/support/editor/inspectors/attachments/ContentTypeHandler.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/inspectors/attachments/ContentTypeHandler.java
@@ -89,7 +89,7 @@ public class ContentTypeHandler {
         contentTypeToSuffix.put("application/postscript", "ps");
         contentTypeToSuffix.put("application/octet-stream", "dat");
 
-        suffixToContentType = new HashMap<String, String>();
+        suffixToContentType = new HashMap<>();
         suffixToContentType.put("html", "text/html");
         suffixToContentType.put("htm", "text/html");
         suffixToContentType.put("txt", "text/plain");

--- a/soapui/src/main/java/com/eviware/soapui/support/editor/inspectors/auth/OAuth2ScriptsEditor.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/inspectors/auth/OAuth2ScriptsEditor.java
@@ -66,9 +66,9 @@ public class OAuth2ScriptsEditor extends JPanel {
     static final String[] DEFAULT_SCRIPT_NAMES = {"Page 1 (e.g. login screen)", "Page 2 (e.g. consent screen)"};
     private static final String HELP_LINK_TEXT = "How to automate the process of getting an access token";
 
-    private List<InputPanel> inputPanels = new ArrayList<InputPanel>();
+    private List<InputPanel> inputPanels = new ArrayList<>();
     private InputPanel selectedInputField = null;
-    private List<RSyntaxTextArea> scriptFields = new ArrayList<RSyntaxTextArea>();
+    private List<RSyntaxTextArea> scriptFields = new ArrayList<>();
     private JavaScriptValidator javaScriptValidator = new JavaScriptValidator();
     private JPanel scriptsPanel;
     private JButton removeScriptButton;
@@ -103,7 +103,7 @@ public class OAuth2ScriptsEditor extends JPanel {
     }
 
     public List<String> getJavaScripts() {
-        List<String> scripts = new ArrayList<String>();
+        List<String> scripts = new ArrayList<>();
         for (RSyntaxTextArea scriptField : scriptFields) {
             scripts.add(scriptField.getText());
         }
@@ -319,14 +319,14 @@ public class OAuth2ScriptsEditor extends JPanel {
 
         private final List<String> expectedScripts;
         private boolean hasErrors = false;
-        private List<String> executedScripts = new ArrayList<String>();
+        private List<String> executedScripts = new ArrayList<>();
 
         public JavaScriptErrorReporter(List<String> automationJavaScripts) {
             this.expectedScripts = nonEmptyScriptsIn(automationJavaScripts);
         }
 
         private List<String> nonEmptyScriptsIn(List<String> scriptList) {
-            List<String> filteredList = new ArrayList<String>();
+            List<String> filteredList = new ArrayList<>();
             for (String script : scriptList) {
                 if (StringUtils.hasContent(script)) {
                     filteredList.add(script);

--- a/soapui/src/main/java/com/eviware/soapui/support/editor/inspectors/auth/ProfileSelectionForm.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/inspectors/auth/ProfileSelectionForm.java
@@ -86,7 +86,7 @@ public class ProfileSelectionForm<T extends AbstractHttpRequest> extends Abstrac
     private static final String OAUTH_1_FORM_LABEL = "OAuth 1 form";
     private static final ImageIcon AUTH_NOT_ENABLED_ICON = null;
 
-    private static final Map<String, ShowOnlineHelpAction> helpActions = new HashMap<String, ShowOnlineHelpAction>();
+    private static final Map<String, ShowOnlineHelpAction> helpActions = new HashMap<>();
     private final JPanel outerPanel = new JPanel(new BorderLayout());
     private final JPanel cardPanel = new JPanel(new CardLayout());
     private T request;
@@ -115,7 +115,7 @@ public class ProfileSelectionForm<T extends AbstractHttpRequest> extends Abstrac
     }
 
     protected static ArrayList<String> getBasicAuthenticationTypes() {
-        ArrayList<String> options = new ArrayList<String>();
+        ArrayList<String> options = new ArrayList<>();
         options.add(AbstractHttpRequest.BASIC_AUTH_PROFILE);
         options.add(NTLM.toString());
         options.add(SPNEGO_KERBEROS.toString());
@@ -159,7 +159,7 @@ public class ProfileSelectionForm<T extends AbstractHttpRequest> extends Abstrac
         cardPanel.add(createEmptyPanel(), EMPTY_PANEL);
         innerPanel.add(cardPanel, BorderLayout.CENTER);
 
-        authenticationForm = new BasicAuthenticationForm<T>(request);
+        authenticationForm = new BasicAuthenticationForm<>(request);
         cardPanel.add(authenticationForm.getComponent(), BASIC_FORM_LABEL);
 
         if (isSoapRequest(request)) {
@@ -414,7 +414,7 @@ public class ProfileSelectionForm<T extends AbstractHttpRequest> extends Abstrac
     }
 
     private String[] createOptionsForAuthorizationCombo(String selectedAuthProfile) {
-        ArrayList<String> options = new ArrayList<String>();
+        ArrayList<String> options = new ArrayList<>();
         options.add(CredentialsConfig.AuthType.NO_AUTHORIZATION.toString());
         Set<String> basicAuthenticationProfiles = request.getBasicAuthenticationProfiles();
         options.addAll(basicAuthenticationProfiles);
@@ -455,7 +455,7 @@ public class ProfileSelectionForm<T extends AbstractHttpRequest> extends Abstrac
     }
 
     private ArrayList<String> getAddEditOptions() {
-        ArrayList<String> addEditOptions = new ArrayList<String>();
+        ArrayList<String> addEditOptions = new ArrayList<>();
         addEditOptions.add(AddEditOptions.ADD.getDescription());
         addEditOptions.add(AddEditOptions.RENAME.getDescription());
         addEditOptions.add(AddEditOptions.DELETE.getDescription());

--- a/soapui/src/main/java/com/eviware/soapui/support/editor/inspectors/jms/property/JMSPropertyInspectorFactory.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/inspectors/jms/property/JMSPropertyInspectorFactory.java
@@ -88,7 +88,7 @@ public class JMSPropertyInspectorFactory implements RequestInspectorFactory, Res
 
         public void setJMSProperties(StringToStringMap stringToStringMap) {
             String[] keyList = stringToStringMap.getKeys();
-            List<JMSPropertyConfig> propertyList = new ArrayList<JMSPropertyConfig>();
+            List<JMSPropertyConfig> propertyList = new ArrayList<>();
             for (String key : keyList) {
                 JMSPropertyConfig jmsPropertyConfig = JMSPropertyConfig.Factory.newInstance();
                 jmsPropertyConfig.setName(key);

--- a/soapui/src/main/java/com/eviware/soapui/support/editor/support/AbstractEditorView.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/support/AbstractEditorView.java
@@ -39,7 +39,7 @@ public abstract class AbstractEditorView<T extends EditorDocument> implements Ed
     private boolean isActive;
     private PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
     private T xmlDocument;
-    private Set<EditorLocationListener<T>> listeners = new HashSet<EditorLocationListener<T>>();
+    private Set<EditorLocationListener<T>> listeners = new HashSet<>();
     private Editor<T> editor;
     private JComponent component;
     private final String viewId;

--- a/soapui/src/main/java/com/eviware/soapui/support/editor/views/AbstractXmlEditorView.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/views/AbstractXmlEditorView.java
@@ -41,7 +41,7 @@ public abstract class AbstractXmlEditorView<T extends XmlDocument> implements Xm
     private PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
     private T xmlDocument;
     private boolean editorDocumentChanged;
-    private Set<EditorLocationListener<T>> listeners = new HashSet<EditorLocationListener<T>>();
+    private Set<EditorLocationListener<T>> listeners = new HashSet<>();
     private XmlEditor<T> editor;
     private final String viewId;
 

--- a/soapui/src/main/java/com/eviware/soapui/support/editor/views/xml/source/XmlSourceEditorView.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/editor/views/xml/source/XmlSourceEditorView.java
@@ -635,7 +635,7 @@ public class XmlSourceEditorView<T extends ModelItem> extends AbstractXmlEditorV
         try {
             XmlUtils.createXmlObject(xml, new XmlOptions().setLoadLineNumbers());
         } catch (XmlException e) {
-            List<ValidationError> result = new ArrayList<ValidationError>();
+            List<ValidationError> result = new ArrayList<>();
 
             if (e.getErrors() != null) {
                 for (Object error : e.getErrors()) {

--- a/soapui/src/main/java/com/eviware/soapui/support/factory/SoapUIFactoryRegistry.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/factory/SoapUIFactoryRegistry.java
@@ -34,10 +34,10 @@ import java.util.Map;
 import java.util.Set;
 
 public class SoapUIFactoryRegistry {
-    private Map<Class<?>, List<Object>> factories = new HashMap<Class<?>, List<Object>>();
-    private Map<Class<?>, SoapUIFactoryConfig> factoryConfigs = new HashMap<Class<?>, SoapUIFactoryConfig>();
+    private Map<Class<?>, List<Object>> factories = new HashMap<>();
+    private Map<Class<?>, SoapUIFactoryConfig> factoryConfigs = new HashMap<>();
     private final static Logger log = LogManager.getLogger(SoapUIFactoryRegistry.class);
-    private Set<SoapUIFactoryRegistryListener> listeners = new HashSet<SoapUIFactoryRegistryListener>();
+    private Set<SoapUIFactoryRegistryListener> listeners = new HashSet<>();
 
     public SoapUIFactoryRegistry(InputStream config) {
         if (config != null) {
@@ -112,7 +112,7 @@ public class SoapUIFactoryRegistry {
 
     @SuppressWarnings("unchecked")
     public <T extends Object> List<T> getFactories(Class<T> factoryType) {
-        List<T> result = new ArrayList<T>();
+        List<T> result = new ArrayList<>();
 
         if (factories.containsKey(factoryType)) {
             for( Object obj : factories.get(factoryType))

--- a/soapui/src/main/java/com/eviware/soapui/support/jnlp/WebstartUtil.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/jnlp/WebstartUtil.java
@@ -39,13 +39,13 @@ public class WebstartUtil {
         return dir;
     }
 
-    private static void extract(JarFile jar, String dir) throws IOException, FileNotFoundException {
+    private static void extract(JarFile jar, String dir) throws IOException {
         makeDirectories(jar, dir);
         extractFiles(jar, dir);
     }
 
     @SuppressWarnings("unchecked")
-    private static void extractFiles(JarFile jar, String eviwareDir) throws IOException, FileNotFoundException {
+    private static void extractFiles(JarFile jar, String eviwareDir) throws IOException {
         Enumeration entries = jar.entries();
         while (entries.hasMoreElements()) {
             JarEntry file = (JarEntry) entries.nextElement();
@@ -80,7 +80,7 @@ public class WebstartUtil {
         }
     }
 
-    private static JarFile getJar(String jarUrl) throws MalformedURLException, IOException {
+    private static JarFile getJar(String jarUrl) throws IOException {
         // String reportsJarUrl = System.getProperty("reports.jar.url");
         URL url = new URL("jar:" + jarUrl + "!/");
         JarURLConnection jarConnection = (JarURLConnection) url.openConnection();

--- a/soapui/src/main/java/com/eviware/soapui/support/listener/SoapUIListenerRegistry.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/listener/SoapUIListenerRegistry.java
@@ -33,9 +33,9 @@ import java.util.List;
 import java.util.Map;
 
 public class SoapUIListenerRegistry implements ListenerRegistry {
-    private Map<Class<?>, List<Class<?>>> listeners = new HashMap<Class<?>, List<Class<?>>>();
-    private Map<Class<?>, List<Object>> singletonListeners = new HashMap<Class<?>, List<Object>>();
-    private Map<Class<?>, SoapUIListenerConfig> listenerConfigs = new HashMap<Class<?>, SoapUIListenerConfig>();
+    private Map<Class<?>, List<Class<?>>> listeners = new HashMap<>();
+    private Map<Class<?>, List<Object>> singletonListeners = new HashMap<>();
+    private Map<Class<?>, SoapUIListenerConfig> listenerConfigs = new HashMap<>();
     private final static Logger log = LogManager.getLogger(SoapUIListenerRegistry.class);
 
     public void addListener(Class<?> listenerInterface, Class<?> listenerClass, SoapUIListenerConfig config) {
@@ -44,7 +44,7 @@ public class SoapUIListenerRegistry implements ListenerRegistry {
             classes = listeners.get(listenerInterface);
         }
         if (classes == null) {
-            classes = new ArrayList<Class<?>>();
+            classes = new ArrayList<>();
         }
         classes.add(listenerClass);
         listeners.put(listenerInterface, classes);
@@ -144,7 +144,7 @@ public class SoapUIListenerRegistry implements ListenerRegistry {
 
     @SuppressWarnings("unchecked")
     public <T extends Object> List<T> getListeners(Class<T> listenerType) {
-        List<T> result = new ArrayList<T>();
+        List<T> result = new ArrayList<>();
         if (listeners.containsKey(listenerType)) {
             List<Class<?>> list = listeners.get(listenerType);
             for (Class<?> listenerClass : list) {
@@ -170,7 +170,7 @@ public class SoapUIListenerRegistry implements ListenerRegistry {
 
     @SuppressWarnings("unchecked")
     public <T extends Object> List<T> joinListeners(Class<T> listenerType, Collection<T> existing) {
-        List<T> result = new ArrayList<T>();
+        List<T> result = new ArrayList<>();
         if (listeners.containsKey(listenerType)) {
             List<Class<?>> list = listeners.get(listenerType);
             for (Class<?> listenerClass : list) {

--- a/soapui/src/main/java/com/eviware/soapui/support/log/InspectorLog4JMonitor.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/log/InspectorLog4JMonitor.java
@@ -45,7 +45,7 @@ public class InspectorLog4JMonitor implements JInspectorPanel, Log4JMonitor {
     public JLogList addLogArea(String title, String loggerName, boolean isDefault) {
         JLogList logArea = new JLogList(title);
         logArea.addLogger(loggerName, !isDefault);
-        JComponentInspector<JLogList> inspector = new JComponentInspector<JLogList>(logArea, title, null, true);
+        JComponentInspector<JLogList> inspector = new JComponentInspector<>(logArea, title, null, true);
         addInspector(inspector);
 
         if (isDefault) {

--- a/soapui/src/main/java/com/eviware/soapui/support/log/JLogList.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/log/JLogList.java
@@ -74,10 +74,10 @@ public class JLogList extends JPanel {
     private long maxRows = 1000;
     private JList logList;
     private final LogListModel model;
-    private List<Logger> loggers = new ArrayList<Logger>();
+    private List<Logger> loggers = new ArrayList<>();
     private InternalLogAppender internalLogAppender = new InternalLogAppender();
     private boolean tailing = true;
-    private BlockingQueue<Object> linesToAdd = new LinkedBlockingQueue<Object>();
+    private BlockingQueue<Object> linesToAdd = new LinkedBlockingQueue<>();
     private JCheckBoxMenuItem enableMenuItem;
     private final String title;
 
@@ -195,7 +195,7 @@ public class JLogList extends JPanel {
     }
 
     private static class LogAreaCellRenderer extends DefaultListCellRenderer {
-        private Map<Level, Color> levelColors = new HashMap<Level, Color>();
+        private Map<Level, Color> levelColors = new HashMap<>();
 
         private LogAreaCellRenderer() {
             levelColors.put(Level.ERROR, new Color(192, 0, 0));
@@ -477,7 +477,7 @@ public class JLogList extends JPanel {
                     Object line;
                     while ((line = getNextLine()) != null) {
                         try {
-                            List<Object> linesToAddNow = new ArrayList<Object>();
+                            List<Object> linesToAddNow = new ArrayList<>();
                             linesToAddNow.add(line);
                             while ((line = linesToAdd.poll()) != null) {
                                 linesToAddNow.add(line);

--- a/soapui/src/main/java/com/eviware/soapui/support/log/LogDisablingTestMonitorListener.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/log/LogDisablingTestMonitorListener.java
@@ -35,8 +35,8 @@ import java.util.Set;
  */
 
 public final class LogDisablingTestMonitorListener extends TestMonitorListenerAdapter {
-    private Set<LoadTestRunner> loadTestRunners = new HashSet<LoadTestRunner>();
-    private Set<SecurityTestRunner> securityTestRunners = new HashSet<SecurityTestRunner>();
+    private Set<LoadTestRunner> loadTestRunners = new HashSet<>();
+    private Set<SecurityTestRunner> securityTestRunners = new HashSet<>();
 
     public void loadTestStarted(LoadTestRunner runner) {
         if (loadTestRunners.isEmpty()) {

--- a/soapui/src/main/java/com/eviware/soapui/support/propertyexpansion/scrollmenu/ScrollableMenu.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/propertyexpansion/scrollmenu/ScrollableMenu.java
@@ -74,7 +74,7 @@ public class ScrollableMenu extends JMenu implements ScrollableMenuContainer {
     /**
      * Container to hold submenus.
      */
-    private Vector<JMenuItem> subMenus = new Vector<JMenuItem>();
+    private Vector<JMenuItem> subMenus = new Vector<>();
     /**
      * Height of the screen.
      */

--- a/soapui/src/main/java/com/eviware/soapui/support/propertyexpansion/scrollmenu/ScrollablePopup.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/propertyexpansion/scrollmenu/ScrollablePopup.java
@@ -70,7 +70,7 @@ public class ScrollablePopup extends JPopupMenu implements ScrollableMenuContain
     /**
      * Container to hold submenus.
      */
-    private Vector<JMenuItem> subMenus = new Vector<JMenuItem>();
+    private Vector<JMenuItem> subMenus = new Vector<>();
     /**
      * Height of the screen.
      */

--- a/soapui/src/main/java/com/eviware/soapui/support/registry/AbstractRegistry.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/registry/AbstractRegistry.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 public abstract class AbstractRegistry<T1 extends RegistryEntry<T2, T3>, T2 extends RegistryEntryConfig, T3 extends Object> {
-    private Map<String, Class<? extends T1>> registry = new HashMap<String, Class<? extends T1>>();
+    private Map<String, Class<? extends T1>> registry = new HashMap<>();
 
     public void mapType(String type, Class<? extends T1> clazz) {
         registry.put(type, clazz);
@@ -67,7 +67,7 @@ public abstract class AbstractRegistry<T1 extends RegistryEntry<T2, T3>, T2 exte
     }
 
     public String[] getTypesWithInterface(Class<?> clazz) {
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
 
         for (String type : registry.keySet()) {
             if (Arrays.asList(registry.get(type).getInterfaces()).contains(clazz)) {

--- a/soapui/src/main/java/com/eviware/soapui/support/resolver/ChooseAnotherPropertySourceResolver.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/resolver/ChooseAnotherPropertySourceResolver.java
@@ -46,8 +46,8 @@ public class ChooseAnotherPropertySourceResolver implements Resolver {
     private boolean resolved;
     private PropertyTransfer badTransfer = null;
     private PropertyTransfersTestStep parent = null;
-    private ArrayList<Object> sources = new ArrayList<Object>();
-    private ArrayList<String[]> properties = new ArrayList<String[]>();
+    private ArrayList<Object> sources = new ArrayList<>();
+    private ArrayList<String[]> properties = new ArrayList<>();
 
     public ChooseAnotherPropertySourceResolver(PropertyTransfer propertyTransfer, PropertyTransfersTestStep parent) {
         this.badTransfer = propertyTransfer;

--- a/soapui/src/main/java/com/eviware/soapui/support/resolver/ChooseAnotherPropertyTargetResolver.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/resolver/ChooseAnotherPropertyTargetResolver.java
@@ -46,8 +46,8 @@ public class ChooseAnotherPropertyTargetResolver implements Resolver {
     private boolean resolved;
     private PropertyTransfer badTransfer = null;
     private PropertyTransfersTestStep parent = null;
-    private ArrayList<Object> sources = new ArrayList<Object>();
-    private ArrayList<String[]> properties = new ArrayList<String[]>();
+    private ArrayList<Object> sources = new ArrayList<>();
+    private ArrayList<String[]> properties = new ArrayList<>();
 
     public ChooseAnotherPropertyTargetResolver(PropertyTransfer propertyTransfer, PropertyTransfersTestStep parent) {
         this.badTransfer = propertyTransfer;

--- a/soapui/src/main/java/com/eviware/soapui/support/resolver/ResolveContext.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/resolver/ResolveContext.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ResolveContext<T extends AbstractWsdlModelItem<?>> {
-    private List<PathToResolve> pathsToResolve = new ArrayList<PathToResolve>();
+    private List<PathToResolve> pathsToResolve = new ArrayList<>();
     private final T modelItem;
 
     public ResolveContext(T modelItem) {
@@ -53,7 +53,7 @@ public class ResolveContext<T extends AbstractWsdlModelItem<?>> {
     public class PathToResolve {
         private final AbstractWsdlModelItem<?> owner;
         private final String description;
-        private List<Resolver> resolvers = new ArrayList<Resolver>();
+        private List<Resolver> resolvers = new ArrayList<>();
         private final String path;
         private Resolver resolver;
         private boolean resolved;

--- a/soapui/src/main/java/com/eviware/soapui/support/resolver/ResolveDialog.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/resolver/ResolveDialog.java
@@ -217,13 +217,13 @@ public class ResolveDialog {
     @SuppressWarnings("serial")
     private class ResolveContextTableModel extends AbstractTableModel {
         private ResolveContext<?> context;
-        private ArrayList<JComboBox> jbcList = new ArrayList<JComboBox>();
+        private ArrayList<JComboBox> jbcList = new ArrayList<>();
 
         @SuppressWarnings("unchecked")
         public ResolveContextTableModel(ResolveContext<?> context2) {
             context = context2;
             for (PathToResolve path : context.getPathsToResolve()) {
-                ArrayList<Object> resolversAndDefaultAction = new ArrayList<Object>();
+                ArrayList<Object> resolversAndDefaultAction = new ArrayList<>();
                 resolversAndDefaultAction.add("Choose one...");
                 for (Object resolver : path.getResolvers()) {
                     resolversAndDefaultAction.add(resolver);

--- a/soapui/src/main/java/com/eviware/soapui/support/scripting/ScriptEnginePool.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/scripting/ScriptEnginePool.java
@@ -28,7 +28,7 @@ import java.util.Stack;
  */
 
 public class ScriptEnginePool {
-    private Stack<SoapUIScriptEngine> scriptEngines = new Stack<SoapUIScriptEngine>();
+    private Stack<SoapUIScriptEngine> scriptEngines = new Stack<>();
     private String script;
     private ModelItem modelItem;
     private int borrowed;

--- a/soapui/src/main/java/com/eviware/soapui/support/scripting/SoapUIScriptEngineRegistry.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/scripting/SoapUIScriptEngineRegistry.java
@@ -36,7 +36,7 @@ import java.util.Map;
 public class SoapUIScriptEngineRegistry {
     public static final String DEFAULT_SCRIPT_ENGINE_ID = GroovyScriptEngineFactory.ID;
 
-    private static Map<String, SoapUIScriptEngineFactory> factories = new HashMap<String, SoapUIScriptEngineFactory>();
+    private static Map<String, SoapUIScriptEngineFactory> factories = new HashMap<>();
 
     public static void registerScriptEngine(String id, SoapUIScriptEngineFactory factory) {
         factories.put(id, factory);

--- a/soapui/src/main/java/com/eviware/soapui/support/swing/ComponentBag.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/swing/ComponentBag.java
@@ -28,7 +28,7 @@ import java.util.Map;
  */
 
 public class ComponentBag {
-    private Map<String, JComponent> components = new HashMap<String, JComponent>();
+    private Map<String, JComponent> components = new HashMap<>();
 
     public ComponentBag() {
     }

--- a/soapui/src/main/java/com/eviware/soapui/support/swing/MenuBuilderHelper.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/swing/MenuBuilderHelper.java
@@ -54,14 +54,14 @@ public class MenuBuilderHelper {
         ActionList actions = buildActionsForActionGroup(actionGroup);
         if (menu.getText().equals(SoapUI.STEP)) {
             SoapUIActionMapping<WsdlTestStep> toggleDisabledActionMapping = null;
-            DefaultActionMapping<WsdlTestStep> actionMapping = new DefaultActionMapping<WsdlTestStep>(
+            DefaultActionMapping<WsdlTestStep> actionMapping = new DefaultActionMapping<>(
                     ShowDesktopPanelAction.SOAPUI_ACTION_ID, "ENTER", null, true, null);
             actionMapping.setName("Open Editor");
             actionMapping.setDescription("Opens the editor for this TestStep");
             SwingActionDelegate actionDelegate = new SwingActionDelegate(actionMapping, null);
             menu.add(actionDelegate);
 
-            toggleDisabledActionMapping = new DefaultActionMapping<WsdlTestStep>(
+            toggleDisabledActionMapping = new DefaultActionMapping<>(
                     ToggleDisableTestStepAction.SOAPUI_ACTION_ID, null, null, false, null);
 
             SwingActionDelegate actionDelegateToggle = new SwingActionDelegate(toggleDisabledActionMapping, null);

--- a/soapui/src/main/java/com/eviware/soapui/support/swing/TreePathUtils.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/swing/TreePathUtils.java
@@ -26,7 +26,7 @@ import java.util.List;
  */
 public class TreePathUtils {
     public static TreePath getPath(TreeNode treeNode) {
-        List<Object> nodes = new ArrayList<Object>();
+        List<Object> nodes = new ArrayList<>();
         if (treeNode != null) {
             nodes.add(treeNode);
             treeNode = treeNode.getParent();

--- a/soapui/src/main/java/com/eviware/soapui/support/uri/HttpParser.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/uri/HttpParser.java
@@ -33,7 +33,7 @@ public class HttpParser {
     }
 
     public static Header[] parseHeaders(InputStream is, String charset) throws IOException, HttpException {
-        ArrayList<Header> headers = new ArrayList<Header>();
+        ArrayList<Header> headers = new ArrayList<>();
         String name = null;
         StringBuffer value = null;
         for (; ; ) {

--- a/soapui/src/main/java/com/eviware/soapui/support/xml/XPathData.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/xml/XPathData.java
@@ -32,7 +32,7 @@ import java.util.List;
  */
 public class XPathData {
     private StringToStringMap nsMap = new StringToStringMap();
-    private List<String> pathComponents = new ArrayList<String>();
+    private List<String> pathComponents = new ArrayList<>();
     private String function;
     private boolean absolute = false;
 
@@ -113,7 +113,7 @@ public class XPathData {
         }
 
         StringToStringMap nsMap2 = new StringToStringMap(nsMap);
-        ArrayList<String> pathComponents2 = new ArrayList<String>(pathComponents);
+        ArrayList<String> pathComponents2 = new ArrayList<>(pathComponents);
         pathComponents2.remove(0);
         return new XPathData(nsMap2, pathComponents2, absolute);
     }
@@ -230,7 +230,7 @@ public class XPathData {
      * Get a path with all namespaces replaced.
      */
     public String getCanonicalPath() {
-        HashMap<String, String> inverseNsMap = new HashMap<String, String>();
+        HashMap<String, String> inverseNsMap = new HashMap<>();
         for (String key : nsMap.keySet()) {
             String value = nsMap.get(key);
             inverseNsMap.put(value, key);

--- a/soapui/src/main/java/com/eviware/soapui/support/xml/XmlObjectTreeModel.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/xml/XmlObjectTreeModel.java
@@ -49,9 +49,9 @@ import java.util.Set;
 
 public class XmlObjectTreeModel implements TreeTableModel {
     private XmlObject xmlObject;
-    private Set<TreeModelListener> listeners = new HashSet<TreeModelListener>();
+    private Set<TreeModelListener> listeners = new HashSet<>();
     private XmlCursor cursor;
-    private Map<XmlObject, XmlTreeNode> treeNodeMap = new HashMap<XmlObject, XmlTreeNode>();
+    private Map<XmlObject, XmlTreeNode> treeNodeMap = new HashMap<>();
 
     public final static Class<?> hierarchicalColumnClass = TreeTableModel.class;
     private SchemaTypeSystem typeSystem;
@@ -486,7 +486,7 @@ public class XmlObjectTreeModel implements TreeTableModel {
         }
 
         public TreePath getTreePath() {
-            List<XmlTreeNode> nodes = new ArrayList<XmlTreeNode>();
+            List<XmlTreeNode> nodes = new ArrayList<>();
             nodes.add(this);
 
             XmlTreeNode node = this;
@@ -534,7 +534,7 @@ public class XmlObjectTreeModel implements TreeTableModel {
     }
 
     public class ElementXmlTreeNode extends AbstractXmlTreeNode {
-        private LinkedList<XmlTreeNode> elements = new LinkedList<XmlTreeNode>();
+        private LinkedList<XmlTreeNode> elements = new LinkedList<>();
         private TextXmlTreeNode textTreeNode;
         private int attrCount;
 
@@ -783,7 +783,7 @@ public class XmlObjectTreeModel implements TreeTableModel {
 
     public XmlTreeNode[] selectTreeNodes(String xpath) {
         XmlObject[] nodes = xmlObject.selectPath(xpath);
-        List<XmlTreeNode> result = new ArrayList<XmlTreeNode>();
+        List<XmlTreeNode> result = new ArrayList<>();
 
         for (XmlObject xmlObject : nodes) {
             XmlTreeNode tn = getXmlTreeNode(xmlObject);

--- a/soapui/src/main/java/com/eviware/soapui/support/xml/XmlUtils.java
+++ b/soapui/src/main/java/com/eviware/soapui/support/xml/XmlUtils.java
@@ -664,7 +664,7 @@ public final class XmlUtils {
     public static XPathData createXPathData(Node node, boolean anonymous, boolean selectText, boolean absolute,
                                             boolean normalize) {
         StringToStringMap nsMap = new StringToStringMap();
-        List<String> pathComponents = new ArrayList<String>();
+        List<String> pathComponents = new ArrayList<>();
 
         int nsCnt = 1;
 
@@ -827,7 +827,7 @@ public final class XmlUtils {
     }
 
     public static String declareXPathNamespaces(XmlObject xmlObject) {
-        Map<QName, String> map = new HashMap<QName, String>();
+        Map<QName, String> map = new HashMap<>();
         XmlCursor cursor = xmlObject.newCursor();
 
         while (cursor.hasNextToken()) {
@@ -841,8 +841,8 @@ public final class XmlUtils {
         int nsCnt = 0;
 
         StringBuilder buf = new StringBuilder();
-        Set<String> prefixes = new HashSet<String>();
-        Set<String> usedPrefixes = new HashSet<String>();
+        Set<String> prefixes = new HashSet<>();
+        Set<String> usedPrefixes = new HashSet<>();
 
         for (Map.Entry<QName, String> entry : map.entrySet()) {
             QName name = entry.getKey();
@@ -933,7 +933,7 @@ public final class XmlUtils {
     }
 
     public static NodeList getChildElements(Element elm) {
-        List<Element> list = new ArrayList<Element>();
+        List<Element> list = new ArrayList<>();
 
         NodeList nl = elm.getChildNodes();
         for (int c = 0; c < nl.getLength(); c++) {
@@ -947,7 +947,7 @@ public final class XmlUtils {
     }
 
     public static NodeList getChildElementsByTagName(Element elm, String name) {
-        List<Element> list = new ArrayList<Element>();
+        List<Element> list = new ArrayList<>();
 
         NodeList nl = elm.getChildNodes();
         for (int c = 0; c < nl.getLength(); c++) {
@@ -961,7 +961,7 @@ public final class XmlUtils {
     }
 
     public static NodeList getChildElementsOfType(Element elm, SchemaType schemaType) {
-        List<Element> list = new ArrayList<Element>();
+        List<Element> list = new ArrayList<>();
 
         NodeList nl = elm.getChildNodes();
         for (int c = 0; c < nl.getLength(); c++) {
@@ -982,7 +982,7 @@ public final class XmlUtils {
     }
 
     public static NodeList getChildElementsByTagNameNS(Element elm, String namespaceUri, String localName) {
-        List<Element> list = new ArrayList<Element>();
+        List<Element> list = new ArrayList<>();
 
         NodeList nl = elm.getChildNodes();
         for (int c = 0; c < nl.getLength(); c++) {
@@ -1198,7 +1198,7 @@ public final class XmlUtils {
     }
 
     public static Node[] selectDomNodes(XmlObject xmlObject, String xpath) {
-        List<Node> result = new ArrayList<Node>();
+        List<Node> result = new ArrayList<>();
 
         XmlCursor cursor = xmlObject.newCursor();
         try {

--- a/soapui/src/main/java/com/eviware/soapui/testondemand/TestOnDemandCaller.java
+++ b/soapui/src/main/java/com/eviware/soapui/testondemand/TestOnDemandCaller.java
@@ -120,7 +120,7 @@ public class TestOnDemandCaller {
         NodeList locationNodes = (NodeList) xpath.evaluate(LOCATION_XPATH_EXPRESSION, responseDocument,
                 XPathConstants.NODESET);
 
-        List<Location> locations = new ArrayList<Location>();
+        List<Location> locations = new ArrayList<>();
         for (int i = 0; i < locationNodes.getLength(); i++) {
             Node locationNode = locationNodes.item(i);
             String name = (String) xpath.evaluate(LOCATION_NAME_XPATH_EXPRESSION, locationNode, XPathConstants.STRING);
@@ -287,7 +287,7 @@ public class TestOnDemandCaller {
     private XmlOptions getXmlOptionsWithoutNamespaces() {
         XmlOptions options = new XmlOptions();
         options.setUseDefaultNamespace();
-        Map<String, String> namespaces = new HashMap<String, String>();
+        Map<String, String> namespaces = new HashMap<>();
         namespaces.put("", "http://eviware.com/soapui/config");
         options.setSaveImplicitNamespaces(namespaces);
         return options;

--- a/soapui/src/main/java/com/eviware/soapui/tools/AbstractSoapUIRunner.java
+++ b/soapui/src/main/java/com/eviware/soapui/tools/AbstractSoapUIRunner.java
@@ -68,7 +68,7 @@ public abstract class AbstractSoapUIRunner implements CmdLineRunner {
     private boolean enableUI;
     private String outputFolder;
     private String[] projectProperties;
-    private Map<String, String> runnerGlobalProperties = new HashMap<String, String>();
+    private Map<String, String> runnerGlobalProperties = new HashMap<>();
 
     public AbstractSoapUIRunner(String title) {
         if (title != null) {
@@ -300,7 +300,7 @@ public abstract class AbstractSoapUIRunner implements CmdLineRunner {
     }
 
     public String getModelItemOutputFolder(ModelItem modelItem) {
-        List<ModelItem> chain = new ArrayList<ModelItem>();
+        List<ModelItem> chain = new ArrayList<>();
         ModelItem p = modelItem;
 
         while (!(p instanceof Project)) {

--- a/soapui/src/main/java/com/eviware/soapui/tools/MockAsWar.java
+++ b/soapui/src/main/java/com/eviware/soapui/tools/MockAsWar.java
@@ -126,10 +126,10 @@ public class MockAsWar {
     }
 
     private ArrayList<File> getAllFilesFrom(File dir) {
-        ArrayList<File> result = new ArrayList<File>();
+        ArrayList<File> result = new ArrayList<>();
         if (dir.isDirectory()) {
             result.addAll(Arrays.asList(dir.listFiles()));
-            ArrayList<File> toAdd = new ArrayList<File>();
+            ArrayList<File> toAdd = new ArrayList<>();
             for (File f : result) {
                 if (f.isDirectory()) {
                     toAdd.addAll(getAllFilesFrom(f));

--- a/soapui/src/main/java/com/eviware/soapui/tools/SoapUILoadTestRunner.java
+++ b/soapui/src/main/java/com/eviware/soapui/tools/SoapUILoadTestRunner.java
@@ -66,7 +66,7 @@ public class SoapUILoadTestRunner extends AbstractSoapUITestRunner implements Lo
     private String testCase;
     private String loadTest;
     private boolean printReport;
-    private List<LoadTestRunner> failedTests = new ArrayList<LoadTestRunner>();
+    private List<LoadTestRunner> failedTests = new ArrayList<>();
     private int testCaseCount;
     private int loadTestCount;
     private int limit = -1;

--- a/soapui/src/main/java/com/eviware/soapui/tools/SoapUIMockServiceRunner.java
+++ b/soapui/src/main/java/com/eviware/soapui/tools/SoapUIMockServiceRunner.java
@@ -46,7 +46,7 @@ public class SoapUIMockServiceRunner extends AbstractSoapUIRunner {
     private String mockService;
     private String port;
     private String path;
-    private List<MockRunner> runners = new ArrayList<MockRunner>();
+    private List<MockRunner> runners = new ArrayList<>();
     private boolean block;
     private String projectPassword;
     private WsdlProject project;

--- a/soapui/src/main/java/com/eviware/soapui/tools/SoapUISecurityTestRunner.java
+++ b/soapui/src/main/java/com/eviware/soapui/tools/SoapUISecurityTestRunner.java
@@ -80,7 +80,7 @@ public class SoapUISecurityTestRunner extends SoapUITestCaseRunner implements Se
     private int securityScanCount;
     private int securityScanRequestCount;
     private int securityScanAlertCount;
-    private List<SecurityTestStepResult> failedResults = new ArrayList<SecurityTestStepResult>();
+    private List<SecurityTestStepResult> failedResults = new ArrayList<>();
     private JUnitSecurityReportCollector reportCollector = new JUnitSecurityReportCollector();
 
     /**
@@ -152,7 +152,7 @@ public class SoapUISecurityTestRunner extends SoapUITestCaseRunner implements Se
 
         long startTime = System.nanoTime();
 
-        List<TestCase> testCasesToRun = new ArrayList<TestCase>();
+        List<TestCase> testCasesToRun = new ArrayList<>();
 
         // start by listening to all testcases.. (since one testcase can call
         // another)

--- a/soapui/src/main/java/com/eviware/soapui/tools/SoapUITestCaseRunner.java
+++ b/soapui/src/main/java/com/eviware/soapui/tools/SoapUITestCaseRunner.java
@@ -87,9 +87,9 @@ public class SoapUITestCaseRunner extends AbstractSoapUITestRunner {
 
     private String testSuite;
     private String testCase;
-    private List<TestAssertion> assertions = new ArrayList<TestAssertion>();
-    private Map<TestAssertion, WsdlTestStepResult> assertionResults = new HashMap<TestAssertion, WsdlTestStepResult>();
-    private List<TestCase> failedTests = new ArrayList<TestCase>();
+    private List<TestAssertion> assertions = new ArrayList<>();
+    private Map<TestAssertion, WsdlTestStepResult> assertionResults = new HashMap<>();
+    private List<TestCase> failedTests = new ArrayList<>();
 
     private int testSuiteCount;
     private int testCaseCount;
@@ -365,7 +365,7 @@ public class SoapUITestCaseRunner extends AbstractSoapUITestRunner {
 
         long startTime = System.nanoTime();
 
-        List<TestCase> testCasesToRun = new ArrayList<TestCase>();
+        List<TestCase> testCasesToRun = new ArrayList<>();
 
         // validate testSuite argument
         if (testSuite != null && project.getTestSuiteByName(testSuite) == null) {

--- a/soapui/src/main/java/com/eviware/soapui/tools/ToolActionFactory.java
+++ b/soapui/src/main/java/com/eviware/soapui/tools/ToolActionFactory.java
@@ -50,7 +50,7 @@ public class ToolActionFactory {
     private static Hashtable<String, Class> toolActionTypeMap;
 
     static {
-        toolActionTypeMap = new Hashtable<String, Class>();
+        toolActionTypeMap = new Hashtable<>();
         toolActionTypeMap.put("axis1", Axis1XWSDL2JavaAction.class);
         toolActionTypeMap.put("axis2", Axis2WSDL2CodeAction.class);
         toolActionTypeMap.put("dotnet", DotNetWsdlAction.class);

--- a/soapui/src/main/java/com/eviware/soapui/ui/JDesktopPanelsList.java
+++ b/soapui/src/main/java/com/eviware/soapui/ui/JDesktopPanelsList.java
@@ -97,7 +97,7 @@ public class JDesktopPanelsList extends JPanel {
     }
 
     public List<DesktopPanel> getDesktopPanels() {
-        List<DesktopPanel> result = new ArrayList<DesktopPanel>();
+        List<DesktopPanel> result = new ArrayList<>();
 
         for (int c = 0; c < desktopPanels.getSize(); c++) {
             result.add((DesktopPanel) desktopPanels.get(c));

--- a/soapui/src/main/java/com/eviware/soapui/ui/desktop/AbstractSoapUIDesktop.java
+++ b/soapui/src/main/java/com/eviware/soapui/ui/desktop/AbstractSoapUIDesktop.java
@@ -53,7 +53,7 @@ public abstract class AbstractSoapUIDesktop implements SoapUIDesktop {
     private final InternalInterfaceListener interfaceListener = new InternalInterfaceListener();
     private final InternalTestSuiteListener testSuiteListener = new InternalTestSuiteListener();
     private final InternalMockServiceListener mockServiceListener = new InternalMockServiceListener();
-    private Set<DesktopListener> listeners = new HashSet<DesktopListener>();
+    private Set<DesktopListener> listeners = new HashSet<>();
     private InternalWorkspaceListener workspaceListener = new InternalWorkspaceListener();
 
     public AbstractSoapUIDesktop(Workspace workspace) {

--- a/soapui/src/main/java/com/eviware/soapui/ui/desktop/DesktopRegistry.java
+++ b/soapui/src/main/java/com/eviware/soapui/ui/desktop/DesktopRegistry.java
@@ -29,7 +29,7 @@ import java.util.Map;
 
 public class DesktopRegistry {
     private static DesktopRegistry instance;
-    private Map<String, DesktopFactory> factories = new HashMap<String, DesktopFactory>();
+    private Map<String, DesktopFactory> factories = new HashMap<>();
 
     public static DesktopRegistry getInstance() {
         if (instance == null) {

--- a/soapui/src/main/java/com/eviware/soapui/ui/desktop/standalone/MostRecentlyUsedOrderDesktopManager.java
+++ b/soapui/src/main/java/com/eviware/soapui/ui/desktop/standalone/MostRecentlyUsedOrderDesktopManager.java
@@ -41,7 +41,7 @@ import java.util.Deque;
  */
 public class MostRecentlyUsedOrderDesktopManager implements DesktopManager {
     // Keep desktop panel list (JInternalFrame) of existing internal frames in a most-recently-used order (i.e. a stack).
-    Deque<JInternalFrame> mostRecentlyUsedFrames = new ArrayDeque<JInternalFrame>();
+    Deque<JInternalFrame> mostRecentlyUsedFrames = new ArrayDeque<>();
 
     private DesktopManager delegate;
     // this is used to prevent AquaInternalFrameManager from activating another pane when we are closing one on Mac

--- a/soapui/src/main/java/com/eviware/soapui/ui/desktop/standalone/StandaloneDesktop.java
+++ b/soapui/src/main/java/com/eviware/soapui/ui/desktop/standalone/StandaloneDesktop.java
@@ -75,8 +75,8 @@ import java.util.Map;
 
 public class StandaloneDesktop extends AbstractSoapUIDesktop {
     private JDesktopPane desktop;
-    private Map<ModelItem, JInternalFrame> modelItemToInternalFrameMap = new HashMap<ModelItem, JInternalFrame>();
-    private Map<JInternalFrame, DesktopPanel> internalFrameToDesktopPanelMap = new HashMap<JInternalFrame, DesktopPanel>();
+    private Map<ModelItem, JInternalFrame> modelItemToInternalFrameMap = new HashMap<>();
+    private Map<JInternalFrame, DesktopPanel> internalFrameToDesktopPanelMap = new HashMap<>();
     private DesktopPanelPropertyChangeListener desktopPanelPropertyChangeListener = new DesktopPanelPropertyChangeListener();
     private InternalDesktopFrameListener internalFrameListener = new InternalDesktopFrameListener();
     private ActionList actions;
@@ -90,7 +90,7 @@ public class StandaloneDesktop extends AbstractSoapUIDesktop {
     private static final int xOffset = 30, yOffset = 30;
     private boolean transferring;
 
-    private List<DesktopPanel> deferredDesktopPanels = new LinkedList<DesktopPanel>();
+    private List<DesktopPanel> deferredDesktopPanels = new LinkedList<>();
     private JInspectorPanel inspector;
     private JPanel inspectorPanel;
 
@@ -467,7 +467,7 @@ public class StandaloneDesktop extends AbstractSoapUIDesktop {
     public void transferTo(SoapUIDesktop newDesktop) {
         transferring = true;
 
-        List<DesktopPanel> values = new ArrayList<DesktopPanel>(internalFrameToDesktopPanelMap.values());
+        List<DesktopPanel> values = new ArrayList<>(internalFrameToDesktopPanelMap.values());
         for (DesktopPanel desktopPanel : values) {
             closeDesktopPanel(desktopPanel);
             newDesktop.showDesktopPanel(desktopPanel);

--- a/soapui/src/main/java/com/eviware/soapui/ui/navigator/Navigator.java
+++ b/soapui/src/main/java/com/eviware/soapui/ui/navigator/Navigator.java
@@ -72,7 +72,7 @@ public class Navigator extends JPanel {
     private Workspace workspace;
     private JTree mainTree;
     private SoapUITreeModel treeModel;
-    private Set<NavigatorListener> listeners = new HashSet<NavigatorListener>();
+    private Set<NavigatorListener> listeners = new HashSet<>();
     private NavigatorNodesExpandStateEngine navigatorNodesExpandStateEngine;
 
 
@@ -204,7 +204,7 @@ public class Navigator extends JPanel {
                 }
             } else {
                 TreePath[] selectionPaths = mainTree.getSelectionPaths();
-                List<ModelItem> targets = new ArrayList<ModelItem>();
+                List<ModelItem> targets = new ArrayList<>();
                 for (TreePath treePath : selectionPaths) {
                     SoapUITreeNode node = (SoapUITreeNode) treePath.getLastPathComponent();
                     targets.add(node.getModelItem());
@@ -392,7 +392,7 @@ public class Navigator extends JPanel {
                 showToolTipLessPopupMenu(popupMenu, e.getX(), e.getY());
             } else {
                 TreePath[] selectionPaths = mainTree.getSelectionPaths();
-                List<ModelItem> targets = new ArrayList<ModelItem>();
+                List<ModelItem> targets = new ArrayList<>();
                 for (TreePath treePath : selectionPaths) {
                     SoapUITreeNode node = (SoapUITreeNode) treePath.getLastPathComponent();
                     targets.add(node.getModelItem());

--- a/soapui/src/main/java/com/eviware/soapui/ui/support/AbstractMockOperationDesktopPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/ui/support/AbstractMockOperationDesktopPanel.java
@@ -81,7 +81,7 @@ public abstract class AbstractMockOperationDesktopPanel<MockOperationType extend
 
         inspectorPanel = JInspectorPanelFactory.build(buildResponseList());
         inspectorPanel.setDefaultDividerLocation(0.5F);
-        dispatchInspector = new JComponentInspector<JComponent>(buildDispatchEditor(), "Dispatch ("
+        dispatchInspector = new JComponentInspector<>(buildDispatchEditor(), "Dispatch ("
                 + getModelItem().getDispatchStyle().toString() + ")", "Configures current dispatch style", true);
         inspectorPanel.addInspector(dispatchInspector);
         inspectorPanel.activate(dispatchInspector);
@@ -170,7 +170,7 @@ public abstract class AbstractMockOperationDesktopPanel<MockOperationType extend
 
         defaultResponsePanel.add(new JLabel("Default Response: "), BorderLayout.WEST);
 
-        ModelItemNames<MockResponse> names = new ModelItemNames<MockResponse>(getModelItem().getMockResponses());
+        ModelItemNames<MockResponse> names = new ModelItemNames<>(getModelItem().getMockResponses());
         defaultResponseCombo = new JComboBox(new ExtendedComboBoxModel(names.getNames()));
         defaultResponseCombo.setPreferredSize(new Dimension(150, 20));
         defaultResponseCombo.addItemListener(new ItemListener() {
@@ -219,7 +219,7 @@ public abstract class AbstractMockOperationDesktopPanel<MockOperationType extend
 
     public class ResponseListModel extends AbstractListModel implements ListModel, MockServiceListener,
             PropertyChangeListener {
-        private java.util.List<MockResponse> responses = new ArrayList<MockResponse>();
+        private java.util.List<MockResponse> responses = new ArrayList<>();
 
         public ResponseListModel() {
             for (int c = 0; c < getModelItem().getMockResponseCount(); c++) {

--- a/soapui/src/main/java/com/eviware/soapui/ui/support/DefaultDesktopPanel.java
+++ b/soapui/src/main/java/com/eviware/soapui/ui/support/DefaultDesktopPanel.java
@@ -38,7 +38,7 @@ public class DefaultDesktopPanel implements DesktopPanel {
     private PropertyChangeSupport propertyChangeSupport;
     private String title;
     private JComponent component;
-    private Set<ModelItem> depends = new HashSet<ModelItem>();
+    private Set<ModelItem> depends = new HashSet<>();
     private ImageIcon icon;
     private final String description;
 

--- a/soapui/src/main/java/com/eviware/x/form/AbstractXFormField.java
+++ b/soapui/src/main/java/com/eviware/x/form/AbstractXFormField.java
@@ -42,7 +42,7 @@ public abstract class AbstractXFormField<T> implements XFormField {
 
     public void addFormFieldListener(XFormFieldListener listener) {
         if (listeners == null) {
-            listeners = new HashSet<XFormFieldListener>();
+            listeners = new HashSet<>();
         }
 
         listeners.add(listener);
@@ -50,7 +50,7 @@ public abstract class AbstractXFormField<T> implements XFormField {
 
     public void addFormFieldValidator(XFormFieldValidator validator) {
         if (validators == null) {
-            validators = new ArrayList<XFormFieldValidator>();
+            validators = new ArrayList<>();
         }
 
         validators.add(validator);
@@ -95,7 +95,7 @@ public abstract class AbstractXFormField<T> implements XFormField {
             return null;
         }
 
-        ArrayList<ValidationMessage> messages = new ArrayList<ValidationMessage>();
+        ArrayList<ValidationMessage> messages = new ArrayList<>();
 
         for (XFormFieldValidator validator : validators) {
             ValidationMessage[] validateField = validator.validateField(this);

--- a/soapui/src/main/java/com/eviware/x/form/ComponentEnabler.java
+++ b/soapui/src/main/java/com/eviware/x/form/ComponentEnabler.java
@@ -22,7 +22,7 @@ public class ComponentEnabler implements XFormFieldListener {
     private final XFormField formField;
 
     // Cannot use HashMap, because the XFormField may be a Proxy.
-    private ArrayList<FieldValue> fields = new ArrayList<FieldValue>();
+    private ArrayList<FieldValue> fields = new ArrayList<>();
 
     private static class FieldValue {
         XFormField field;

--- a/soapui/src/main/java/com/eviware/x/form/XFormDialogBuilder.java
+++ b/soapui/src/main/java/com/eviware/x/form/XFormDialogBuilder.java
@@ -23,7 +23,7 @@ import javax.swing.ImageIcon;
 import java.util.ArrayList;
 
 public abstract class XFormDialogBuilder {
-    private ArrayList<XForm> forms = new ArrayList<XForm>();
+    private ArrayList<XForm> forms = new ArrayList<>();
 
     public XFormDialogBuilder() {
     }

--- a/soapui/src/main/java/com/eviware/x/form/support/XFormMultiSelectList.java
+++ b/soapui/src/main/java/com/eviware/x/form/support/XFormMultiSelectList.java
@@ -53,7 +53,7 @@ import java.util.List;
 public class XFormMultiSelectList extends AbstractSwingXFormField<JPanel> implements XFormOptionsField {
     private JList list;
     private DefaultListModel listModel;
-    private List<Boolean> selected = new ArrayList<Boolean>();
+    private List<Boolean> selected = new ArrayList<>();
 
     PropertyChangeSupport pcs = new PropertyChangeSupport(this);
     private int[] defaultIndex;
@@ -129,7 +129,7 @@ public class XFormMultiSelectList extends AbstractSwingXFormField<JPanel> implem
     }
 
     public Object[] getSelectedOptions() {
-        List<Object> result = new ArrayList<Object>();
+        List<Object> result = new ArrayList<>();
 
         for (int c = 0; c < selected.size(); c++) {
             if (selected.get(c)) {

--- a/soapui/src/main/java/com/eviware/x/form/support/XFormRadioGroup.java
+++ b/soapui/src/main/java/com/eviware/x/form/support/XFormRadioGroup.java
@@ -41,8 +41,8 @@ import java.util.Map;
 
 public class XFormRadioGroup extends AbstractSwingXFormField<JPanel> implements XFormOptionsField {
     protected ButtonGroup buttonGroup;
-    protected Map<String, ButtonModel> models = new HashMap<String, ButtonModel>();
-    protected List<Object> items = new ArrayList<Object>();
+    protected Map<String, ButtonModel> models = new HashMap<>();
+    protected List<Object> items = new ArrayList<>();
 
     public XFormRadioGroup(String[] values) {
         super(new JPanel());

--- a/soapui/src/main/java/com/eviware/x/impl/swing/JTabbedFormDialog.java
+++ b/soapui/src/main/java/com/eviware/x/impl/swing/JTabbedFormDialog.java
@@ -41,7 +41,7 @@ import java.util.List;
 
 public class JTabbedFormDialog extends SwingXFormDialog {
     private JDialog dialog;
-    private List<SwingXFormImpl> forms = new ArrayList<SwingXFormImpl>();
+    private List<SwingXFormImpl> forms = new ArrayList<>();
     private JTabbedPane tabs;
     private JButtonBar buttons;
 
@@ -80,7 +80,7 @@ public class JTabbedFormDialog extends SwingXFormDialog {
     }
 
     public XForm[] getForms() {
-        List<XForm> result = new ArrayList<XForm>();
+        List<XForm> result = new ArrayList<>();
         for (XForm form : forms) {
             result.add(form);
         }

--- a/soapui/src/main/java/com/eviware/x/impl/swing/JWizardDialog.java
+++ b/soapui/src/main/java/com/eviware/x/impl/swing/JWizardDialog.java
@@ -49,15 +49,15 @@ import java.util.List;
 
 public class JWizardDialog extends SwingXFormDialog {
     private String name;
-    private ArrayList<String> pageNames = new ArrayList<String>();
+    private ArrayList<String> pageNames = new ArrayList<>();
 
     private JFrame dialog;
     private DescriptionPanel descriptionPanel;
-    private List<SwingXFormImpl> forms = new ArrayList<SwingXFormImpl>();
+    private List<SwingXFormImpl> forms = new ArrayList<>();
     private JPanel pages;
     private CardLayout cardLayout;
 
-    private HashMap<String, WizardPage> controllers = new HashMap<String, WizardPage>();
+    private HashMap<String, WizardPage> controllers = new HashMap<>();
     private int currentPage = 0;
 
     private DefaultActionList actions;
@@ -98,7 +98,7 @@ public class JWizardDialog extends SwingXFormDialog {
     }
 
     public XForm[] getForms() {
-        List<XForm> result = new ArrayList<XForm>();
+        List<XForm> result = new ArrayList<>();
         for (XForm form : forms) {
             result.add(form);
         }

--- a/soapui/src/main/java/com/eviware/x/impl/swing/SwingFileDialogs.java
+++ b/soapui/src/main/java/com/eviware/x/impl/swing/SwingFileDialogs.java
@@ -31,7 +31,7 @@ import java.util.Map;
  */
 public class SwingFileDialogs implements XFileDialogs {
     private static Component parent;
-    private static Map<Object, JFileChooser> choosers = new HashMap<Object, JFileChooser>();
+    private static Map<Object, JFileChooser> choosers = new HashMap<>();
 
     public SwingFileDialogs(Component parent) {
         SwingFileDialogs.parent = parent;

--- a/soapui/src/main/java/com/eviware/x/impl/swing/SwingXFormImpl.java
+++ b/soapui/src/main/java/com/eviware/x/impl/swing/SwingXFormImpl.java
@@ -44,7 +44,7 @@ public class SwingXFormImpl implements XForm {
     private FormLayout layout;
     private RowSpec rowSpec;
     private int rowSpacing = 5;
-    private Map<String, XFormField> components = new HashMap<String, XFormField>();
+    private Map<String, XFormField> components = new HashMap<>();
     private String rowAlignment = "top";
     private String name;
 

--- a/soapui/src/main/java/com/smartbear/swagger/SwaggerUtils.java
+++ b/soapui/src/main/java/com/smartbear/swagger/SwaggerUtils.java
@@ -138,7 +138,7 @@ class SwaggerUtils {
             @Override
             public Object construct(XProgressMonitor xProgressMonitor) {
                 // create the importer and import!
-                List<RestService> result = new ArrayList<RestService>();
+                List<RestService> result = new ArrayList<>();
                 try {
                     result.addAll(Arrays.asList(importer.importSwagger(finalExpUrl)));
 

--- a/soapui/src/main/java/org/apache/commons/httpclient/URI.java
+++ b/soapui/src/main/java/org/apache/commons/httpclient/URI.java
@@ -155,7 +155,7 @@ public class URI implements Cloneable, Comparable, Serializable {
      * @since 3.0
      */
     public URI(String s, boolean escaped, String charset)
-            throws URIException, NullPointerException {
+            throws URIException {
         protocolCharset = charset;
         parseUriReference(s, escaped);
     }
@@ -173,7 +173,7 @@ public class URI implements Cloneable, Comparable, Serializable {
      * @since 3.0
      */
     public URI(String s, boolean escaped)
-            throws URIException, NullPointerException {
+            throws URIException {
         parseUriReference(s, escaped);
     }
 
@@ -189,7 +189,7 @@ public class URI implements Cloneable, Comparable, Serializable {
      * @deprecated Use #URI(String, boolean, String)
      */
     public URI(char[] escaped, String charset)
-            throws URIException, NullPointerException {
+            throws URIException {
         protocolCharset = charset;
         parseUriReference(new String(escaped), true);
     }
@@ -207,7 +207,7 @@ public class URI implements Cloneable, Comparable, Serializable {
      * @deprecated Use #URI(String, boolean)
      */
     public URI(char[] escaped)
-            throws URIException, NullPointerException {
+            throws URIException {
         parseUriReference(new String(escaped), true);
     }
 
@@ -2580,7 +2580,7 @@ public class URI implements Cloneable, Comparable, Serializable {
      * @throws DefaultCharsetChanged default charset changed
      */
     public static void setDefaultProtocolCharset(String charset)
-            throws DefaultCharsetChanged {
+    {
 
         defaultProtocolCharset = charset;
         throw new DefaultCharsetChanged(DefaultCharsetChanged.PROTOCOL_CHARSET,
@@ -2660,7 +2660,7 @@ public class URI implements Cloneable, Comparable, Serializable {
      * @throws DefaultCharsetChanged default charset changed
      */
     public static void setDefaultDocumentCharset(String charset)
-            throws DefaultCharsetChanged {
+    {
 
         defaultDocumentCharset = charset;
         throw new DefaultCharsetChanged(DefaultCharsetChanged.DOCUMENT_CHARSET,
@@ -2734,7 +2734,7 @@ public class URI implements Cloneable, Comparable, Serializable {
      * @throws NullPointerException null authority
      */
     public void setRawAuthority(char[] escapedAuthority)
-            throws URIException, NullPointerException {
+            throws URIException {
 
         parseAuthority(new String(escapedAuthority), true);
         setURI();
@@ -3726,7 +3726,7 @@ public class URI implements Cloneable, Comparable, Serializable {
      *         -1, if failed, first being compared with in the authority component
      * @throws ClassCastException not URI argument
      */
-    public int compareTo(Object obj) throws ClassCastException {
+    public int compareTo(Object obj) {
 
         URI another = (URI) obj;
         if (!equals(_authority, another.getRawAuthority())) {

--- a/soapui/src/main/java/org/syntax/jedit/InputHandler.java
+++ b/soapui/src/main/java/org/syntax/jedit/InputHandler.java
@@ -117,7 +117,7 @@ public abstract class InputHandler extends KeyAdapter {
     private static Hashtable<String, ActionListener> actions;
 
     static {
-        actions = new Hashtable<String, ActionListener>();
+        actions = new Hashtable<>();
         actions.put("backspace", BACKSPACE);
         actions.put("backspace-word", BACKSPACE_WORD);
         actions.put("delete", DELETE);

--- a/soapui/src/main/java/org/syntax/jedit/JEditTextArea.java
+++ b/soapui/src/main/java/org/syntax/jedit/JEditTextArea.java
@@ -169,7 +169,7 @@ public class JEditTextArea extends JComponent implements Scrollable {
         popup = defaults.popup;
 
         // We don't seem to get the initial focus event?
-        focusedComponentRef = new WeakReference<JEditTextArea>(this);
+        focusedComponentRef = new WeakReference<>(this);
 
         addMouseWheelListener(new MouseWheelListener() {
 
@@ -1886,7 +1886,7 @@ public class JEditTextArea extends JComponent implements Scrollable {
             if (isEditable()) {
                 setCaretVisible(true);
             }
-            focusedComponentRef = new WeakReference<JEditTextArea>(JEditTextArea.this);
+            focusedComponentRef = new WeakReference<>(JEditTextArea.this);
         }
 
         public void focusLost(FocusEvent evt) {
@@ -1922,7 +1922,7 @@ public class JEditTextArea extends JComponent implements Scrollable {
                 setCaretVisible(true);
             }
 
-            focusedComponentRef = new WeakReference<JEditTextArea>(JEditTextArea.this);
+            focusedComponentRef = new WeakReference<>(JEditTextArea.this);
 
             if (popup != null && evt.isPopupTrigger()) {
                 doPopup(evt);

--- a/soapui/src/main/java/org/syntax/jedit/JEditTextArea.java
+++ b/soapui/src/main/java/org/syntax/jedit/JEditTextArea.java
@@ -2055,13 +2055,13 @@ public class JEditTextArea extends JComponent implements Scrollable {
             return "caret move";
         }
 
-        public void undo() throws CannotUndoException {
+        public void undo() {
             super.undo();
 
             select(start, end);
         }
 
-        public void redo() throws CannotRedoException {
+        public void redo() {
             super.redo();
 
             select(start, end);


### PR DESCRIPTION
Superfluous exceptions within throws clauses have negative effects on the readability and maintainability of the code. An exception in a throws clause is superfluous if it is:

- listed multiple times
- a subclass of another listed exception

This PR improves readability of source code by removing code that is unnecessary.