### PR TITLE
Fix permanent UI freeze from off-EDT JsonResponseView.setEditorContent

### DIFF
--- a/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/views/json/JsonResponseView.java
+++ b/soapui/src/main/java/com/eviware/soapui/impl/rest/panels/request/views/json/JsonResponseView.java
@@ -44,6 +44,7 @@ import javax.swing.Action;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
@@ -162,7 +163,12 @@ public class JsonResponseView extends AbstractXmlEditorView<HttpResponseDocument
     public void propertyChange(PropertyChangeEvent evt) {
         if (evt.getPropertyName().equals(AbstractHttpRequestInterface.RESPONSE_PROPERTY) && !updatingRequest) {
             updatingRequest = true;
-            setEditorContent(((HttpResponse) evt.getNewValue()));
+            final HttpResponse response = (HttpResponse) evt.getNewValue();
+            SwingUtilities.invokeLater(new Runnable() {
+                public void run() {
+                    setEditorContent(response);
+                }
+            });
             updatingRequest = false;
         }
     }


### PR DESCRIPTION
﻿Fixes #898

JsonResponseView.propertyChange called setEditorContent directly on the RESPONSE_PROPERTY change, which fires from the request submit worker thread, not the EDT. setEditorContent mutates the RSyntaxDocument via JTextComponent.setText, which violates Swing's single-thread rule.

This produces a classic AB-BA deadlock when a response lands while the EDT is mid layout pass: the worker thread holds the document write lock and blocks trying to acquire the AWTTreeLock (via RUndoManager updating action enablement), while the EDT already holds the AWTTreeLock during validate and blocks waiting for the same document's read lock. Neither thread can proceed, and only killing the process recovers, exactly as documented in the issue with a full thread dump.

Deferred the setEditorContent call to SwingUtilities.invokeLater so the document is only ever mutated on the EDT, removing the cross-thread lock contention entirely. The updatingRequest reentrancy guard is left exactly where it was, set synchronously on the calling thread around scheduling the update, not around running it.

Verified by tracing the exact lock chain in the issue thread dump against current source and by compiling soapui/src/main/java cleanly with mvn compile. This is a Swing threading fix, not something a unit test can reasonably exercise given the race is timing dependent.