### PR TITLE
Fix BigDecimal displayed in scientific notation in JSON response view

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/views/json/JsonResponseView.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/views/json/JsonResponseView.java
@@ -31,8 +31,7 @@ import com.eviware.soapui.support.editor.views.AbstractXmlEditorView;
 import com.eviware.soapui.support.xml.SyntaxEditorUtil;
 import com.eviware.soapui.support.xml.actions.EnableLineNumbersAction;
 import com.eviware.soapui.support.xml.actions.GoToLineAction;
-import net.sf.json.JSON;
-import net.sf.json.JSONException;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
@@ -143,13 +142,13 @@ public class JsonResponseView extends AbstractXmlEditorView<HttpResponseDocument
 
             if (JsonUtil.seemsToBeJsonContentType(httpResponse.getContentType())) {
                 try {
-                    JSON json = new JsonUtil().parseTrimmedText(httpResponse.getContentAsString());
-                    if (json.isEmpty()) {
+                    JsonNode jsonNode = JsonUtil.parseTrimmedTextToJsonNode(httpResponse.getContentAsString());
+                    if (jsonNode == null) {
                         content = "<Empty JSON content>";
                     } else {
-                        content = json.toString(3);
+                        content = JsonUtil.format(jsonNode);
                     }
-                } catch (JSONException e) {
+                } catch (IOException e) {
                     content = httpResponse.getContentAsString();
                 }
                 contentEditor.setText(content);

--- a/soapui/src/test/java/com/eviware/soapui/support/JsonUtilTest.java
+++ b/soapui/src/test/java/com/eviware/soapui/support/JsonUtilTest.java
@@ -17,6 +17,8 @@
 package com.eviware.soapui.support;
 
 import org.junit.Test;
+import com.fasterxml.jackson.databind.JsonNode;
+import static org.junit.Assert.*;
 
 /**
  * @author joel.jonsson
@@ -30,5 +32,36 @@ public class JsonUtilTest {
     @Test
     public void canParseWithPrecedingWhile1() {
         new JsonUtil().parseTrimmedText(" \n  while(1);  \n\n   {1:2}\n\n \t   ");
+    }
+
+    @Test
+    public void parseTrimmedTextToJsonNode_preservesBigDecimalPrecision() throws Exception {
+        String input = "{ \"i_am_a_big_decimal\": 123456789123456789123456789 }";
+        JsonNode node = JsonUtil.parseTrimmedTextToJsonNode(input);
+        String output = JsonUtil.format(node);
+        assertTrue("BigDecimal should not use scientific notation", !output.contains("E"));
+        assertTrue("BigDecimal value should be preserved exactly", output.contains("123456789123456789123456789"));
+    }
+
+    // now null output produces null while empty output produces an empty object
+    @Test
+    public void parseTrimmedTextToJsonNode_returnsNullForNullInput() throws Exception {
+        assertNull(JsonUtil.parseTrimmedTextToJsonNode(null));
+    }
+
+    @Test
+    public void parseTrimmedTextToJsonNode_returnsNonNullForEmptyObject() throws Exception {
+        JsonNode node = JsonUtil.parseTrimmedTextToJsonNode("{}");
+        assertNotNull("Empty JSON object should not return null", node);
+        // formatter produces { } (with a space)
+        assertEquals("{ }", JsonUtil.format(node).trim());
+    }
+
+    @Test
+    public void format_doesNotUseScientificNotationForLargeNumbers() throws Exception {
+        String input = "{ \"value\": 9007199254740993 }";
+        JsonNode node = JsonUtil.parseTrimmedTextToJsonNode(input);
+        String output = JsonUtil.format(node);
+        assertTrue(output.contains("9007199254740993"));
     }
 }


### PR DESCRIPTION
## Problem

When a REST response contains large numbers (e.g. `123456789123456789123456789`), the JSON tab displays them incorrectly as scientific notation with precision loss (e.g. `1.2345678912345679E26`). The Raw tab shows the correct value but the JSON tab differently.
Aimed to fix #844

## Root Cause

`JsonResponseView.setEditorContent()` was using the old `net.sf.json` library which internally converts all numbers to Java `double`, losing precision for large values.

## Fix

Replaced `net.sf.json` with the Jackson mapper already configured in `JsonUtil`, which uses `USE_BIG_DECIMAL_FOR_FLOATS` to preserve full precision without scientific notation.

## Testing

- Added unit tests to `JsonUtilTest` covering BigDecimal precision, null input, empty object, and large integer formatting
- Verified manually using a local SoapUI mock service returning a large number - the JSON tab now displays the exact value - attached images for before and after scenarios
- All current tests and build passes.

## Note to maintainers
I noticed the issue wasn't fixed yet, so I took the liberty of fixing it. I'd humbly request a review and any feedback on whether the approach is correct to expectations or if changes are needed. Happy to update based on your guidance!

<img width="1280" height="832" alt="fixed" src="https://github.com/user-attachments/assets/b1c79806-270c-485c-ad22-1c322179d798" />
<img width="1280" height="832" alt="original" src="https://github.com/user-attachments/assets/68e95969-652f-4380-8b8b-6a79f05a27df" />
