### PR TITLE
Adding all missing Signature Algoritms from XMLSignature

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/entries/SignatureEntry.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/entries/SignatureEntry.java
@@ -113,13 +113,23 @@ public class SignatureEntry extends WssEntryBase {
                 }
         });
         form.appendComboBox("signatureAlgorithm", "Signature Algorithm", new String[]{DEFAULT_OPTION, WSConstants.RSA,
-                WSConstants.DSA, XMLSignature.ALGO_ID_MAC_HMAC_SHA1, XMLSignature.ALGO_ID_MAC_HMAC_SHA256,
-                XMLSignature.ALGO_ID_MAC_HMAC_SHA384, XMLSignature.ALGO_ID_MAC_HMAC_SHA512,
-                XMLSignature.ALGO_ID_MAC_HMAC_RIPEMD160, XMLSignature.ALGO_ID_MAC_HMAC_NOT_RECOMMENDED_MD5,
-                XMLSignature.ALGO_ID_SIGNATURE_ECDSA_SHA1, XMLSignature.ALGO_ID_SIGNATURE_NOT_RECOMMENDED_RSA_MD5,
-                XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA1, XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256,
-                XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA384, XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA512,
-                XMLSignature.ALGO_ID_SIGNATURE_RSA_RIPEMD160}, "Set the name of the signature encryption algorithm to use");
+                WSConstants.DSA, XMLSignature.ALGO_ID_MAC_HMAC_SHA1, XMLSignature.ALGO_ID_SIGNATURE_DSA ,
+                XMLSignature.ALGO_ID_SIGNATURE_DSA_SHA256, XMLSignature.ALGO_ID_SIGNATURE_RSA ,
+                XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA1, XMLSignature.ALGO_ID_SIGNATURE_NOT_RECOMMENDED_RSA_MD5 ,
+                XMLSignature.ALGO_ID_SIGNATURE_RSA_RIPEMD160, XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA224 ,
+                XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256, XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA384 ,
+                XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA512, XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA1_MGF1 ,
+                XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA224_MGF1, XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256_MGF1 ,
+                XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA384_MGF1, XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA512_MGF1 ,
+                XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA3_224_MGF1, XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA3_256_MGF1 ,
+                XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA3_384_MGF1, XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA3_512_MGF1 ,
+                XMLSignature.ALGO_ID_MAC_HMAC_NOT_RECOMMENDED_MD5, XMLSignature.ALGO_ID_MAC_HMAC_RIPEMD160 ,
+                XMLSignature.ALGO_ID_MAC_HMAC_SHA224, XMLSignature.ALGO_ID_MAC_HMAC_SHA256 ,
+                XMLSignature.ALGO_ID_MAC_HMAC_SHA384, XMLSignature.ALGO_ID_MAC_HMAC_SHA512 ,
+                XMLSignature.ALGO_ID_SIGNATURE_ECDSA_SHA1, XMLSignature.ALGO_ID_SIGNATURE_ECDSA_SHA224 ,
+                XMLSignature.ALGO_ID_SIGNATURE_ECDSA_SHA256, XMLSignature.ALGO_ID_SIGNATURE_ECDSA_SHA384 ,
+                XMLSignature.ALGO_ID_SIGNATURE_ECDSA_SHA512, XMLSignature.ALGO_ID_SIGNATURE_ECDSA_RIPEMD160
+}, "Set the name of the signature encryption algorithm to use");
         form.appendComboBox("signatureCanonicalization", "Signature Canonicalization", new String[]{DEFAULT_OPTION,
                 WSConstants.C14N_OMIT_COMMENTS, WSConstants.C14N_WITH_COMMENTS, WSConstants.C14N_EXCL_OMIT_COMMENTS,
                 WSConstants.C14N_EXCL_WITH_COMMENTS}, "Set the canonicalization method to use.");


### PR DESCRIPTION
This patch adds all missing signature algorithm constants from org.apache.xml.security.signature.XMLSignature to the algorithm selection dropdown built in the buildUI method of SignatureEntry.java.

### Problem
The WSS SignatureEntry configuration UI only exposed a subset of the signature algorithms supported by the Apache XML Security library. Users who needed to sign SOAP messages with algorithms such as ECDSA variants, or HMAC variants were unable to select them through the UI, forcing workarounds or manual configuration.
### Solution
The buildUI method in soapui/src/main/java/com/eviware/soapui/impl/wsdl/support/wss/entries/SignatureEntry.java has been updated to include all algorithm URI constants defined in org.apache.xml.security.signature.XMLSignature, ensuring full parity between what the Apache XML Security library supports and what SoapUI exposes to the user.
### Changes
SignatureEntry.java — extended the signature algorithm list in buildUI to include all constants from XMLSignature (e.g. ECDSA variants, etc.)