### PR TITLE
soapui-log4j.xml: Avoid no space left due to GLOBAL_GROOVY_LOG

### DIFF
--- a/soapui-installer/src/dist/bin/soapui-log4j.xml
+++ b/soapui-installer/src/dist/bin/soapui-log4j.xml
@@ -34,9 +34,16 @@
 
         <SOAPUI name="SOAPUI"/>
 
-        <File name="GLOBAL_GROOVY_LOG" fileName="${sys:user.home}/.soapuios/logs/global-groovy.log" append="true">
+        <RollingFile name="GLOBAL_GROOVY_LOG"
+                     fileName="${sys:user.home}/.soapuios/logs/global-groovy.log"
+                     filePattern="${sys:user.home}/.soapuios/logs/global-groovy.log.%i"
+                     append="true">
             <PatternLayout pattern="%d %-5p [%c{1}] %m%n"/>
-        </File>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="50 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="50"/>
+        </RollingFile>
 
     </Appenders>
     <Loggers>


### PR DESCRIPTION
Avoid no space left filesystem by `RollingFile` usage instead of `File` on GLOBAL_GROOVY_LOG. There was no house keeping on global-groovy.log