### PR TITLE
RIA-26438 SoapUI: update dom4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <commons-cli.version>1.2</commons-cli.version>
         <json-lib.version>2.2.2-jdk15</json-lib.version>
         <ezmorph.version>1.0.5</ezmorph.version>
-        <xom.version>1.1</xom.version>
+        <xom.version>1.4.1</xom.version>
         <commons-codec.version>1.10</commons-codec.version>
         <rhino-js.version>1.7R2</rhino-js.version>
         <saxon.version>9.1.0.8j</saxon.version>
@@ -131,7 +131,7 @@
         <commons-httpclient.version>3.1</commons-httpclient.version>
         <i4jruntime.version>5.1.14</i4jruntime.version>
         <animal-sniffer-annotations.version>1.11</animal-sniffer-annotations.version>
-        <reflections.version>0.9.9-RC1</reflections.version>
+        <reflections.version>0.10.2</reflections.version>
         <install4j-maven-plugin.version>1.1.1</install4j-maven-plugin.version>
         <io.cucumber.version>7.20.1</io.cucumber.version>
         <picocontainer.version>2.14.3</picocontainer.version>

--- a/soapui/src/main/java/com/eviware/soapui/plugins/LoaderBase.java
+++ b/soapui/src/main/java/com/eviware/soapui/plugins/LoaderBase.java
@@ -31,11 +31,9 @@ import com.eviware.soapui.support.factory.SoapUIFactoryRegistry;
 import com.eviware.soapui.support.listener.ListenerRegistry;
 import org.apache.commons.lang.ObjectUtils;
 import org.reflections.Reflections;
-import org.reflections.adapters.JavaReflectionAdapter;
-import org.reflections.scanners.SubTypesScanner;
+import org.reflections.scanners.Scanners;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
-import org.reflections.vfs.Vfs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,8 +99,8 @@ public class LoaderBase {
     protected void loadAutoFactories(Reflections jarFileScanner, Collection<SoapUIFactory> factories) {
         ConfigurationBuilder builder = new ConfigurationBuilder();
         builder.addUrls(ClasspathHelper.forClass(AutoFactory.class));
-        builder.setScanners(new SubTypesScanner(), new TypeAnnotationsScanner());
-        builder.addClassLoader(Thread.currentThread().getContextClassLoader());
+        builder.setScanners(Scanners.SubTypes, Scanners.TypesAnnotated);
+        builder.addClassLoaders(Thread.currentThread().getContextClassLoader());
         Reflections autoAnnotationFinder = new Reflections(builder);
 
         for (Class clazz : autoAnnotationFinder.getTypesAnnotatedWith(AutoFactory.class)) {
@@ -373,35 +371,4 @@ public class LoaderBase {
         return annotation != null && StringUtils.hasContent(annotation.toolbarIcon());
     }
 
-    // due to Reflections internals (or my misunderstanding of them) this class has to be
-    // named as its superclass
-    protected static class TypeAnnotationsScanner extends org.reflections.scanners.TypeAnnotationsScanner {
-        @Override
-        public boolean acceptsInput(String file) {
-            if (file.endsWith(".groovy")) {
-                return true;
-            } else {
-                return super.acceptsInput(file);
-            }
-        }
-    }
-
-    // loads both groovy and java classes for Reflections package
-    protected static class GroovyAndJavaReflectionAdapter extends JavaReflectionAdapter {
-
-        private final JarClassLoader jarClassLoader;
-
-        public GroovyAndJavaReflectionAdapter(JarClassLoader jarClassLoader) {
-            this.jarClassLoader = jarClassLoader;
-        }
-
-        @Override
-        public Class getOfCreateClassObject(Vfs.File file) throws Exception {
-            if (file.getName().endsWith(".groovy")) {
-                return jarClassLoader.loadScriptClass(file.getRelativePath());
-            } else {
-                return super.getOfCreateClassObject(file, jarClassLoader);
-            }
-        }
-    }
 }

--- a/soapui/src/main/java/com/eviware/soapui/plugins/PluginLoader.java
+++ b/soapui/src/main/java/com/eviware/soapui/plugins/PluginLoader.java
@@ -61,12 +61,13 @@ public class PluginLoader extends LoaderBase {
         tempFile.deleteOnExit();
         FileUtils.copyFile(pluginFile, tempFile);
         JarClassLoader jarClassLoader = new JarClassLoader(tempFile, PluginLoader.class.getClassLoader(), dependencyClassLoaders);
-        ConfigurationBuilder configurationBuilder = new ConfigurationBuilder().setUrls(jarClassLoader.getURLs()).addClassLoader(jarClassLoader);
+        ConfigurationBuilder configurationBuilder = new ConfigurationBuilder()
+                .setUrls(jarClassLoader.getURLs())
+                .addClassLoaders(jarClassLoader);
 
         if (jarClassLoader.hasScripts()) {
-            configurationBuilder.addClassLoader(jarClassLoader.getScriptClassLoader());
-            configurationBuilder.addScanners(new TypeAnnotationsScanner());
-            configurationBuilder.setMetadataAdapter(new GroovyAndJavaReflectionAdapter(jarClassLoader));
+            configurationBuilder.addClassLoaders(jarClassLoader.getScriptClassLoader())
+                    .addScanners(new TypeAnnotationsScanner());
         }
 
         return new ReflectionsAndClassLoader(new Reflections(configurationBuilder), jarClassLoader);


### PR DESCRIPTION
Dom4j came as transitive dependency of old XOM version and org.reflections.
Resolved by updating both of the libs.
Plugin loader code changes are direct results of breaking API change in org.reflections.